### PR TITLE
Added neon server URL property to GTD config and added a call to load…

### DIFF
--- a/src/app/neon-gtd-config.ts
+++ b/src/app/neon-gtd-config.ts
@@ -26,4 +26,5 @@ export class NeonGTDConfig {
     datasets: Dataset[] = [];
     layouts: { [ key: string ]: any } = {};
     errors: String[];
+    neonServerUrl: string;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -134,6 +134,9 @@ function validateConfig(config) {
 
 function bootstrapWithData(configFromFile) {
     let configObject = validateConfig(configFromFile);
+    if (configObject && configObject.neonServerUrl) {
+        neon.setNeonServerUrl(configObject.neonServerUrl);
+    }
     let errors = neonConfigErrors;
     neonConfigErrors = null;
     if (errors && errors.length > 0) {


### PR DESCRIPTION
… it on startup if it exists.

Existing configuration files will need to be changed to make use of this feature, but will work as normal if not changed. Neon server URL will still default to `../neon` if not set.