### PR TITLE
Removed emptyField from BaseNeonComponent

### DIFF
--- a/src/app/components/aggregation/aggregation.component.html
+++ b/src/app/components/aggregation/aggregation.component.html
@@ -105,7 +105,7 @@
                 <mat-form-field *ngIf="!isXYSubcomponent(options.type)">
                     <mat-select placeholder="Aggregation Field" [(ngModel)]="options.aggregationField" required="options.aggregation != 'count'"
                         (ngModelChange)="handleChangeData()" [disabled]="options.fields.length == 0">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>
@@ -184,7 +184,7 @@
                 <mat-form-field>
                     <mat-select placeholder="Group Field" [(ngModel)]="options.groupField" required="false"
                         (ngModelChange)="handleChangeFilterField()" [disabled]="options.fields.length == 0">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>

--- a/src/app/components/aggregation/aggregation.component.spec.ts
+++ b/src/app/components/aggregation/aggregation.component.spec.ts
@@ -94,10 +94,10 @@ describe('Component: Aggregation', () => {
     });
 
     it('class options properties are set to expected defaults', () => {
-        expect(component.options.aggregationField).toEqual(component.emptyField);
-        expect(component.options.groupField).toEqual(component.emptyField);
-        expect(component.options.xField).toEqual(component.emptyField);
-        expect(component.options.yField).toEqual(component.emptyField);
+        expect(component.options.aggregationField).toEqual(new FieldMetaData());
+        expect(component.options.groupField).toEqual(new FieldMetaData());
+        expect(component.options.xField).toEqual(new FieldMetaData());
+        expect(component.options.yField).toEqual(new FieldMetaData());
 
         expect(component.options.aggregation).toEqual('count');
         expect(component.options.dualView).toEqual('');

--- a/src/app/components/aggregation/aggregation.component.ts
+++ b/src/app/components/aggregation/aggregation.component.ts
@@ -47,7 +47,7 @@ import { ChartJsLineSubcomponent } from './subcomponent.chartjs.line';
 import { ChartJsPieSubcomponent } from './subcomponent.chartjs.pie';
 import { ChartJsScatterSubcomponent } from './subcomponent.chartjs.scatter';
 import { ListSubcomponent } from './subcomponent.list';
-import { EMPTY_FIELD, FieldMetaData } from '../../dataset';
+import { FieldMetaData } from '../../dataset';
 import { neonVariables } from '../../neon-namespaces';
 
 import { DateBucketizer } from '../bucketizers/DateBucketizer';

--- a/src/app/components/annotation-viewer/annotation-viewer.component.html
+++ b/src/app/components/annotation-viewer/annotation-viewer.component.html
@@ -59,7 +59,7 @@
                 <mat-form-field>
                     <mat-select placeholder="Document Text Field" [(ngModel)]="options.documentTextField" required="true" (ngModelChange)="handleChangeFilterField()"
                         [disabled]="options.fields.length == 0">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>
@@ -68,7 +68,7 @@
                 <mat-form-field>
                     <mat-select placeholder="ID Field" [(ngModel)]="options.idField" required="false" (ngModelChange)="handleChangeFilterField()"
                         [disabled]="options.fields.length == 0">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>
@@ -77,7 +77,7 @@
                 <mat-form-field>
                     <mat-select placeholder="Link Field" [(ngModel)]="options.linkField" required="false" (ngModelChange)="handleChangeFilterField()"
                         [disabled]="options.fields.length == 0">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>
@@ -110,7 +110,7 @@
 
                 <mat-form-field>
                     <mat-select placeholder="Annotation Start Character Field" [(ngModel)]="options.startCharacterField" required="true" [disabled]="options.fields.length == 0">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>
@@ -118,7 +118,7 @@
 
                 <mat-form-field>
                     <mat-select placeholder="Annotation End Character Field" [(ngModel)]="options.endCharacterField" required="true" [disabled]="options.fields.length == 0">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>
@@ -126,7 +126,7 @@
 
                 <mat-form-field>
                     <mat-select placeholder="Annotation Text Field" [(ngModel)]="options.textField" required="true" [disabled]="options.fields.length == 0">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>
@@ -134,7 +134,7 @@
 
                 <mat-form-field>
                     <mat-select placeholder="Annotation Type Field" [(ngModel)]="options.typeField" required="true" [disabled]="options.fields.length == 0">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>

--- a/src/app/components/bar-chart/bar-chart.component.html
+++ b/src/app/components/bar-chart/bar-chart.component.html
@@ -86,7 +86,7 @@
                 <mat-form-field>
                     <mat-select placeholder="Color Field" [(ngModel)]="options.colorField"
                                (ngModelChange)="handleChangeData()" [disabled]="options.fields.length == 0">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>

--- a/src/app/components/bar-chart/bar-chart.component.spec.ts
+++ b/src/app/components/bar-chart/bar-chart.component.spec.ts
@@ -97,9 +97,9 @@ describe('Component: BarChart', () => {
         expect(component.options.type).toBe('bar');
         expect(component.options.yPercentage).toBe(0.2);
 
-        expect(component.options.aggregationField).toEqual(component.emptyField);
-        expect(component.options.colorField).toEqual(component.emptyField);
-        expect(component.options.dataField).toEqual(component.emptyField);
+        expect(component.options.aggregationField).toEqual(new FieldMetaData());
+        expect(component.options.colorField).toEqual(new FieldMetaData());
+        expect(component.options.dataField).toEqual(new FieldMetaData());
     });
 
     it('does have expected class properties', () => {

--- a/src/app/components/base-neon-component/base-layered-neon.component.ts
+++ b/src/app/components/base-neon-component/base-layered-neon.component.ts
@@ -29,7 +29,7 @@ import { FilterService } from '../../services/filter.service';
 import { ThemesService } from '../../services/themes.service';
 import { VisualizationService } from '../../services/visualization.service';
 
-import { EMPTY_FIELD, FieldMetaData, TableMetaData, DatabaseMetaData } from '../../dataset';
+import { FieldMetaData, TableMetaData, DatabaseMetaData } from '../../dataset';
 import * as neon from 'neon-framework';
 import * as _ from 'lodash';
 import * as uuid from 'node-uuid';
@@ -108,7 +108,7 @@ export abstract class BaseNeonLayer {
             field = this.findField(this.datasetService.getMapping(this.database.name, this.table.name, mappingKey));
         }
 
-        return field || EMPTY_FIELD;
+        return field || new FieldMetaData();
     }
 
     /**
@@ -254,8 +254,6 @@ export abstract class BaseLayeredNeonComponent implements OnInit, OnDestroy {
 
     public isLoading: number = 0;
     public isExportable: boolean = true;
-
-    public emptyField = EMPTY_FIELD;
 
     public errorMessage: string = '';
 
@@ -1080,5 +1078,9 @@ export abstract class BaseLayeredNeonComponent implements OnInit, OnDestroy {
         let table = _.find(database.tables, (t) => t.name === tableName);
         let labelOptions = table.labelOptions;
         return labelOptions;
+    }
+
+    protected createEmptyField(): FieldMetaData {
+        return new FieldMetaData();
     }
 }

--- a/src/app/components/base-neon-component/base-neon.component.ts
+++ b/src/app/components/base-neon-component/base-neon.component.ts
@@ -29,7 +29,7 @@ import { FilterService } from '../../services/filter.service';
 import { ThemesService } from '../../services/themes.service';
 import { VisualizationService } from '../../services/visualization.service';
 
-import { EMPTY_FIELD, FieldMetaData, TableMetaData, DatabaseMetaData } from '../../dataset';
+import { FieldMetaData, TableMetaData, DatabaseMetaData } from '../../dataset';
 import * as neon from 'neon-framework';
 import * as uuid from 'node-uuid';
 import * as _ from 'lodash';
@@ -337,8 +337,6 @@ export abstract class BaseNeonComponent implements OnInit, OnDestroy {
 
     public isLoading: boolean = false;
     public isExportable: boolean = true;
-
-    public emptyField: FieldMetaData = EMPTY_FIELD;
 
     public errorMessage: string = '';
 
@@ -1127,4 +1125,7 @@ export abstract class BaseNeonComponent implements OnInit, OnDestroy {
         return labelOptions;
     }
 
+    protected createEmptyField(): FieldMetaData {
+        return new FieldMetaData();
+    }
 }

--- a/src/app/components/data-table/data-table.component.html
+++ b/src/app/components/data-table/data-table.component.html
@@ -57,7 +57,7 @@
                     <mat-select placeholder="ID Field" [(ngModel)]="options.idField"
                                 required="false" (ngModelChange)="handleChangeData()"
                                 [disabled]="options.fields.length == 0">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>

--- a/src/app/components/data-table/data-table.component.ts
+++ b/src/app/components/data-table/data-table.component.ts
@@ -35,7 +35,7 @@ import { ThemesService } from '../../services/themes.service';
 import { VisualizationService } from '../../services/visualization.service';
 
 import { BaseNeonComponent, BaseNeonOptions } from '../base-neon-component/base-neon.component';
-import { EMPTY_FIELD, FieldMetaData } from '../../dataset';
+import { FieldMetaData } from '../../dataset';
 import { neonUtilities, neonVariables } from '../../neon-namespaces';
 import * as neon from 'neon-framework';
 

--- a/src/app/components/document-viewer/document-viewer.component.html
+++ b/src/app/components/document-viewer/document-viewer.component.html
@@ -67,7 +67,7 @@
                 <mat-form-field>
                     <mat-select placeholder="Date Field" [(ngModel)]="options.dateField" (ngModelChange)="handleChangeData()"
                         [disabled]="options.fields.length == 0">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>

--- a/src/app/components/document-viewer/document-viewer.component.spec.ts
+++ b/src/app/components/document-viewer/document-viewer.component.spec.ts
@@ -92,9 +92,9 @@ describe('Component: DocumentViewer', () => {
     }));
 
     it('has expected options properties', () => {
-        expect(component.options.dataField).toEqual(component.emptyField);
-        expect(component.options.dateField).toEqual(component.emptyField);
-        expect(component.options.idField).toEqual(component.emptyField);
+        expect(component.options.dataField).toEqual(new FieldMetaData());
+        expect(component.options.dateField).toEqual(new FieldMetaData());
+        expect(component.options.idField).toEqual(new FieldMetaData());
         expect(component.options.metadataFields).toEqual([]);
         expect(component.options.popoutFields).toEqual([]);
         expect(component.options.showSelect).toBe(false);
@@ -391,9 +391,9 @@ describe('Component: DocumentViewer', () => {
 
     it('doesn\'t do anything in refreshVisualization', () => {
         expect(component.refreshVisualization()).toBeUndefined();
-        expect(component.options.dataField).toEqual(component.emptyField);
-        expect(component.options.dateField).toEqual(component.emptyField);
-        expect(component.options.idField).toEqual(component.emptyField);
+        expect(component.options.dataField).toEqual(new FieldMetaData());
+        expect(component.options.dateField).toEqual(new FieldMetaData());
+        expect(component.options.idField).toEqual(new FieldMetaData());
         expect(component.options.metadataFields).toEqual([]);
         expect(component.options.popoutFields).toEqual([]);
         expect(component.options.showSelect).toBe(false);

--- a/src/app/components/document-viewer/document-viewer.component.ts
+++ b/src/app/components/document-viewer/document-viewer.component.ts
@@ -36,7 +36,7 @@ import { VisualizationService } from '../../services/visualization.service';
 
 import { BaseNeonComponent, BaseNeonOptions } from '../base-neon-component/base-neon.component';
 import { DocumentViewerSingleItemComponent } from '../document-viewer-single-item/document-viewer-single-item.component';
-import { EMPTY_FIELD, FieldMetaData } from '../../dataset';
+import { FieldMetaData } from '../../dataset';
 import { neonUtilities, neonVariables } from '../../neon-namespaces';
 import * as neon from 'neon-framework';
 import * as _ from 'lodash';
@@ -316,7 +316,7 @@ export class DocumentViewerComponent extends BaseNeonComponent implements OnInit
         let activeItemText = this.createTableRowText(activeItemData, arrayFilter);
         if (activeItemText) {
             activeItem.rows.push({
-                name: name || (this.options.findField(field) || this.emptyField).prettyName || field,
+                name: name || (this.options.findField(field) || this.createEmptyField()).prettyName || field,
                 text: activeItemText
             });
         }

--- a/src/app/components/filter-builder/filter-builder.component.ts
+++ b/src/app/components/filter-builder/filter-builder.component.ts
@@ -196,7 +196,7 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
         let clause: FilterClauseMetaData = new FilterClauseMetaData(this.injector, this.datasetService);
         clause.database = this.options.database;
         clause.table = this.options.table;
-        clause.field = this.emptyField;
+        clause.field = this.createEmptyField();
         clause.operator = this.operators[0];
         clause.value = '';
         clause.active = false;

--- a/src/app/components/line-chart/line-chart.component.ts
+++ b/src/app/components/line-chart/line-chart.component.ts
@@ -37,7 +37,7 @@ import { VisualizationService } from '../../services/visualization.service';
 import { BaseNeonComponent, BaseNeonOptions } from '../base-neon-component/base-neon.component';
 import { ChartComponent } from '../chart/chart.component';
 import { DateBucketizer } from '../bucketizers/DateBucketizer';
-import { EMPTY_FIELD, FieldMetaData } from '../../dataset';
+import { FieldMetaData } from '../../dataset';
 import { MonthBucketizer } from '../bucketizers/MonthBucketizer';
 import { neonVariables } from '../../neon-namespaces';
 import { YearBucketizer } from '../bucketizers/YearBucketizer';

--- a/src/app/components/map/map.component.html
+++ b/src/app/components/map/map.component.html
@@ -99,7 +99,7 @@
                         <mat-form-field>
                             <mat-select placeholder="Color Field" [(ngModel)]="options.layers[i].colorField"
                                         (ngModelChange)="handleChangeDataAtLayerIndex(i)" [disabled]="options.layers[i].fields.length == 0">
-                                <mat-option [value]="emptyField">(None)</mat-option>
+                                <mat-option [value]="createEmptyField()">(None)</mat-option>
                                 <mat-option *ngFor="let field of options.layers[i].fields"
                                             [value]="field">{{ field.prettyName }}</mat-option>
                             </mat-select>

--- a/src/app/components/map/map.component.spec.ts
+++ b/src/app/components/map/map.component.spec.ts
@@ -294,11 +294,11 @@ describe('Component: Map', () => {
         expect(component.options.layers[0].table).toEqual(new TableMetaData());
         expect(component.options.layers[0].fields).toEqual([]);
         expect(component.options.layers[0].title).toEqual('New Layer');
-        expect(component.options.layers[0].colorField).toEqual(component.emptyField);
-        expect(component.options.layers[0].dateField).toEqual(component.emptyField);
-        expect(component.options.layers[0].latitudeField).toEqual(component.emptyField);
-        expect(component.options.layers[0].longitudeField).toEqual(component.emptyField);
-        expect(component.options.layers[0].sizeField).toEqual(component.emptyField);
+        expect(component.options.layers[0].colorField).toEqual(new FieldMetaData());
+        expect(component.options.layers[0].dateField).toEqual(new FieldMetaData());
+        expect(component.options.layers[0].latitudeField).toEqual(new FieldMetaData());
+        expect(component.options.layers[0].longitudeField).toEqual(new FieldMetaData());
+        expect(component.options.layers[0].sizeField).toEqual(new FieldMetaData());
     });
 
     it('should create the default map (Leaflet)', () => {
@@ -578,11 +578,11 @@ describe('Component: Map', () => {
         let layer = component.subAddLayer({});
 
         expect(component.options.layers[1].title).toEqual('New Layer');
-        expect(component.options.layers[1].colorField).toEqual(component.emptyField);
-        expect(component.options.layers[1].dateField).toEqual(component.emptyField);
-        expect(component.options.layers[1].latitudeField).toEqual(component.emptyField);
-        expect(component.options.layers[1].longitudeField).toEqual(component.emptyField);
-        expect(component.options.layers[1].sizeField).toEqual(component.emptyField);
+        expect(component.options.layers[1].colorField).toEqual(new FieldMetaData());
+        expect(component.options.layers[1].dateField).toEqual(new FieldMetaData());
+        expect(component.options.layers[1].latitudeField).toEqual(new FieldMetaData());
+        expect(component.options.layers[1].longitudeField).toEqual(new FieldMetaData());
+        expect(component.options.layers[1].sizeField).toEqual(new FieldMetaData());
 
         expect(component.docCount).toEqual([0, 0]);
         expect(component.filterVisible).toEqual([true, true]);

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -46,7 +46,7 @@ import {
 } from './map.type.abstract';
 import { BaseLayeredNeonComponent, BaseNeonLayer, BaseNeonMultiLayerOptions } from '../base-neon-component/base-layered-neon.component';
 import { CesiumNeonMap } from './map.type.cesium';
-import { EMPTY_FIELD, FieldMetaData } from '../../dataset';
+import { FieldMetaData } from '../../dataset';
 import { LeafletNeonMap } from './map.type.leaflet';
 import { neonMappings, neonVariables } from '../../neon-namespaces';
 import * as neon from 'neon-framework';

--- a/src/app/components/media-viewer/media-viewer.component.html
+++ b/src/app/components/media-viewer/media-viewer.component.html
@@ -68,7 +68,7 @@
 
                 <mat-form-field>
                     <mat-select placeholder="Name Field" [(ngModel)]="options.nameField" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>
@@ -76,7 +76,7 @@
 
                 <mat-form-field>
                     <mat-select placeholder="Type Field" [(ngModel)]="options.typeField" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>

--- a/src/app/components/media-viewer/media-viewer.component.spec.ts
+++ b/src/app/components/media-viewer/media-viewer.component.spec.ts
@@ -85,11 +85,11 @@ describe('Component: MediaViewer', () => {
         expect(component.options.resize).toEqual(true);
         expect(component.options.typeMap).toEqual({});
         expect(component.options.url).toEqual('');
-        expect(component.options.idField).toEqual(component.emptyField);
-        expect(component.options.linkField).toEqual(component.emptyField);
+        expect(component.options.idField).toEqual(new FieldMetaData());
+        expect(component.options.linkField).toEqual(new FieldMetaData());
         expect(component.options.linkFields).toEqual([]);
-        expect(component.options.nameField).toEqual(component.emptyField);
-        expect(component.options.typeField).toEqual(component.emptyField);
+        expect(component.options.nameField).toEqual(new FieldMetaData());
+        expect(component.options.typeField).toEqual(new FieldMetaData());
     });
 
     it('does have expected class properties', () => {

--- a/src/app/components/network-graph/network-graph.component.html
+++ b/src/app/components/network-graph/network-graph.component.html
@@ -72,7 +72,7 @@
                     <mat-form-field>
                         <mat-select placeholder="Node Name Field" [(ngModel)]="options.nodeNameField" required="false" (ngModelChange)="handleChangeData()"
                                     [disabled]="options.fields.length == 0">
-                            <mat-option [value]="emptyField">(None)</mat-option>
+                            <mat-option [value]="createEmptyField()">(None)</mat-option>
                             <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                         </mat-select>
                     </mat-form-field>
@@ -81,7 +81,7 @@
                     <mat-form-field>
                         <mat-select placeholder="Node Shape" [(ngModel)]="options.nodeShape" required="false" (ngModelChange)="handleChangeData()"
                                     [disabled]="nodeShapes.length == 0">
-                            <mat-option [value]="emptyField">(Default)</mat-option>
+                            <mat-option [value]="createEmptyField()">(Default)</mat-option>
                             <mat-option *ngFor="let shape of nodeShapes" [value]="shape">{{ shape }}</mat-option>
                         </mat-select>
                     </mat-form-field>
@@ -98,7 +98,7 @@
                     <mat-form-field>
                         <mat-select placeholder="Link Name Field" [(ngModel)]="options.linkNameField" required="false" (ngModelChange)="handleChangeData()"
                                     [disabled]="options.fields.length == 0">
-                            <mat-option [value]="emptyField">(None)</mat-option>
+                            <mat-option [value]="createEmptyField()">(None)</mat-option>
                             <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                         </mat-select>
                     </mat-form-field>
@@ -108,7 +108,7 @@
                 <mat-form-field>
                     <mat-select placeholder="Node Shape" [(ngModel)]="options.nodeShape" required="false" (ngModelChange)="handleChangeData()"
                                 [disabled]="nodeShapes.length == 0">
-                        <mat-option [value]="emptyField">(Default)</mat-option>
+                        <mat-option [value]="createEmptyField()">(Default)</mat-option>
                         <mat-option *ngFor="let shape of nodeShapes" [value]="shape">{{ shape }}</mat-option>
                     </mat-select>
                 </mat-form-field>
@@ -156,7 +156,7 @@
                 <mat-form-field *ngIf="!options.isReified">
                     <mat-select placeholder="Edge Color Field" [(ngModel)]="options.edgeColorField" (ngModelChange)="handleChangeData()"
                         [disabled]="options.fields.length == 0">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>

--- a/src/app/components/network-graph/network-graph.component.spec.ts
+++ b/src/app/components/network-graph/network-graph.component.spec.ts
@@ -109,17 +109,17 @@ describe('Component: NetworkGraph', () => {
         expect(component.options.setColorScheme).toEqual(false);
         expect(component.options.legendFiltering).toEqual(true);
 
-        expect(component.options.nodeColorField).toEqual(component.emptyField);
-        expect(component.options.edgeColorField).toEqual(component.emptyField);
-        expect(component.options.linkField).toEqual(component.emptyField);
-        expect(component.options.linkNameField).toEqual(component.emptyField);
-        expect(component.options.nodeField).toEqual(component.emptyField);
-        expect(component.options.nodeNameField).toEqual(component.emptyField);
-        expect(component.options.typeField).toEqual(component.emptyField);
-        expect(component.options.xPositionField).toEqual(component.emptyField);
-        expect(component.options.yPositionField).toEqual(component.emptyField);
-        expect(component.options.xTargetPositionField).toEqual(component.emptyField);
-        expect(component.options.yTargetPositionField).toEqual(component.emptyField);
+        expect(component.options.nodeColorField).toEqual(new FieldMetaData());
+        expect(component.options.edgeColorField).toEqual(new FieldMetaData());
+        expect(component.options.linkField).toEqual(new FieldMetaData());
+        expect(component.options.linkNameField).toEqual(new FieldMetaData());
+        expect(component.options.nodeField).toEqual(new FieldMetaData());
+        expect(component.options.nodeNameField).toEqual(new FieldMetaData());
+        expect(component.options.typeField).toEqual(new FieldMetaData());
+        expect(component.options.xPositionField).toEqual(new FieldMetaData());
+        expect(component.options.yPositionField).toEqual(new FieldMetaData());
+        expect(component.options.xTargetPositionField).toEqual(new FieldMetaData());
+        expect(component.options.yTargetPositionField).toEqual(new FieldMetaData());
     });
 
     it('createQuery does return expected query', (() => {

--- a/src/app/components/news-feed/news-feed.component.html
+++ b/src/app/components/news-feed/news-feed.component.html
@@ -55,7 +55,7 @@
 
                 <mat-form-field>
                      <mat-select placeholder="ID Field" [(ngModel)]="options.idField" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                         <mat-option [value]="emptyField">(None)</mat-option>
+                         <mat-option [value]="createEmptyField()">(None)</mat-option>
                          <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                      </mat-select>
                  </mat-form-field>
@@ -63,7 +63,7 @@
 
                  <mat-form-field>
                      <mat-select placeholder="Link Field" [(ngModel)]="options.linkField" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                         <mat-option [value]="emptyField">(None)</mat-option>
+                         <mat-option [value]="createEmptyField()">(None)</mat-option>
                          <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                      </mat-select>
                  </mat-form-field>
@@ -71,7 +71,7 @@
 
                  <mat-form-field>
                      <mat-select placeholder="Date Field" [(ngModel)]="options.dateField" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                         <mat-option [value]="emptyField">(None)</mat-option>
+                         <mat-option [value]="createEmptyField()">(None)</mat-option>
                          <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                      </mat-select>
                  </mat-form-field>
@@ -79,7 +79,7 @@
 
                  <mat-form-field>
                      <mat-select placeholder="Filter Field" [(ngModel)]="options.filterField" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                         <mat-option [value]="emptyField">(None)</mat-option>
+                         <mat-option [value]="createEmptyField()">(None)</mat-option>
                          <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                      </mat-select>
                  </mat-form-field>
@@ -87,7 +87,7 @@
 
                  <mat-form-field>
                      <mat-select placeholder="PrimaryTitleField Field" [(ngModel)]="options.primaryTitleField" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                         <mat-option [value]="emptyField">(None)</mat-option>
+                         <mat-option [value]="createEmptyField()">(None)</mat-option>
                          <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                      </mat-select>
                  </mat-form-field>
@@ -102,7 +102,7 @@
 
                  <mat-form-field>
                      <mat-select placeholder="Content Field" [(ngModel)]="options.contentField" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                         <mat-option [value]="emptyField">(None)</mat-option>
+                         <mat-option [value]="createEmptyField()">(None)</mat-option>
                          <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                      </mat-select>
                  </mat-form-field>

--- a/src/app/components/news-feed/news-feed.component.spec.ts
+++ b/src/app/components/news-feed/news-feed.component.spec.ts
@@ -81,14 +81,14 @@ describe('Component: NewsFeed', () => {
     it('does have expected class options properties', () => {
         expect(component.options.id).toEqual('');
         expect(component.options.ignoreSelf).toEqual(false);
-        expect(component.options.contentField).toEqual(component.emptyField);
-        expect(component.options.dateField).toEqual(component.emptyField);
-        expect(component.options.filterField).toEqual(component.emptyField);
-        expect(component.options.idField).toEqual(component.emptyField);
-        expect(component.options.linkField).toEqual(component.emptyField);
-        expect(component.options.primaryTitleField).toEqual(component.emptyField);
-        expect(component.options.secondaryTitleField).toEqual(component.emptyField);
-        expect(component.options.sortField).toEqual(component.emptyField);
+        expect(component.options.contentField).toEqual(new FieldMetaData());
+        expect(component.options.dateField).toEqual(new FieldMetaData());
+        expect(component.options.filterField).toEqual(new FieldMetaData());
+        expect(component.options.idField).toEqual(new FieldMetaData());
+        expect(component.options.linkField).toEqual(new FieldMetaData());
+        expect(component.options.primaryTitleField).toEqual(new FieldMetaData());
+        expect(component.options.secondaryTitleField).toEqual(new FieldMetaData());
+        expect(component.options.sortField).toEqual(new FieldMetaData());
     });
 
     it('does have expected class properties', () => {
@@ -992,11 +992,11 @@ describe('Component: NewsFeed', () => {
     it('isSelectable does return expected boolean', () => {
         component.options.filterField = new FieldMetaData('testFilterField', 'Test Filter Field');
         expect(component.isSelectable()).toEqual(true);
-        component.options.filterField = component.emptyField;
+        component.options.filterField = new FieldMetaData();
 
         component.options.idField = new FieldMetaData('testIdField', 'Test ID Field');
         expect(component.isSelectable()).toEqual(true);
-        component.options.idField = component.emptyField;
+        component.options.idField = new FieldMetaData();
     });
 
     //for isSelected method

--- a/src/app/components/sample/sample.component.html
+++ b/src/app/components/sample/sample.component.html
@@ -68,7 +68,7 @@
                 <mat-form-field>
                     <mat-select placeholder="Sample Optional Field" [(ngModel)]="options.sampleOptionalField" required="false"
                         (ngModelChange)="handleChangeData()" [disabled]="options.fields.length == 0">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>

--- a/src/app/components/sample/sample.component.spec.ts
+++ b/src/app/components/sample/sample.component.spec.ts
@@ -138,8 +138,8 @@ describe('Component: Sample', () => {
     });
 
     it('class options properties are set to expected defaults', () => {
-        expect(component.options.sampleOptionalField).toEqual(component.emptyField);
-        expect(component.options.sampleRequiredField).toEqual(component.emptyField);
+        expect(component.options.sampleOptionalField).toEqual(new FieldMetaData());
+        expect(component.options.sampleRequiredField).toEqual(new FieldMetaData());
         expect(component.options.sortDescending).toEqual(false);
         expect(component.options.subcomponentType).toEqual('Impl1');
         expect(component.options.subcomponentTypes).toEqual(['Impl1', 'Impl2']);
@@ -1205,8 +1205,8 @@ describe('Component: Sample', () => {
         component.options.sampleRequiredField = undefined;
 
         component.options.updateFields();
-        expect(component.options.sampleOptionalField).toEqual(component.emptyField);
-        expect(component.options.sampleRequiredField).toEqual(component.emptyField);
+        expect(component.options.sampleOptionalField).toEqual(new FieldMetaData());
+        expect(component.options.sampleRequiredField).toEqual(new FieldMetaData());
     });
 
     it('does show toolbar and sidenav and body-container', () => {
@@ -1729,8 +1729,8 @@ describe('Component: Sample with config', () => {
     });
 
     it('options.updateFields does set field options as expected from config bindings', () => {
-        component.options.sampleOptionalField = component.emptyField;
-        component.options.sampleRequiredField = component.emptyField;
+        component.options.sampleOptionalField = new FieldMetaData();
+        component.options.sampleRequiredField = new FieldMetaData();
 
         component.options.updateFields();
         expect(component.options.sampleOptionalField).toEqual(DatasetServiceMock.NAME_FIELD);

--- a/src/app/components/sample/sample.component.ts
+++ b/src/app/components/sample/sample.component.ts
@@ -36,7 +36,7 @@ import { VisualizationService } from '../../services/visualization.service';
 
 import { AbstractSubcomponent, SubcomponentListener } from './subcomponent.abstract';
 import { BaseNeonComponent, BaseNeonOptions } from '../base-neon-component/base-neon.component';
-import { EMPTY_FIELD, FieldMetaData } from '../../dataset';
+import { FieldMetaData } from '../../dataset';
 import { neonVariables } from '../../neon-namespaces';
 import { SubcomponentImpl1 } from './subcomponent.impl1';
 import { SubcomponentImpl2 } from './subcomponent.impl2';

--- a/src/app/components/scatter-plot/scatter-plot.component.html
+++ b/src/app/components/scatter-plot/scatter-plot.component.html
@@ -81,7 +81,7 @@
                 <mat-form-field>
                     <mat-select placeholder="Color Field" [(ngModel)]="options.colorField"
                                (ngModelChange)="handleChangeData()" [disabled]="options.fields.length == 0">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>

--- a/src/app/components/scatter-plot/scatter-plot.component.ts
+++ b/src/app/components/scatter-plot/scatter-plot.component.ts
@@ -36,7 +36,7 @@ import { VisualizationService } from '../../services/visualization.service';
 
 import { BaseNeonComponent, BaseNeonOptions } from '../base-neon-component/base-neon.component';
 import { ChartComponent } from '../chart/chart.component';
-import { EMPTY_FIELD, FieldMetaData } from '../../dataset';
+import { FieldMetaData } from '../../dataset';
 import { neonVariables } from '../../neon-namespaces';
 import * as neon from 'neon-framework';
 

--- a/src/app/components/text-cloud/text-cloud.component.html
+++ b/src/app/components/text-cloud/text-cloud.component.html
@@ -65,7 +65,7 @@
                 <mat-form-field>
                     <mat-select placeholder="Size Field" [(ngModel)]="options.sizeField"
                                (ngModelChange)="handleChangeData()" [disabled]="options.fields.length == 0">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>

--- a/src/app/components/text-cloud/text-cloud.component.spec.ts
+++ b/src/app/components/text-cloud/text-cloud.component.spec.ts
@@ -91,8 +91,8 @@ describe('Component: TextCloud', () => {
     it('has expected options properties', () => {
         expect(component.options.aggregation).toBe('AVG');
         expect(component.options.andFilters).toBe(true);
-        expect(component.options.dataField).toEqual(component.emptyField);
-        expect(component.options.sizeField).toEqual(component.emptyField);
+        expect(component.options.dataField).toEqual(new FieldMetaData());
+        expect(component.options.sizeField).toEqual(new FieldMetaData());
     });
 
     it('has expected class properties', () => {

--- a/src/app/components/text-cloud/text-cloud.component.ts
+++ b/src/app/components/text-cloud/text-cloud.component.ts
@@ -35,7 +35,7 @@ import { ThemesService } from '../../services/themes.service';
 import { VisualizationService } from '../../services/visualization.service';
 
 import { BaseNeonComponent, BaseNeonOptions } from '../base-neon-component/base-neon.component';
-import { EMPTY_FIELD, FieldMetaData } from '../../dataset';
+import { FieldMetaData } from '../../dataset';
 import { neonVariables } from '../../neon-namespaces';
 import { TextCloud, SizeOptions, ColorOptions } from './text-cloud-namespace';
 import * as neon from 'neon-framework';

--- a/src/app/components/thumbnail-grid/thumbnail-grid.component.html
+++ b/src/app/components/thumbnail-grid/thumbnail-grid.component.html
@@ -63,7 +63,7 @@
 
                     <mat-form-field>
                         <mat-select placeholder="Flag Label" [(ngModel)]="options.flagLabel" required="true" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                            <mat-option [value]="emptyField">(None)</mat-option>
+                            <mat-option [value]="createEmptyField()">(None)</mat-option>
                             <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                         </mat-select>
                     </mat-form-field>
@@ -71,7 +71,7 @@
 
                     <mat-form-field>
                         <mat-select placeholder="Flag Sub-Label 1" [(ngModel)]="options.flagSubLabel1" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                            <mat-option [value]="emptyField">(None)</mat-option>
+                            <mat-option [value]="createEmptyField()">(None)</mat-option>
                             <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                         </mat-select>
                     </mat-form-field>
@@ -79,7 +79,7 @@
 
                     <mat-form-field>
                         <mat-select placeholder="Flag Sub-Label 2" [(ngModel)]="options.flagSubLabel2" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                            <mat-option [value]="emptyField">(None)</mat-option>
+                            <mat-option [value]="createEmptyField()">(None)</mat-option>
                             <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                         </mat-select>
                     </mat-form-field>
@@ -87,7 +87,7 @@
 
                     <mat-form-field>
                         <mat-select placeholder="Flag Sub-Label 3" [(ngModel)]="options.flagSubLabel3" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                            <mat-option [value]="emptyField">(None)</mat-option>
+                            <mat-option [value]="createEmptyField()">(None)</mat-option>
                             <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                         </mat-select>
                     </mat-form-field>
@@ -97,7 +97,7 @@
                 <div *ngIf="!options.detailedThumbnails">
                     <mat-form-field>
                         <mat-select placeholder="Name Field" [(ngModel)]="options.nameField" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                            <mat-option [value]="emptyField">(None)</mat-option>
+                            <mat-option [value]="createEmptyField()">(None)</mat-option>
                             <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                         </mat-select>
                     </mat-form-field>
@@ -105,7 +105,7 @@
 
                     <mat-form-field>
                         <mat-select placeholder="Actual Name Field" [(ngModel)]="options.objectNameField" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                            <mat-option [value]="emptyField">(None)</mat-option>
+                            <mat-option [value]="createEmptyField()">(None)</mat-option>
                             <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                         </mat-select>
                     </mat-form-field>
@@ -113,7 +113,7 @@
 
                     <mat-form-field>
                         <mat-select placeholder="Predicted Name Field" [(ngModel)]="options.predictedNameField" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                            <mat-option [value]="emptyField">(None)</mat-option>
+                            <mat-option [value]="createEmptyField()">(None)</mat-option>
                             <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                         </mat-select>
                     </mat-form-field>
@@ -121,7 +121,7 @@
 
                     <mat-form-field>
                         <mat-select placeholder="Predicted Probability Field" [(ngModel)]="options.percentField" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                            <mat-option [value]="emptyField">(None)</mat-option>
+                            <mat-option [value]="createEmptyField()">(None)</mat-option>
                             <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                         </mat-select>
                     </mat-form-field>
@@ -129,7 +129,7 @@
 
                     <mat-form-field>
                         <mat-select placeholder="Category Field" [(ngModel)]="options.categoryField" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                            <mat-option [value]="emptyField">(None)</mat-option>
+                            <mat-option [value]="createEmptyField()">(None)</mat-option>
                             <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                         </mat-select>
                     </mat-form-field>
@@ -137,7 +137,7 @@
 
                     <mat-form-field>
                         <mat-select placeholder="Comparison Field" [(ngModel)]="options.compareField" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                            <mat-option [value]="emptyField">(None)</mat-option>
+                            <mat-option [value]="createEmptyField()">(None)</mat-option>
                             <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                         </mat-select>
                     </mat-form-field>
@@ -146,7 +146,7 @@
 
                 <mat-form-field>
                     <mat-select placeholder="Filter Field" [(ngModel)]="options.filterField" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>
@@ -154,7 +154,7 @@
 
                 <mat-form-field>
                     <mat-select placeholder="ID Field" [(ngModel)]="options.idField" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>
@@ -176,7 +176,7 @@
 
                 <mat-form-field>
                     <mat-select placeholder="Type Field" [(ngModel)]="options.typeField" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
-                        <mat-option [value]="emptyField">(None)</mat-option>
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
                     </mat-select>
                 </mat-form-field>

--- a/src/app/components/thumbnail-grid/thumbnail-grid.component.spec.ts
+++ b/src/app/components/thumbnail-grid/thumbnail-grid.component.spec.ts
@@ -99,18 +99,18 @@ describe('Component: ThumbnailGrid', () => {
         expect(component.options.textMap).toEqual({});
         expect(component.options.typeMap).toEqual({});
 
-        expect(component.options.categoryField).toEqual(component.emptyField);
-        expect(component.options.compareField).toEqual(component.emptyField);
-        expect(component.options.filterField).toEqual(component.emptyField);
-        expect(component.options.idField).toEqual(component.emptyField);
-        expect(component.options.linkField).toEqual(component.emptyField);
-        expect(component.options.nameField).toEqual(component.emptyField);
-        expect(component.options.objectIdField).toEqual(component.emptyField);
-        expect(component.options.objectNameField).toEqual(component.emptyField);
-        expect(component.options.percentField).toEqual(component.emptyField);
-        expect(component.options.predictedNameField).toEqual(component.emptyField);
-        expect(component.options.sortField).toEqual(component.emptyField);
-        expect(component.options.typeField).toEqual(component.emptyField);
+        expect(component.options.categoryField).toEqual(new FieldMetaData());
+        expect(component.options.compareField).toEqual(new FieldMetaData());
+        expect(component.options.filterField).toEqual(new FieldMetaData());
+        expect(component.options.idField).toEqual(new FieldMetaData());
+        expect(component.options.linkField).toEqual(new FieldMetaData());
+        expect(component.options.nameField).toEqual(new FieldMetaData());
+        expect(component.options.objectIdField).toEqual(new FieldMetaData());
+        expect(component.options.objectNameField).toEqual(new FieldMetaData());
+        expect(component.options.percentField).toEqual(new FieldMetaData());
+        expect(component.options.predictedNameField).toEqual(new FieldMetaData());
+        expect(component.options.sortField).toEqual(new FieldMetaData());
+        expect(component.options.typeField).toEqual(new FieldMetaData());
 
         expect(component.headerText).toBeDefined();
         expect(component.infoText).toBeDefined();
@@ -1508,11 +1508,11 @@ describe('Component: ThumbnailGrid', () => {
 
         component.options.filterField = new FieldMetaData('testFilterField', 'Test Filter Field');
         expect(component.isSelectable()).toEqual(true);
-        component.options.filterField = component.emptyField;
+        component.options.filterField = new FieldMetaData();
 
         component.options.idField = new FieldMetaData('testIdField', 'Test ID Field');
         expect(component.isSelectable()).toEqual(true);
-        component.options.idField = component.emptyField;
+        component.options.idField = new FieldMetaData();
 
         component.options.openOnMouseClick = true;
         expect(component.isSelectable()).toEqual(true);

--- a/src/app/components/timeline/timeline.component.ts
+++ b/src/app/components/timeline/timeline.component.ts
@@ -39,7 +39,7 @@ import { VisualizationService } from '../../services/visualization.service';
 import { BaseNeonComponent, BaseNeonOptions } from '../base-neon-component/base-neon.component';
 import { Bucketizer } from '../bucketizers/Bucketizer';
 import { DateBucketizer } from '../bucketizers/DateBucketizer';
-import { EMPTY_FIELD, FieldMetaData } from '../../dataset';
+import { FieldMetaData } from '../../dataset';
 import { MonthBucketizer } from '../bucketizers/MonthBucketizer';
 import { neonMappings, neonVariables } from '../../neon-namespaces';
 import { TimelineSelectorChart, TimelineSeries, TimelineData } from './TimelineSelectorChart';

--- a/src/app/components/wiki-viewer/wiki-viewer.component.spec.ts
+++ b/src/app/components/wiki-viewer/wiki-viewer.component.spec.ts
@@ -82,8 +82,8 @@ describe('Component: WikiViewer', () => {
     }));
 
     it('does set expected options properties', () => {
-        expect(component.options.idField).toEqual(component.emptyField);
-        expect(component.options.linkField).toEqual(component.emptyField);
+        expect(component.options.idField).toEqual(new FieldMetaData());
+        expect(component.options.linkField).toEqual(new FieldMetaData());
         expect(component.options.id).toEqual('');
     });
 

--- a/src/app/components/wiki-viewer/wiki-viewer.component.ts
+++ b/src/app/components/wiki-viewer/wiki-viewer.component.ts
@@ -37,7 +37,7 @@ import { ThemesService } from '../../services/themes.service';
 import { VisualizationService } from '../../services/visualization.service';
 
 import { BaseNeonComponent, BaseNeonOptions } from '../base-neon-component/base-neon.component';
-import { EMPTY_FIELD, FieldMetaData } from '../../dataset';
+import { FieldMetaData } from '../../dataset';
 import { neonUtilities } from '../../neon-namespaces';
 import * as neon from 'neon-framework';
 

--- a/src/app/dataset.ts
+++ b/src/app/dataset.ts
@@ -22,8 +22,6 @@ export class FieldMetaData {
     ) {}
 }
 
-export const EMPTY_FIELD = new FieldMetaData();
-
 export class TableMetaData {
     constructor(
         public name: string = '',


### PR DESCRIPTION
PLEASE DO NOT MERGE YET.  Just approve the changes and let me merge when ready.

I removed the EMPTY_FIELD and emptyField variables that were used by the many Components when they needed to reference an empty Field object.  I found in some of the tests that we were accidentally assigning variables to emptyField.columnName or emptyField.prettyName which would then affect the rest of the application (since it's a shared variable).  I didn't want this happening in the production code so I thought it would be best to simply remove the shared variable and force the Components create new Field objects as needed.

Please let me know if you have any questions.

Thanks!