### PR TITLE
Changed the ColorSets to use CSS Custom Properties

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -89,6 +89,4 @@
             </div>
         </div>
     </div>
-    <div class="color-primary"></div>
-    <div class="color-highlight"></div>
 </mat-sidenav-container>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -45,14 +45,6 @@
     overflow-y: auto;
 }
 
-.color-primary {
-    color: var(--color-primary, grey);
-}
-
-.color-highlight {
-    color: var(--color-accent, lightgrey);
-}
-
 .header-toggle-container {
     z-index: 9999;
     position: absolute;

--- a/src/app/color.spec.ts
+++ b/src/app/color.spec.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 Next Century Corporation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { Color, ColorSet } from './color';
+
+describe('Color', () => {
+    it('fromHexString does create Color from hex string', () => {
+        expect(Color.fromHexString('#000000')).toEqual(new Color('#000000', 'rgba(0,0,0,0.66)', 'rgba(0,0,0,0.33)'));
+        expect(Color.fromHexString('#ffffff')).toEqual(new Color('#ffffff', 'rgba(255,255,255,0.66)', 'rgba(255,255,255,0.33)'));
+        expect(Color.fromHexString('#00ff00')).toEqual(new Color('#00ff00', 'rgba(0,255,0,0.66)', 'rgba(0,255,0,0.33)'));
+        expect(Color.fromHexString('#0f0')).toEqual(new Color('#0f0', 'rgba(0,255,0,0.66)', 'rgba(0,255,0,0.33)'));
+
+        expect(Color.fromHexString(null)).toEqual(null);
+        expect(Color.fromHexString('')).toEqual(null);
+
+        expect(Color.fromHexString('ffffff')).toEqual(new Color('#ffffff', 'rgba(255,255,255,0.66)', 'rgba(255,255,255,0.33)'));
+        expect(Color.fromHexString('fff')).toEqual(new Color('#fff', 'rgba(255,255,255,0.66)', 'rgba(255,255,255,0.33)'));
+    });
+
+    it('fromRgb does create Color from RGB', () => {
+        expect(Color.fromRgb(0, 0, 0)).toEqual(new Color('rgb(0,0,0)', 'rgba(0,0,0,0.66)', 'rgba(0,0,0,0.33)'));
+        expect(Color.fromRgb(255, 255, 255)).toEqual(new Color('rgb(255,255,255)', 'rgba(255,255,255,0.66)', 'rgba(255,255,255,0.33)'));
+        expect(Color.fromRgb(1, 2, 3)).toEqual(new Color('rgb(1,2,3)', 'rgba(1,2,3,0.66)', 'rgba(1,2,3,0.33)'));
+
+        expect(Color.fromRgb(1, 2, null)).toEqual(null);
+        expect(Color.fromRgb(1, null, 3)).toEqual(null);
+        expect(Color.fromRgb(null, 2, 3)).toEqual(null);
+    });
+
+    it('fromRgbArray does create Color from RGB array', () => {
+        expect(Color.fromRgbArray([0, 0, 0])).toEqual(new Color('rgb(0,0,0)', 'rgba(0,0,0,0.66)', 'rgba(0,0,0,0.33)'));
+        expect(Color.fromRgbArray([255, 255, 255])).toEqual(new Color('rgb(255,255,255)', 'rgba(255,255,255,0.66)',
+            'rgba(255,255,255,0.33)'));
+        expect(Color.fromRgbArray([1, 2, 3])).toEqual(new Color('rgb(1,2,3)', 'rgba(1,2,3,0.66)', 'rgba(1,2,3,0.33)'));
+
+        expect(Color.fromRgbArray(null)).toEqual(null);
+        expect(Color.fromRgbArray([])).toEqual(null);
+        expect(Color.fromRgbArray([1])).toEqual(null);
+        expect(Color.fromRgbArray([1, 2])).toEqual(null);
+        expect(Color.fromRgbArray([1, 2, 3, 4])).toEqual(null);
+    });
+
+    it('fromRgbString does create Color from RGB string', () => {
+        expect(Color.fromRgbString('0,0,0')).toEqual(new Color('rgb(0,0,0)', 'rgba(0,0,0,0.66)', 'rgba(0,0,0,0.33)'));
+        expect(Color.fromRgbString('255,255,255')).toEqual(new Color('rgb(255,255,255)', 'rgba(255,255,255,0.66)',
+            'rgba(255,255,255,0.33)'));
+        expect(Color.fromRgbString('1,2,3')).toEqual(new Color('rgb(1,2,3)', 'rgba(1,2,3,0.66)', 'rgba(1,2,3,0.33)'));
+
+        expect(Color.fromRgbString(null)).toEqual(null);
+        expect(Color.fromRgbString('')).toEqual(null);
+        expect(Color.fromRgbString('1')).toEqual(null);
+        expect(Color.fromRgbString('1,2')).toEqual(null);
+        expect(Color.fromRgbString('1,2,3,4')).toEqual(null);
+    });
+});
+
+describe('ColorSet', () => {
+    let color1: Color = new Color('var(--color-set-1)', 'var(--color-set-1-transparency-medium)', 'var(--color-set-1-transparency-high)');
+    let color2: Color = new Color('var(--color-set-2)', 'var(--color-set-2-transparency-medium)', 'var(--color-set-2-transparency-high)');
+
+    it('getColorForValue does set new color for new value', () => {
+        let colorSet = new ColorSet('testColorKey', 'testDatabase', 'testTable', 'testColorField');
+        expect(colorSet.getColorForValue('testColorValue1')).toEqual(color1);
+        expect(colorSet.getColorForValue('testColorValue2')).toEqual(color2);
+    });
+
+    it('getColorForValue does use old color for old value', () => {
+        let colorSet = new ColorSet('testColorKey', 'testDatabase', 'testTable', 'testColorField');
+        colorSet.getColorForValue('testColorValue1');
+        colorSet.getColorForValue('testColorValue2');
+        expect(colorSet.getColorForValue('testColorValue1')).toEqual(color1);
+        expect(colorSet.getColorForValue('testColorValue2')).toEqual(color2);
+    });
+
+    it('getAllKeys does return expected array', () => {
+        let colorSet = new ColorSet('testColorKey', 'testDatabase', 'testTable', 'testColorField');
+        expect(colorSet.getAllKeys()).toEqual([]);
+        colorSet.getColorForValue('testColorValue1');
+        expect(colorSet.getAllKeys()).toEqual(['testColorValue1']);
+        colorSet.getColorForValue('testColorValue2');
+        expect(colorSet.getAllKeys()).toEqual(['testColorValue1', 'testColorValue2']);
+    });
+
+    it('with custom color map', () => {
+        let testColor1 = new Color('a', 'b', 'c');
+        let testColor2 = new Color('d', 'e', 'f');
+
+        let colorMap = new Map<string, Color>();
+        colorMap.set('testColorValue1', testColor1);
+        colorMap.set('testColorValue2', testColor2);
+
+        let colorSet = new ColorSet('testColorKey', 'testDatabase', 'testTable', 'testColorField', colorMap);
+        expect(colorSet.getColorForValue('testColorValue1')).toEqual(testColor1);
+        expect(colorSet.getColorForValue('testColorValue2')).toEqual(testColor2);
+    });
+});

--- a/src/app/color.ts
+++ b/src/app/color.ts
@@ -21,11 +21,14 @@ import { ElementRef } from '@angular/core';
  */
 export class Color {
     /**
-     * Creates and returns a Color object using the given Hex string like #123 or #112233.
+     * Creates and returns a Color object using the given Hex string like "#123" or "#112233" or "112233".
      * @arg {string} inputHex
      * @return {Color}
      */
     static fromHexString(inputHex: string): Color {
+        if (!inputHex) {
+            return null;
+        }
         // https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
         let shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
         let hex = inputHex.replace(shorthandRegex, function(m, r, g, b) {
@@ -34,7 +37,8 @@ export class Color {
         let hexArray = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
         if (hexArray) {
             let rgb = parseInt(hexArray[1], 16) + ',' + parseInt(hexArray[2], 16) + ',' + parseInt(hexArray[3], 16);
-            return new Color(inputHex, 'rgba(' + rgb + ',0.66)', 'rgba(' + rgb + ',0.33)');
+            return new Color((inputHex.indexOf('#') === 0 ? inputHex : ('#' + inputHex)), 'rgba(' + rgb + ',0.66)',
+                'rgba(' + rgb + ',0.33)');
         }
         return null;
     }
@@ -67,7 +71,7 @@ export class Color {
     }
 
     /**
-     * Creates and returns a Color object using the given RGB string like rgb(12, 34, 56).
+     * Creates and returns a Color object using the given RGB string like "12,34,56".
      * @arg {string} inputRGB
      * @return {Color}
      */
@@ -76,16 +80,16 @@ export class Color {
             return null;
         }
         let arrayRGB = inputRGB.replace(/[^\d,]/g, '').split(',');
-        return Color.fromRgb(Number(arrayRGB[0]), Number(arrayRGB[1]), Number(arrayRGB[2]));
+        return arrayRGB.length === 3 ? Color.fromRgb(Number(arrayRGB[0]), Number(arrayRGB[1]), Number(arrayRGB[2])) : null;
     }
 
     /**
      * @constructor
      * @arg {string} css
-     * @arg {string} opacity66
-     * @arg {string} opacity33
+     * @arg {string} transparencyMedium
+     * @arg {string} transparencyHigh
      */
-    constructor(private css: string, private opacity66: string, private opacity33: string) {
+    constructor(private css: string, private transparencyMedium: string, private transparencyHigh: string) {
         // Do nothing.
     }
 
@@ -99,21 +103,21 @@ export class Color {
     }
 
     /**
-     * Returns the CSS for the color with opacity 66 using the given ElementRef object to find custom CSS properties like "--variable".
+     * Returns the CSS for the medium transparency color using the given ElementRef object to find custom CSS properties like "--variable".
      * @arg {ElementRef} elementRef
      * @return {string}
      */
-    public getComputedCssOpacity66(elementRef: ElementRef): string {
-        return this.computeColor(this.opacity66, elementRef);
+    public getComputedCssTransparencyMedium(elementRef: ElementRef): string {
+        return this.computeColor(this.transparencyMedium, elementRef);
     }
 
     /**
-     * Returns the CSS for the color with opacity 33 using the given ElementRef object to find custom CSS properties like "--variable".
+     * Returns the CSS for the high transparency color using the given ElementRef object to find custom CSS properties like "--variable".
      * @arg {ElementRef} elementRef
      * @return {string}
      */
-    public getComputedCssOpacity33(elementRef: ElementRef): string {
-        return this.computeColor(this.opacity33, elementRef);
+    public getComputedCssTransparencyHigh(elementRef: ElementRef): string {
+        return this.computeColor(this.transparencyHigh, elementRef);
     }
 
     /**
@@ -125,19 +129,19 @@ export class Color {
     }
 
     /**
-     * Returns the CSS for the color with opacity 66.
+     * Returns the CSS for the color with medium transparency.
      * @return {string}
      */
-    public getCssOpacity66(): string {
-        return this.opacity66;
+    public getCssTransparencyMedium(): string {
+        return this.transparencyMedium;
     }
 
     /**
-     * Returns the CSS for the color with opacity 33.
+     * Returns the CSS for the color with high transparency.
      * @return {string}
      */
-    public getCssOpacity33(): string {
-        return this.opacity33;
+    public getCssTransparencyHigh(): string {
+        return this.transparencyHigh;
     }
 
     /**
@@ -164,30 +168,30 @@ export class Color {
  */
 export class ColorSet {
     private colors: Color[] = [
-        new Color('var(--color-set-1)', 'var(--color-set-1-opacity-66)', 'var(--color-set-1-opacity-33)'),
-        new Color('var(--color-set-2)', 'var(--color-set-2-opacity-66)', 'var(--color-set-2-opacity-33)'),
-        new Color('var(--color-set-3)', 'var(--color-set-3-opacity-66)', 'var(--color-set-3-opacity-33)'),
-        new Color('var(--color-set-4)', 'var(--color-set-4-opacity-66)', 'var(--color-set-4-opacity-33)'),
-        new Color('var(--color-set-5)', 'var(--color-set-5-opacity-66)', 'var(--color-set-5-opacity-33)'),
-        new Color('var(--color-set-6)', 'var(--color-set-6-opacity-66)', 'var(--color-set-6-opacity-33)'),
-        new Color('var(--color-set-7)', 'var(--color-set-7-opacity-66)', 'var(--color-set-7-opacity-33)'),
-        new Color('var(--color-set-8)', 'var(--color-set-8-opacity-66)', 'var(--color-set-8-opacity-33)'),
-        new Color('var(--color-set-light-1)', 'var(--color-set-light-1-opacity-66)', 'var(--color-set-light-1-opacity-33)'),
-        new Color('var(--color-set-light-2)', 'var(--color-set-light-2-opacity-66)', 'var(--color-set-light-2-opacity-33)'),
-        new Color('var(--color-set-light-3)', 'var(--color-set-light-3-opacity-66)', 'var(--color-set-light-3-opacity-33)'),
-        new Color('var(--color-set-light-4)', 'var(--color-set-light-4-opacity-66)', 'var(--color-set-light-4-opacity-33)'),
-        new Color('var(--color-set-light-5)', 'var(--color-set-light-5-opacity-66)', 'var(--color-set-light-5-opacity-33)'),
-        new Color('var(--color-set-light-6)', 'var(--color-set-light-6-opacity-66)', 'var(--color-set-light-6-opacity-33)'),
-        new Color('var(--color-set-light-7)', 'var(--color-set-light-7-opacity-66)', 'var(--color-set-light-7-opacity-33)'),
-        new Color('var(--color-set-light-8)', 'var(--color-set-light-8-opacity-66)', 'var(--color-set-light-8-opacity-33)'),
-        new Color('var(--color-set-dark-1)', 'var(--color-set-dark-1-opacity-66)', 'var(--color-set-dark-1-opacity-33)'),
-        new Color('var(--color-set-dark-2)', 'var(--color-set-dark-2-opacity-66)', 'var(--color-set-dark-2-opacity-33)'),
-        new Color('var(--color-set-dark-3)', 'var(--color-set-dark-3-opacity-66)', 'var(--color-set-dark-3-opacity-33)'),
-        new Color('var(--color-set-dark-4)', 'var(--color-set-dark-4-opacity-66)', 'var(--color-set-dark-4-opacity-33)'),
-        new Color('var(--color-set-dark-5)', 'var(--color-set-dark-5-opacity-66)', 'var(--color-set-dark-5-opacity-33)'),
-        new Color('var(--color-set-dark-6)', 'var(--color-set-dark-6-opacity-66)', 'var(--color-set-dark-6-opacity-33)'),
-        new Color('var(--color-set-dark-7)', 'var(--color-set-dark-7-opacity-66)', 'var(--color-set-dark-7-opacity-33)'),
-        new Color('var(--color-set-dark-8)', 'var(--color-set-dark-8-opacity-66)', 'var(--color-set-dark-8-opacity-33)')
+        new Color('var(--color-set-1)', 'var(--color-set-1-transparency-medium)', 'var(--color-set-1-transparency-high)'),
+        new Color('var(--color-set-2)', 'var(--color-set-2-transparency-medium)', 'var(--color-set-2-transparency-high)'),
+        new Color('var(--color-set-3)', 'var(--color-set-3-transparency-medium)', 'var(--color-set-3-transparency-high)'),
+        new Color('var(--color-set-4)', 'var(--color-set-4-transparency-medium)', 'var(--color-set-4-transparency-high)'),
+        new Color('var(--color-set-5)', 'var(--color-set-5-transparency-medium)', 'var(--color-set-5-transparency-high)'),
+        new Color('var(--color-set-6)', 'var(--color-set-6-transparency-medium)', 'var(--color-set-6-transparency-high)'),
+        new Color('var(--color-set-7)', 'var(--color-set-7-transparency-medium)', 'var(--color-set-7-transparency-high)'),
+        new Color('var(--color-set-8)', 'var(--color-set-8-transparency-medium)', 'var(--color-set-8-transparency-high)'),
+        new Color('var(--color-set-light-1)', 'var(--color-set-light-1-transparency-medium)', 'var(--color-set-light-1-transparency-high)'),
+        new Color('var(--color-set-light-2)', 'var(--color-set-light-2-transparency-medium)', 'var(--color-set-light-2-transparency-high)'),
+        new Color('var(--color-set-light-3)', 'var(--color-set-light-3-transparency-medium)', 'var(--color-set-light-3-transparency-high)'),
+        new Color('var(--color-set-light-4)', 'var(--color-set-light-4-transparency-medium)', 'var(--color-set-light-4-transparency-high)'),
+        new Color('var(--color-set-light-5)', 'var(--color-set-light-5-transparency-medium)', 'var(--color-set-light-5-transparency-high)'),
+        new Color('var(--color-set-light-6)', 'var(--color-set-light-6-transparency-medium)', 'var(--color-set-light-6-transparency-high)'),
+        new Color('var(--color-set-light-7)', 'var(--color-set-light-7-transparency-medium)', 'var(--color-set-light-7-transparency-high)'),
+        new Color('var(--color-set-light-8)', 'var(--color-set-light-8-transparency-medium)', 'var(--color-set-light-8-transparency-high)'),
+        new Color('var(--color-set-dark-1)', 'var(--color-set-dark-1-transparency-medium)', 'var(--color-set-dark-1-transparency-high)'),
+        new Color('var(--color-set-dark-2)', 'var(--color-set-dark-2-transparency-medium)', 'var(--color-set-dark-2-transparency-high)'),
+        new Color('var(--color-set-dark-3)', 'var(--color-set-dark-3-transparency-medium)', 'var(--color-set-dark-3-transparency-high)'),
+        new Color('var(--color-set-dark-4)', 'var(--color-set-dark-4-transparency-medium)', 'var(--color-set-dark-4-transparency-high)'),
+        new Color('var(--color-set-dark-5)', 'var(--color-set-dark-5-transparency-medium)', 'var(--color-set-dark-5-transparency-high)'),
+        new Color('var(--color-set-dark-6)', 'var(--color-set-dark-6-transparency-medium)', 'var(--color-set-dark-6-transparency-high)'),
+        new Color('var(--color-set-dark-7)', 'var(--color-set-dark-7-transparency-medium)', 'var(--color-set-dark-7-transparency-high)'),
+        new Color('var(--color-set-dark-8)', 'var(--color-set-dark-8-transparency-medium)', 'var(--color-set-dark-8-transparency-high)')
     ];
     private currentIndex: number = 0;
 

--- a/src/app/color.ts
+++ b/src/app/color.ts
@@ -13,16 +13,13 @@
  * limitations under the License.
  *
  */
+import { ElementRef } from '@angular/core';
 
 /**
  * General color class.
  * This class can provide colors in a hex string, RGB formatted, or in RGB percent.
  */
 export class Color {
-    private red: number;
-    private green: number;
-    private blue: number;
-
     /**
      * Creates and returns a Color object using the given Hex string like #123 or #112233.
      * @arg {string} inputHex
@@ -34,110 +31,131 @@ export class Color {
         let hex = inputHex.replace(shorthandRegex, function(m, r, g, b) {
             return r + r + g + g + b + b;
         });
-
-        let result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-        return result ? new Color(
-            parseInt(result[1], 16),
-            parseInt(result[2], 16),
-            parseInt(result[3], 16)
-        ) : null;
+        let hexArray = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+        if (hexArray) {
+            let rgb = parseInt(hexArray[1], 16) + ',' + parseInt(hexArray[2], 16) + ',' + parseInt(hexArray[3], 16);
+            return new Color(inputHex, 'rgba(' + rgb + ',0.66)', 'rgba(' + rgb + ',0.33)');
+        }
+        return null;
     }
 
     /**
-     * Create a color object from an array of RGB values.
-     * The array must have 3 elements in it
-     * @arg {number[]} rgb
+     * Creates and returns a Color object using the given RGB numbers.
+     * @arg {number} red
+     * @arg {number} green
+     * @arg {number} blue
      * @return {Color}
      */
-    static fromRgbArray(rgb: number[]): Color {
-        if (rgb == null || rgb.length !== 3) {
+    static fromRgb(red: number, green: number, blue: number): Color {
+        if (red === null || green === null || blue === null) {
             return null;
         }
-        return new Color(rgb[0], rgb[1], rgb[2]);
+        let rgb = red + ',' + green + ',' + blue;
+        return new Color('rgb(' + rgb + ')', 'rgba(' + rgb + ',0.66)', 'rgba(' + rgb + ',0.33)');
     }
 
     /**
-     * Create a color object from an RGB string, like "rgb(39, 96, 126)"
-     * @arg {string} rgbstring
+     * Creates and returns a Color object using the given RGB array like [12, 34, 56].
+     * @arg {number[]} inputRGB
      * @return {Color}
      */
-    static fromRgbString(rgbstring: string): Color {
-        if (rgbstring == null || rgbstring.length < 5) {
+    static fromRgbArray(inputRGB: number[]): Color {
+        if (inputRGB === null || inputRGB.length !== 3) {
             return null;
         }
-        let rgbstringarray = rgbstring.replace(/[^\d,]/g, '').split(',');
-        let red = Number(rgbstringarray[0]);
-        let green = Number(rgbstringarray[1]);
-        let blue = Number(rgbstringarray[2]);
-        return Color.fromRgbArray([red, green, blue]);
-    }
-
-    constructor(r: number, g: number, b: number) {
-        this.red = r;
-        this.green = g;
-        this.blue = b;
-    }
-
-    private getBase255(value: number) {
-        return value;
-    }
-
-    private getBase1(value: number) {
-        return value / 255;
-    }
-
-    private getHex(value: number) {
-        return value.toString(16);
+        return Color.fromRgb(inputRGB[0], inputRGB[1], inputRGB[2]);
     }
 
     /**
-     * Get the 'inactive' color, aka the RGBA string with an alpha of 0.3
-     * @return {string}
+     * Creates and returns a Color object using the given RGB string like rgb(12, 34, 56).
+     * @arg {string} inputRGB
+     * @return {Color}
      */
-    getInactiveRgba(): string {
-        return this.toRgba(0.2);
+    static fromRgbString(inputRGB: string): Color {
+        if (inputRGB === null || inputRGB.length < 5) {
+            return null;
+        }
+        let arrayRGB = inputRGB.replace(/[^\d,]/g, '').split(',');
+        return Color.fromRgb(Number(arrayRGB[0]), Number(arrayRGB[1]), Number(arrayRGB[2]));
     }
 
     /**
-     * Get the color as a string of RGB percentages
-     * @return {string}
+     * @constructor
+     * @arg {string} css
+     * @arg {string} opacity66
+     * @arg {string} opacity33
      */
-    toPercentages(): string {
-        return '' + this.getBase1(this.red) + ',' +
-            this.getBase1(this.green) + ',' +
-            this.getBase1(this.blue);
+    constructor(private css: string, private opacity66: string, private opacity33: string) {
+        // Do nothing.
     }
 
     /**
-     * Get the color as a rgb(0,0,0) string
+     * Returns the computed CSS for the color using the given ElementRef object to find custom CSS properties like "--variable".
+     * @arg {ElementRef} elementRef
      * @return {string}
      */
-    toRgb(): string {
-        return 'rgb(' + this.getBase255(this.red) + ',' +
-            this.getBase255(this.green) + ',' +
-            this.getBase255(this.blue) + ')';
+    public getComputedCss(elementRef: ElementRef): string {
+        return this.computeColor(this.css, elementRef);
     }
 
     /**
-     * Get the color as a rgba(0,0,0,a) string
-     * @arg a alpha value (0-1)
+     * Returns the CSS for the color with opacity 66 using the given ElementRef object to find custom CSS properties like "--variable".
+     * @arg {ElementRef} elementRef
      * @return {string}
      */
-    toRgba(a: number): string {
-        return 'rgba(' + this.getBase255(this.red) + ',' +
-            this.getBase255(this.green) + ',' +
-            this.getBase255(this.blue) + ',' +
-            a + ')';
+    public getComputedCssOpacity66(elementRef: ElementRef): string {
+        return this.computeColor(this.opacity66, elementRef);
     }
 
     /**
-     * Get the color as a '#RRGGBB' string
+     * Returns the CSS for the color with opacity 33 using the given ElementRef object to find custom CSS properties like "--variable".
+     * @arg {ElementRef} elementRef
      * @return {string}
      */
-    toHexString(): string {
-        return '#' + this.getHex(this.red) +
-            this.getHex(this.green) +
-            this.getHex(this.blue);
+    public getComputedCssOpacity33(elementRef: ElementRef): string {
+        return this.computeColor(this.opacity33, elementRef);
+    }
+
+    /**
+     * Returns the CSS for the color.
+     * @return {string}
+     */
+    public getCss(): string {
+        return this.css;
+    }
+
+    /**
+     * Returns the CSS for the color with opacity 66.
+     * @return {string}
+     */
+    public getCssOpacity66(): string {
+        return this.opacity66;
+    }
+
+    /**
+     * Returns the CSS for the color with opacity 33.
+     * @return {string}
+     */
+    public getCssOpacity33(): string {
+        return this.opacity33;
+    }
+
+    /**
+     * Returns the color for the given CSS using the given ElementRef object to find custom CSS properties like "--variable".
+     * @arg {string} colorCss
+     * @arg {ElementRef} elementRef
+     * @return {string}
+     */
+    private computeColor(colorCss: string, elementRef: ElementRef): string {
+        if (colorCss.indexOf('var(--') === 0) {
+            let css = colorCss.substring(4, colorCss.length - 1);
+            css = css.indexOf(',') >= 0 ? css.substring(0, css.indexOf(',')) : css;
+            return getComputedStyle(elementRef.nativeElement).getPropertyValue(css);
+        }
+        if (colorCss.indexOf('--') === 0) {
+            return getComputedStyle(elementRef.nativeElement).getPropertyValue(colorCss);
+        }
+        return colorCss;
     }
 }
 
@@ -145,40 +163,42 @@ export class Color {
  * A set of colors, used to keep track of which values map to which colors
  */
 export class ColorSet {
-    // TODO Move to WidgetService
     private colors: Color[] = [
-        // NEON TEAL COLOR THEME
-        new Color(94, 80, 143),   // #5E508F (deep purple)
-        new Color(255, 135, 55),  // #FF8737 (orange)
-        new Color(179, 79, 146),  // #B34F92 (purple)
-        new Color(177, 194, 54),  // #B1C236 (lime)
-        new Color(243, 88, 112),  // #F35870 (pink)
-        new Color(0, 153, 255),   // #0099FF (blue)
-        new Color(255, 214, 0),   // #FFD600 (yellow)
-        new Color(106, 204, 127), // #6ACC7F (sea green)
-
-        // NEON TEAL COLOR THEME - LIGHT
-        new Color(141, 124, 192),   // #8D7CC0 (deep purple)
-        new Color(255, 184, 102),   // #FFb866 (orange)
-        new Color(231, 127, 194),   // #E77FC2 (purple)
-        new Color(230, 245, 105),   // #E6F569 (lime)
-        new Color(255, 139, 158),   // #FF8B9E (pink)
-        new Color(105, 204, 255),   // #69CCFF (blue)
-        new Color(255, 255, 82),    // #FFFF52 (yellow)
-        new Color(157, 255, 175),   // #369A52 (sea green)
-
-        // NEON TEAL COLOR THEME - DARK
-        new Color(49, 39, 97),    // #312761 (deep purple)
-        new Color(198, 88, 0),    // #C65800 (orange)
-        new Color(129, 29, 100),  // #811D64 (purple)
-        new Color(126, 146, 0),   // #7E9200 (lime)
-        new Color(187, 30, 69),   // #BB1E45 (pink)
-        new Color(0, 108, 203),   // #006CCB (blue)
-        new Color(199, 165, 0),   // #C7A500 (yellow)
-        new Color(54, 154, 82)    // #369A52 (sea green)
+        new Color('var(--color-set-1)', 'var(--color-set-1-opacity-66)', 'var(--color-set-1-opacity-33)'),
+        new Color('var(--color-set-2)', 'var(--color-set-2-opacity-66)', 'var(--color-set-2-opacity-33)'),
+        new Color('var(--color-set-3)', 'var(--color-set-3-opacity-66)', 'var(--color-set-3-opacity-33)'),
+        new Color('var(--color-set-4)', 'var(--color-set-4-opacity-66)', 'var(--color-set-4-opacity-33)'),
+        new Color('var(--color-set-5)', 'var(--color-set-5-opacity-66)', 'var(--color-set-5-opacity-33)'),
+        new Color('var(--color-set-6)', 'var(--color-set-6-opacity-66)', 'var(--color-set-6-opacity-33)'),
+        new Color('var(--color-set-7)', 'var(--color-set-7-opacity-66)', 'var(--color-set-7-opacity-33)'),
+        new Color('var(--color-set-8)', 'var(--color-set-8-opacity-66)', 'var(--color-set-8-opacity-33)'),
+        new Color('var(--color-set-light-1)', 'var(--color-set-light-1-opacity-66)', 'var(--color-set-light-1-opacity-33)'),
+        new Color('var(--color-set-light-2)', 'var(--color-set-light-2-opacity-66)', 'var(--color-set-light-2-opacity-33)'),
+        new Color('var(--color-set-light-3)', 'var(--color-set-light-3-opacity-66)', 'var(--color-set-light-3-opacity-33)'),
+        new Color('var(--color-set-light-4)', 'var(--color-set-light-4-opacity-66)', 'var(--color-set-light-4-opacity-33)'),
+        new Color('var(--color-set-light-5)', 'var(--color-set-light-5-opacity-66)', 'var(--color-set-light-5-opacity-33)'),
+        new Color('var(--color-set-light-6)', 'var(--color-set-light-6-opacity-66)', 'var(--color-set-light-6-opacity-33)'),
+        new Color('var(--color-set-light-7)', 'var(--color-set-light-7-opacity-66)', 'var(--color-set-light-7-opacity-33)'),
+        new Color('var(--color-set-light-8)', 'var(--color-set-light-8-opacity-66)', 'var(--color-set-light-8-opacity-33)'),
+        new Color('var(--color-set-dark-1)', 'var(--color-set-dark-1-opacity-66)', 'var(--color-set-dark-1-opacity-33)'),
+        new Color('var(--color-set-dark-2)', 'var(--color-set-dark-2-opacity-66)', 'var(--color-set-dark-2-opacity-33)'),
+        new Color('var(--color-set-dark-3)', 'var(--color-set-dark-3-opacity-66)', 'var(--color-set-dark-3-opacity-33)'),
+        new Color('var(--color-set-dark-4)', 'var(--color-set-dark-4-opacity-66)', 'var(--color-set-dark-4-opacity-33)'),
+        new Color('var(--color-set-dark-5)', 'var(--color-set-dark-5-opacity-66)', 'var(--color-set-dark-5-opacity-33)'),
+        new Color('var(--color-set-dark-6)', 'var(--color-set-dark-6-opacity-66)', 'var(--color-set-dark-6-opacity-33)'),
+        new Color('var(--color-set-dark-7)', 'var(--color-set-dark-7-opacity-66)', 'var(--color-set-dark-7-opacity-33)'),
+        new Color('var(--color-set-dark-8)', 'var(--color-set-dark-8-opacity-66)', 'var(--color-set-dark-8-opacity-33)')
     ];
     private currentIndex: number = 0;
 
+    /**
+     * @constructor
+     * @arg {string} colorKey
+     * @arg {string} databaseName
+     * @arg {string} tableName
+     * @arg {string} fieldName
+     * @arg {Map<string, Color>} [valueToColor=new Map<string, Color>()]
+     */
     constructor(private colorKey: string, private databaseName: string, private tableName: string, private fieldName: string,
         private valueToColor: Map<string, Color> = new Map<string, Color>()) {
 

--- a/src/app/components/aggregation/aggregation.component.scss
+++ b/src/app/components/aggregation/aggregation.component.scss
@@ -40,7 +40,7 @@
     }
 
     .subcomponent-selection {
-        background-color: var(--color-primary-opaque, rgba(128,128,128,0.4));
+        background-color: var(--color-primary-transparent, rgba(128,128,128,0.33));
         height: 10px;
         width: 10px;
         position: absolute;

--- a/src/app/components/aggregation/aggregation.component.spec.ts
+++ b/src/app/components/aggregation/aggregation.component.spec.ts
@@ -50,8 +50,8 @@ describe('Component: Aggregation', () => {
     let fixture: ComponentFixture<AggregationComponent>;
     let getService = (type: any) => fixture.debugElement.injector.get(type);
 
-    let COLOR_1 = new Color(94, 80, 143);
-    let COLOR_2 = new Color(255, 135, 55);
+    let COLOR_1 = new Color('var(--color-set-1)', 'var(--color-set-1-opacity-66)', 'var(--color-set-1-opacity-33)');
+    let COLOR_2 = new Color('var(--color-set-2)', 'var(--color-set-2-opacity-66)', 'var(--color-set-2-opacity-33)');
 
     initializeTestBed({
         declarations: [

--- a/src/app/components/aggregation/aggregation.component.spec.ts
+++ b/src/app/components/aggregation/aggregation.component.spec.ts
@@ -50,8 +50,8 @@ describe('Component: Aggregation', () => {
     let fixture: ComponentFixture<AggregationComponent>;
     let getService = (type: any) => fixture.debugElement.injector.get(type);
 
-    let COLOR_1 = new Color('var(--color-set-1)', 'var(--color-set-1-opacity-66)', 'var(--color-set-1-opacity-33)');
-    let COLOR_2 = new Color('var(--color-set-2)', 'var(--color-set-2-opacity-66)', 'var(--color-set-2-opacity-33)');
+    let COLOR_1 = new Color('var(--color-set-1)', 'var(--color-set-1-transparency-medium)', 'var(--color-set-1-transparency-high)');
+    let COLOR_2 = new Color('var(--color-set-2)', 'var(--color-set-2-transparency-medium)', 'var(--color-set-2-transparency-high)');
 
     initializeTestBed({
         declarations: [

--- a/src/app/components/aggregation/subcomponent.chartjs.abstract.spec.ts
+++ b/src/app/components/aggregation/subcomponent.chartjs.abstract.spec.ts
@@ -83,7 +83,7 @@ class TestChartJsSubcomponent extends AbstractChartJsSubcomponent {
     }
 
     protected createChartDataset(color: Color, label: string, xList: any[]): AbstractChartJsDataset {
-        return new TestChartJsDataset(color, label, xList);
+        return new TestChartJsDataset(this.elementRef, color, label, xList);
     }
 
     protected findAxisTypeX(): string {
@@ -127,22 +127,22 @@ describe('ChartJsSubcomponent', () => {
 
     it('createChartDataAndOptions does return expected object', () => {
         let dataAndOptions = subcomponent.getChartDataAndOptions([{
-            color: new Color(1, 2, 3),
+            color: Color.fromRgb(1, 2, 3),
             group: 'a',
             x: 1,
             y: 2
         }, {
-            color: new Color(1, 2, 3),
+            color: Color.fromRgb(1, 2, 3),
             group: 'a',
             x: 3,
             y: 4
         }, {
-            color: new Color(4, 5, 6),
+            color: Color.fromRgb(4, 5, 6),
             group: 'b',
             x: 5,
             y: 6
         }, {
-            color: new Color(4, 5, 6),
+            color: Color.fromRgb(4, 5, 6),
             group: 'b',
             x: 7,
             y: 8
@@ -189,7 +189,7 @@ describe('ChartJsSubcomponent', () => {
         expect(dataAndOptions.options.tooltips.callbacks.label).toBeDefined();
         expect(dataAndOptions.options.tooltips.callbacks.title).toBeDefined();
 
-        expect(dataAndOptions.data.datasets[0].color).toEqual(new Color(1, 2, 3));
+        expect(dataAndOptions.data.datasets[0].color).toEqual(Color.fromRgb(1, 2, 3));
         expect(dataAndOptions.data.datasets[0].label).toEqual('a');
         expect(dataAndOptions.data.datasets[0].data).toEqual([{
             x: 1,
@@ -205,7 +205,7 @@ describe('ChartJsSubcomponent', () => {
             y: null
         }]);
 
-        expect(dataAndOptions.data.datasets[1].color).toEqual(new Color(4, 5, 6));
+        expect(dataAndOptions.data.datasets[1].color).toEqual(Color.fromRgb(4, 5, 6));
         expect(dataAndOptions.data.datasets[1].label).toEqual('b');
         expect(dataAndOptions.data.datasets[1].data).toEqual([{
             x: 1,
@@ -234,22 +234,22 @@ describe('ChartJsSubcomponent', () => {
         subcomponent.horizontal = true;
 
         let dataAndOptions = subcomponent.getChartDataAndOptions([{
-            color: new Color(1, 2, 3),
+            color: Color.fromRgb(1, 2, 3),
             group: 'a',
             x: 1,
             y: 2
         }, {
-            color: new Color(1, 2, 3),
+            color: Color.fromRgb(1, 2, 3),
             group: 'a',
             x: 3,
             y: 4
         }, {
-            color: new Color(4, 5, 6),
+            color: Color.fromRgb(4, 5, 6),
             group: 'b',
             x: 5,
             y: 6
         }, {
-            color: new Color(4, 5, 6),
+            color: Color.fromRgb(4, 5, 6),
             group: 'b',
             x: 7,
             y: 8

--- a/src/app/components/aggregation/subcomponent.chartjs.abstract.ts
+++ b/src/app/components/aggregation/subcomponent.chartjs.abstract.ts
@@ -26,7 +26,7 @@ export abstract class AbstractChartJsDataset {
     public data: any[] = [];
     public xToY: Map<any, any> = new Map<any, any[]>();
 
-    constructor(public color: Color, public label: string, xList: string[]) {
+    constructor(protected elementRef: ElementRef, public color: Color, public label: string, xList: string[]) {
         xList.forEach((x) => {
             this.xToY.set(x, []);
         });
@@ -40,15 +40,15 @@ export abstract class AbstractChartJsDataset {
     public abstract finalizeData();
 
     public getColorBackground(): string {
-        return this.color.toRgba(0.33);
+        return this.color.getComputedCssOpacity33(this.elementRef);
     }
 
     public getColorDeselected(): string {
-        return this.color.toRgba(0.66);
+        return this.color.getComputedCssOpacity66(this.elementRef);
     }
 
     public getColorSelected(): string {
-        return this.color.toRgb();
+        return this.color.getComputedCss(this.elementRef);
     }
 
     public getLabels(): any[] {

--- a/src/app/components/aggregation/subcomponent.chartjs.abstract.ts
+++ b/src/app/components/aggregation/subcomponent.chartjs.abstract.ts
@@ -40,11 +40,11 @@ export abstract class AbstractChartJsDataset {
     public abstract finalizeData();
 
     public getColorBackground(): string {
-        return this.color.getComputedCssOpacity33(this.elementRef);
+        return this.color.getComputedCssTransparencyHigh(this.elementRef);
     }
 
     public getColorDeselected(): string {
-        return this.color.getComputedCssOpacity66(this.elementRef);
+        return this.color.getComputedCssTransparencyMedium(this.elementRef);
     }
 
     public getColorSelected(): string {

--- a/src/app/components/aggregation/subcomponent.chartjs.bar.ts
+++ b/src/app/components/aggregation/subcomponent.chartjs.bar.ts
@@ -29,8 +29,10 @@ export class ChartJsBarDataset extends AbstractChartJsDataset {
     public hoverBorderColor: string;
     public hoverBorderWidth: number = 3;
 
-    constructor(color: Color, label: string, xList: any[], public xSelected: any[], public horizontal: boolean = false) {
-        super(color, label, xList);
+    constructor(elementRef: ElementRef, color: Color, label: string, xList: any[], public xSelected: any[],
+        public horizontal: boolean = false) {
+
+        super(elementRef, color, label, xList);
         this.borderColor = this.getColorSelected();
         this.hoverBackgroundColor = this.getColorSelected();
         this.hoverBorderColor = this.getColorSelected();
@@ -78,7 +80,7 @@ export class ChartJsBarSubcomponent extends AbstractChartJsSubcomponent {
      * @override
      */
     protected createChartDataset(color: Color, label: string, xList: any[]): AbstractChartJsDataset {
-        return new ChartJsBarDataset(color, label, xList, this.selectedLabels, this.horizontal);
+        return new ChartJsBarDataset(this.elementRef, color, label, xList, this.selectedLabels, this.horizontal);
     }
 
     /**

--- a/src/app/components/aggregation/subcomponent.chartjs.line.ts
+++ b/src/app/components/aggregation/subcomponent.chartjs.line.ts
@@ -13,6 +13,7 @@
  * limitations under the License.
  *
  */
+import { ElementRef } from '@angular/core';
 import { AbstractChartJsDataset, AbstractChartJsSubcomponent, ChartJsData } from './subcomponent.chartjs.abstract';
 import { Color } from '../../color';
 
@@ -35,8 +36,8 @@ export class ChartJsLineDataset extends AbstractChartJsDataset {
     public pointStyle: string = 'circle';
     public showLine: boolean = true;
 
-    constructor(color: Color, label: string, xList: any[]) {
-        super(color, label, xList);
+    constructor(elementRef: ElementRef, color: Color, label: string, xList: any[]) {
+        super(elementRef, color, label, xList);
         this.backgroundColor = this.getColorBackground();
         this.borderColor = this.getColorSelected();
         this.pointBackgroundColor = this.getColorSelected();
@@ -69,7 +70,7 @@ export class ChartJsLineSubcomponent extends AbstractChartJsSubcomponent {
      * @override
      */
     protected createChartDataset(color: Color, label: string, xList: any[]): AbstractChartJsDataset {
-        let dataset = new ChartJsLineDataset(color, label, xList);
+        let dataset = new ChartJsLineDataset(this.elementRef, color, label, xList);
         dataset.fill = this.options.lineFillArea || dataset.fill;
         dataset.lineTension = this.options.lineCurveTension === 0 ? 0 : (this.options.lineCurveTension || dataset.lineTension);
         return dataset;

--- a/src/app/components/aggregation/subcomponent.chartjs.pie.ts
+++ b/src/app/components/aggregation/subcomponent.chartjs.pie.ts
@@ -30,8 +30,8 @@ export class ChartJsPieDataset extends AbstractChartJsDataset {
     public hoverBorderWidth: number = 3;
     public slices: any[] = [];
 
-    constructor(color: Color, label: string, xList: any[], public xSelected: any[]) {
-        super(color, label, xList);
+    constructor(elementRef: ElementRef, color: Color, label: string, xList: any[], public xSelected: any[]) {
+        super(elementRef, color, label, xList);
         this.borderColor = this.getColorSelected();
         this.hoverBackgroundColor = this.getColorSelected();
         this.hoverBorderColor = this.getColorSelected();
@@ -78,7 +78,7 @@ export class ChartJsPieSubcomponent extends AbstractChartJsSubcomponent {
      * @override
      */
     protected createChartDataset(color: Color, label: string, xList: any[]): AbstractChartJsDataset {
-        return new ChartJsPieDataset(color, label, xList, this.selectedLabels);
+        return new ChartJsPieDataset(this.elementRef, color, label, xList, this.selectedLabels);
     }
 
     /**

--- a/src/app/components/aggregation/subcomponent.chartjs.scatter.ts
+++ b/src/app/components/aggregation/subcomponent.chartjs.scatter.ts
@@ -21,8 +21,8 @@ import { Color } from '../../color';
 
 // http://www.chartjs.org/docs/latest/charts/line.html#dataset-properties
 class ChartJsScatterDataset extends ChartJsLineDataset {
-    constructor(color: Color, label: string, xList: any[]) {
-        super(color, label, xList);
+    constructor(elementRef: ElementRef, color: Color, label: string, xList: any[]) {
+        super(elementRef, color, label, xList);
         this.fill = false;
         this.showLine = false;
     }
@@ -53,7 +53,7 @@ export class ChartJsScatterSubcomponent extends ChartJsLineSubcomponent {
      * @override
      */
     protected createChartDataset(color: Color, label: string, xList: any[]): AbstractChartJsDataset {
-        return new ChartJsScatterDataset(color, label, xList);
+        return new ChartJsScatterDataset(this.elementRef, color, label, xList);
     }
 
     /**

--- a/src/app/components/aggregation/subcomponent.list.ts
+++ b/src/app/components/aggregation/subcomponent.list.ts
@@ -97,7 +97,7 @@ export class ListSubcomponent extends AbstractAggregationSubcomponent {
             if (groups.length > 1) {
                 let groupElement = document.createElement('td');
                 groupElement.setAttribute('class', 'list-text');
-                groupElement.setAttribute('style', 'color: ' + item.color.toRgb());
+                groupElement.setAttribute('style', 'color: ' + item.color.getComputedCss(this.elementRef));
                 groupElement.innerHTML = item.group;
                 rowTitle = item.group + ' - ' + rowTitle;
                 rowElement.appendChild(groupElement);

--- a/src/app/components/annotation-viewer/annotation-viewer.component.ts
+++ b/src/app/components/annotation-viewer/annotation-viewer.component.ts
@@ -461,7 +461,7 @@ export class AnnotationViewerComponent extends BaseNeonComponent implements OnIn
                     let currentText = document.annotationTextList[index];
                     let currentType = document.annotationTypeList[index];
                     let highlightColor = this.widgetService.getColor(this.options.database.name, this.options.table.name, currentType,
-                        currentType).toRgba(0.4);
+                        currentType).getComputedCssOpacity33(this.visualization);
 
                     currentPart.highlightColor = highlightColor;
                     currentPart.text = currentText;
@@ -895,7 +895,7 @@ export class AnnotationViewerComponent extends BaseNeonComponent implements OnIn
                 } else {
                     if (part.highlightColor && part.highlightColor.includes('rgb(255,255,255')) {
                         part.highlightColor = this.widgetService.getColor(this.options.database.name, this.options.table.name, part.type,
-                            part.type).toRgba(0.4);
+                            part.type).getComputedCssOpacity33(this.visualization);
                     }
                 }
 

--- a/src/app/components/annotation-viewer/annotation-viewer.component.ts
+++ b/src/app/components/annotation-viewer/annotation-viewer.component.ts
@@ -461,7 +461,7 @@ export class AnnotationViewerComponent extends BaseNeonComponent implements OnIn
                     let currentText = document.annotationTextList[index];
                     let currentType = document.annotationTypeList[index];
                     let highlightColor = this.widgetService.getColor(this.options.database.name, this.options.table.name, currentType,
-                        currentType).getComputedCssOpacity33(this.visualization);
+                        currentType).getComputedCssTransparencyHigh(this.visualization);
 
                     currentPart.highlightColor = highlightColor;
                     currentPart.text = currentText;
@@ -895,7 +895,7 @@ export class AnnotationViewerComponent extends BaseNeonComponent implements OnIn
                 } else {
                     if (part.highlightColor && part.highlightColor.includes('rgb(255,255,255')) {
                         part.highlightColor = this.widgetService.getColor(this.options.database.name, this.options.table.name, part.type,
-                            part.type).getComputedCssOpacity33(this.visualization);
+                            part.type).getComputedCssTransparencyHigh(this.visualization);
                     }
                 }
 

--- a/src/app/components/base-neon-component/base-layered-neon.component.ts
+++ b/src/app/components/base-neon-component/base-layered-neon.component.ts
@@ -704,18 +704,6 @@ export abstract class BaseLayeredNeonComponent implements OnInit, OnDestroy {
         this.messenger.subscribe('select_id', callback);
     }
 
-    getHighlightThemeColor() {
-        let elements = document.getElementsByClassName('color-highlight');
-        let color = elements.length ? window.getComputedStyle(elements[0], null).getPropertyValue('color') : '';
-        return Color.fromRgbString(color || 'rgb(255, 255, 255)');
-    }
-
-    getPrimaryThemeColor() {
-        let elements = document.getElementsByClassName('color-primary');
-        let color = elements.length ? window.getComputedStyle(elements[0], null).getPropertyValue('color') : '';
-        return Color.fromRgbString(color || 'rgb(255, 255, 255)');
-    }
-
     /**
      * Returns whether the given item is a number.
      *

--- a/src/app/components/base-neon-component/base-neon.component.scss
+++ b/src/app/components/base-neon-component/base-neon.component.scss
@@ -75,7 +75,7 @@ $footer-height: 35px;
             }
 
             .chart-selection {
-                background-color: var(--color-primary-opaque, rgba(128,128,128,0.4));
+                background-color: var(--color-primary-transparent, rgba(128,128,128,0.33));
                 height: 10px;
                 width: 10px;
                 position: absolute;

--- a/src/app/components/base-neon-component/base-neon.component.ts
+++ b/src/app/components/base-neon-component/base-neon.component.ts
@@ -705,18 +705,6 @@ export abstract class BaseNeonComponent implements OnInit, OnDestroy {
         this.messenger.subscribe('select_id', callback);
     }
 
-    getHighlightThemeColor() {
-        let elements = document.getElementsByClassName('color-highlight');
-        let color = elements.length ? window.getComputedStyle(elements[0], null).getPropertyValue('color') : '';
-        return Color.fromRgbString(color || 'rgb(255, 255, 255)');
-    }
-
-    getPrimaryThemeColor() {
-        let elements = document.getElementsByClassName('color-primary');
-        let color = elements.length ? window.getComputedStyle(elements[0], null).getPropertyValue('color') : '';
-        return Color.fromRgbString(color || 'rgb(255, 255, 255)');
-    }
-
     getComputedStyle(nativeElement: any) {
         return window.getComputedStyle(nativeElement, null);
     }

--- a/src/app/components/legend/legend.component.html
+++ b/src/app/components/legend/legend.component.html
@@ -1,4 +1,4 @@
-<div class="legend-container">
+<div class="legend-container" #legend>
     <button mat-button [mat-menu-trigger-for]="menu" (onMenuClose)="onMenuClose()" (onMenuOpen)="onMenuOpen()" class="legend-button">
       <span class="legend-text">Legend</span><mat-icon class="neon-icon-small legend-text">{{ menuIcon }}</mat-icon>
     </button>

--- a/src/app/components/legend/legend.component.ts
+++ b/src/app/components/legend/legend.component.ts
@@ -69,6 +69,7 @@ export class LegendComponent implements OnInit {
      */
     @Output() itemSelected = new EventEmitter<{ fieldName: string, value: string, currentlyActive: boolean }>();
 
+    @ViewChild('legend') legend: ElementRef;
     @ViewChild('menu') menu: ElementRef;
 
     public menuIcon: string;
@@ -107,7 +108,7 @@ export class LegendComponent implements OnInit {
 
     getColorFor(colorSet: ColorSet, key: string): string {
         let color = colorSet.getColorForValue(key);
-        return color.toRgb();
+        return color.getComputedCss(this.legend);
     }
 
     /**

--- a/src/app/components/map/map.component.spec.ts
+++ b/src/app/components/map/map.component.spec.ts
@@ -316,87 +316,91 @@ describe('Component: Map', () => {
     });
 
     it('should create uncollapsed map points, largest first', () => {
+        let aHoverMap = new Map<string, number>().set('a', 1);
+        let bHoverMap = new Map<string, number>().set('b', 1);
+        let cHoverMap = new Map<string, number>().set('c', 1);
+        let dHoverMap = new Map<string, number>().set('d', 1);
 
-        //define maps for all test cases
-        let aHoverMap = new Map<string, number>().set('a', 1),
-            bHoverMap = new Map<string, number>().set('b', 1),
-            cHoverMap = new Map<string, number>().set('c', 1),
-            dHoverMap = new Map<string, number>().set('d', 1);
+        let widgetService = getService(AbstractWidgetService);
 
-        let widgetService = getService(AbstractWidgetService),
-            dataset1 = {
-                data: [
-                    { id: 'testId1', lat: 0, lng: 0, category: 'a', hoverPopupField: 'A'},
-                    { id: 'testId2', lat: 0, lng: 0, category: 'b', hoverPopupField: 'B' },
-                    { id: 'testId3', lat: 0, lng: 0, category: 'c', hoverPopupField: 'C'},
-                    { id: 'testId4', lat: 0, lng: 0, category: 'd', hoverPopupField: 'D'},
-                    { id: 'testId5', lat: 0, lng: 0, category: 'd', hoverPopupField: 'D'}
-                ],
-                expected: [
-                    new MapPoint('testId4', ['testId4', 'testId5'], '0.000\u00b0, 0.000\u00b0', 0, 0, 2,
-                        widgetService.getColor('myDatabase', 'myTable', 'category', 'd').toRgb(), 'Count: 2', 'category', 'd', dHoverMap),
-                    new MapPoint('testId1', ['testId1'], '0.000\u00b0, 0.000\u00b0', 0, 0, 1,
-                        widgetService.getColor('myDatabase', 'myTable', 'category', 'a').toRgb(), 'Count: 1', 'category', 'a', aHoverMap),
-                    new MapPoint('testId2', ['testId2'], '0.000\u00b0, 0.000\u00b0', 0, 0, 1,
-                        widgetService.getColor('myDatabase', 'myTable', 'category', 'b').toRgb(), 'Count: 1', 'category', 'b', bHoverMap),
-                    new MapPoint('testId3', ['testId3'], '0.000\u00b0, 0.000\u00b0', 0, 0, 1,
-                        widgetService.getColor('myDatabase', 'myTable', 'category', 'c').toRgb(), 'Count: 1', 'category', 'c', cHoverMap)
-                ]
-            },
-            dataset2 = {
-                data: [
-                    { id: 'testId1', lat: 0, lng: 0, category: 'a', hoverPopupField: 'A' },
-                    { id: 'testId2', lat: 0, lng: 1, category: 'b', hoverPopupField: 'B'},
-                    { id: 'testId3', lat: 0, lng: 2, category: 'c', hoverPopupField: 'C' },
-                    { id: 'testId4', lat: 0, lng: 3, category: 'd', hoverPopupField: 'D'}
-                ],
-                expected: [
-                    new MapPoint('testId1', ['testId1'], '0.000\u00b0, 0.000\u00b0', 0, 0, 1,
-                        widgetService.getColor('myDatabase', 'myTable', 'category', 'a').toRgb(), 'Count: 1', 'category', 'a', aHoverMap),
-                    new MapPoint('testId2', ['testId2'], '0.000\u00b0, 1.000\u00b0', 0, 1, 1,
-                        widgetService.getColor('myDatabase', 'myTable', 'category', 'b').toRgb(), 'Count: 1', 'category', 'b', bHoverMap),
-                    new MapPoint('testId3', ['testId3'], '0.000\u00b0, 2.000\u00b0', 0, 2, 1,
-                        widgetService.getColor('myDatabase', 'myTable', 'category', 'c').toRgb(), 'Count: 1', 'category', 'c', cHoverMap),
-                    new MapPoint('testId4', ['testId4'], '0.000\u00b0, 3.000\u00b0', 0, 3, 1,
-                        widgetService.getColor('myDatabase', 'myTable', 'category', 'd').toRgb(), 'Count: 1', 'category', 'd', dHoverMap)
-                ]
-            },
-            dataset3 = {
-                data: [
-                    { id: 'testId1', lat: [0, 0, 0, 0], lng: [0, 0, 0, 0], category: 'a', hoverPopupField: 'A'},
-                    { id: 'testId2', lat: [0, 0, 0, 0], lng: [0, 0, 0, 0], category: 'b', hoverPopupField: 'B' }
-                ],
-                expected: [
-                    new MapPoint('testId1', ['testId1', 'testId1', 'testId1', 'testId1'], '0.000\u00b0, 0.000\u00b0', 0, 0, 4,
-                        widgetService.getColor('myDatabase', 'myTable', 'category', 'a').toRgb(), 'Count: 4', 'category', 'a', aHoverMap),
-                    new MapPoint('testId2', ['testId2', 'testId2', 'testId2', 'testId2'], '0.000\u00b0, 0.000\u00b0', 0, 0, 4,
-                        widgetService.getColor('myDatabase', 'myTable', 'category', 'b').toRgb(), 'Count: 4', 'category', 'b', bHoverMap)
-                ]
-            },
-            dataset4 = {
-                data: [
-                    { id: 'testId1', lat: [0, 0, 0, 0], lng: [0, 1, 2, 3], category: 'a', hoverPopupField: 'A' },
-                    { id: 'testId2', lat: [0, 0, 0, 0], lng: [4, 5, 6, 7], category: 'b', hoverPopupField: 'B' }
-                ],
-                expected: [
-                    new MapPoint('testId1', ['testId1'], '0.000\u00b0, 3.000\u00b0', 0, 3, 1,
-                        widgetService.getColor('myDatabase', 'myTable', 'category', 'a').toRgb(), 'Count: 1', 'category', 'a', aHoverMap),
-                    new MapPoint('testId1', ['testId1'], '0.000\u00b0, 2.000\u00b0', 0, 2, 1,
-                        widgetService.getColor('myDatabase', 'myTable', 'category', 'a').toRgb(), 'Count: 1', 'category', 'a', aHoverMap),
-                    new MapPoint('testId1', ['testId1'], '0.000\u00b0, 1.000\u00b0', 0, 1, 1,
-                        widgetService.getColor('myDatabase', 'myTable', 'category', 'a').toRgb(), 'Count: 1', 'category', 'a', aHoverMap),
-                    new MapPoint('testId1', ['testId1'], '0.000\u00b0, 0.000\u00b0', 0, 0, 1,
-                        widgetService.getColor('myDatabase', 'myTable', 'category', 'a').toRgb(), 'Count: 1', 'category', 'a', aHoverMap),
-                    new MapPoint('testId2', ['testId2'], '0.000\u00b0, 7.000\u00b0', 0, 7, 1,
-                        widgetService.getColor('myDatabase', 'myTable', 'category', 'b').toRgb(), 'Count: 1', 'category', 'b', bHoverMap),
-                    new MapPoint('testId2', ['testId2'], '0.000\u00b0, 6.000\u00b0', 0, 6, 1,
-                        widgetService.getColor('myDatabase', 'myTable', 'category', 'b').toRgb(), 'Count: 1', 'category', 'b', bHoverMap),
-                    new MapPoint('testId2', ['testId2'], '0.000\u00b0, 5.000\u00b0', 0, 5, 1,
-                        widgetService.getColor('myDatabase', 'myTable', 'category', 'b').toRgb(), 'Count: 1', 'category', 'b', bHoverMap),
-                    new MapPoint('testId2', ['testId2'], '0.000\u00b0, 4.000\u00b0', 0, 4, 1,
-                        widgetService.getColor('myDatabase', 'myTable', 'category', 'b').toRgb(), 'Count: 1', 'category', 'b', bHoverMap)
-                ]
-            };
+        let aColor = widgetService.getColor('myDatabase', 'myTable', 'category', 'a').getComputedCss(component.visualization);
+        let bColor = widgetService.getColor('myDatabase', 'myTable', 'category', 'b').getComputedCss(component.visualization);
+        let cColor = widgetService.getColor('myDatabase', 'myTable', 'category', 'c').getComputedCss(component.visualization);
+        let dColor = widgetService.getColor('myDatabase', 'myTable', 'category', 'd').getComputedCss(component.visualization);
+
+        let dataset1 = {
+            data: [
+                { id: 'testId1', lat: 0, lng: 0, category: 'a', hoverPopupField: 'A'},
+                { id: 'testId2', lat: 0, lng: 0, category: 'b', hoverPopupField: 'B' },
+                { id: 'testId3', lat: 0, lng: 0, category: 'c', hoverPopupField: 'C'},
+                { id: 'testId4', lat: 0, lng: 0, category: 'd', hoverPopupField: 'D'},
+                { id: 'testId5', lat: 0, lng: 0, category: 'd', hoverPopupField: 'D'}
+            ],
+            expected: [
+                new MapPoint('testId4', ['testId4', 'testId5'], '0.000\u00b0, 0.000\u00b0', 0, 0, 2,
+                    dColor, 'Count: 2', 'category', 'd', dHoverMap),
+                new MapPoint('testId1', ['testId1'], '0.000\u00b0, 0.000\u00b0', 0, 0, 1,
+                    aColor, 'Count: 1', 'category', 'a', aHoverMap),
+                new MapPoint('testId2', ['testId2'], '0.000\u00b0, 0.000\u00b0', 0, 0, 1,
+                    bColor, 'Count: 1', 'category', 'b', bHoverMap),
+                new MapPoint('testId3', ['testId3'], '0.000\u00b0, 0.000\u00b0', 0, 0, 1,
+                    cColor, 'Count: 1', 'category', 'c', cHoverMap)
+            ]
+        };
+        let dataset2 = {
+            data: [
+                { id: 'testId1', lat: 0, lng: 0, category: 'a', hoverPopupField: 'A' },
+                { id: 'testId2', lat: 0, lng: 1, category: 'b', hoverPopupField: 'B'},
+                { id: 'testId3', lat: 0, lng: 2, category: 'c', hoverPopupField: 'C' },
+                { id: 'testId4', lat: 0, lng: 3, category: 'd', hoverPopupField: 'D'}
+            ],
+            expected: [
+                new MapPoint('testId1', ['testId1'], '0.000\u00b0, 0.000\u00b0', 0, 0, 1,
+                    aColor, 'Count: 1', 'category', 'a', aHoverMap),
+                new MapPoint('testId2', ['testId2'], '0.000\u00b0, 1.000\u00b0', 0, 1, 1,
+                    bColor, 'Count: 1', 'category', 'b', bHoverMap),
+                new MapPoint('testId3', ['testId3'], '0.000\u00b0, 2.000\u00b0', 0, 2, 1,
+                    cColor, 'Count: 1', 'category', 'c', cHoverMap),
+                new MapPoint('testId4', ['testId4'], '0.000\u00b0, 3.000\u00b0', 0, 3, 1,
+                    dColor, 'Count: 1', 'category', 'd', dHoverMap)
+            ]
+        };
+        let dataset3 = {
+            data: [
+                { id: 'testId1', lat: [0, 0, 0, 0], lng: [0, 0, 0, 0], category: 'a', hoverPopupField: 'A'},
+                { id: 'testId2', lat: [0, 0, 0, 0], lng: [0, 0, 0, 0], category: 'b', hoverPopupField: 'B' }
+            ],
+            expected: [
+                new MapPoint('testId1', ['testId1', 'testId1', 'testId1', 'testId1'], '0.000\u00b0, 0.000\u00b0', 0, 0, 4,
+                    aColor, 'Count: 4', 'category', 'a', aHoverMap),
+                new MapPoint('testId2', ['testId2', 'testId2', 'testId2', 'testId2'], '0.000\u00b0, 0.000\u00b0', 0, 0, 4,
+                    bColor, 'Count: 4', 'category', 'b', bHoverMap)
+            ]
+        };
+        let dataset4 = {
+            data: [
+                { id: 'testId1', lat: [0, 0, 0, 0], lng: [0, 1, 2, 3], category: 'a', hoverPopupField: 'A' },
+                { id: 'testId2', lat: [0, 0, 0, 0], lng: [4, 5, 6, 7], category: 'b', hoverPopupField: 'B' }
+            ],
+            expected: [
+                new MapPoint('testId1', ['testId1'], '0.000\u00b0, 3.000\u00b0', 0, 3, 1,
+                    aColor, 'Count: 1', 'category', 'a', aHoverMap),
+                new MapPoint('testId1', ['testId1'], '0.000\u00b0, 2.000\u00b0', 0, 2, 1,
+                    aColor, 'Count: 1', 'category', 'a', aHoverMap),
+                new MapPoint('testId1', ['testId1'], '0.000\u00b0, 1.000\u00b0', 0, 1, 1,
+                    aColor, 'Count: 1', 'category', 'a', aHoverMap),
+                new MapPoint('testId1', ['testId1'], '0.000\u00b0, 0.000\u00b0', 0, 0, 1,
+                    aColor, 'Count: 1', 'category', 'a', aHoverMap),
+                new MapPoint('testId2', ['testId2'], '0.000\u00b0, 7.000\u00b0', 0, 7, 1,
+                    bColor, 'Count: 1', 'category', 'b', bHoverMap),
+                new MapPoint('testId2', ['testId2'], '0.000\u00b0, 6.000\u00b0', 0, 6, 1,
+                    bColor, 'Count: 1', 'category', 'b', bHoverMap),
+                new MapPoint('testId2', ['testId2'], '0.000\u00b0, 5.000\u00b0', 0, 5, 1,
+                    bColor, 'Count: 1', 'category', 'b', bHoverMap),
+                new MapPoint('testId2', ['testId2'], '0.000\u00b0, 4.000\u00b0', 0, 4, 1,
+                    bColor, 'Count: 1', 'category', 'b', bHoverMap)
+            ]
+        };
 
         let mapPoints1 = component.getMapPoints('myDatabase', 'myTable', 'id', 'lng', 'lat', 'category', 'hoverPopupField', dataset1.data);
         expect(mapPoints1).toEqual(dataset1.expected);

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -108,7 +108,6 @@ export class MapComponent extends BaseLayeredNeonComponent implements OnInit, On
     protected filterBoundingBox: BoundingBoxByDegrees;
 
     public disabledSet: [string[]] = [] as [string[]];
-    protected defaultActiveColor: Color;
 
     constructor(
         connectionService: ConnectionService,
@@ -166,8 +165,6 @@ export class MapComponent extends BaseLayeredNeonComponent implements OnInit, On
     postInit() {
         // Backwards compatibility (mapType deprecated and replaced by type).
         this.options.type = this.injector.get('mapType', this.options.type);
-
-        this.defaultActiveColor = this.getPrimaryThemeColor();
     }
 
     /**
@@ -539,12 +536,12 @@ export class MapComponent extends BaseLayeredNeonComponent implements OnInit, On
         }
 
         let mapPoints: MapPoint[] = [];
-        let rgbColor = this.defaultActiveColor.toRgb();
+        let rgbColor = this.widgetService.getThemeAccentColorHex();
         map.forEach((unique) => {
             let color = rgbColor;
             if (!this.options.singleColor) {
-                color = unique.colorValue ? this.widgetService.getColor(databaseName, tableName, colorField, unique.colorValue).toRgb() :
-                    whiteString;
+                color = !unique.colorValue ? whiteString : this.widgetService.getColor(databaseName, tableName, colorField,
+                    unique.colorValue).getComputedCss(this.visualization);
             }
 
             mapPoints.push(

--- a/src/app/components/map/map.type.abstract.ts
+++ b/src/app/components/map/map.type.abstract.ts
@@ -16,7 +16,7 @@
 import { Color } from '../../color';
 import { ElementRef } from '@angular/core';
 
-export const whiteString = new Color(255, 255, 255).toRgb();
+export const whiteString = 'rgb(255,255,255)';
 
 export enum MapType {Leaflet, Cesium}
 

--- a/src/app/components/network-graph/network-graph.component.ts
+++ b/src/app/components/network-graph/network-graph.component.ts
@@ -125,6 +125,9 @@ class Edge {
 })
 export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, OnDestroy, AfterViewInit {
     @ViewChild('graphElement') graphElement: ElementRef;
+    @ViewChild('visualization', {read: ElementRef}) visualization: ElementRef;
+    @ViewChild('headerText') headerText: ElementRef;
+    @ViewChild('infoText') infoText: ElementRef;
 
     public filters: {
         id: string,
@@ -800,7 +803,7 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
             if (nodeColorField && this.prettifiedNodeLabels.length === 0) {
                 let colorMapVal = nodeColorField && nodeType;
                 nodeColor = this.widgetService.getColor(this.options.database.name, this.options.table.name, nodeColorField,
-                    colorMapVal).toRgb();
+                    colorMapVal).getComputedCss(this.visualization);
             }
 
             // create a new node for each unique nodeId
@@ -816,7 +819,7 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
                             if (nodeLabel === shortName) {
                                 let colorMapVal = nodeColorField && nodeLabel;
                                 nodeColor = this.widgetService.getColor(this.options.database.name, this.options.table.name, nodeColorField,
-                                    colorMapVal).toRgb();
+                                    colorMapVal).getComputedCss(this.visualization);
                                 break;
                             }
                         }
@@ -841,7 +844,7 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
             if (nodeColorField && this.prettifiedNodeLabels.length === 0) {
                 let colorMapVal = nodeColorField && nodeType;
                 linkColor = this.widgetService.getColor(this.options.database.name, this.options.table.name, nodeColorField,
-                    colorMapVal).toRgb();
+                    colorMapVal).getComputedCss(this.visualization);
             }
 
             // create a node if linkfield doesn't point to a node that already exists
@@ -858,7 +861,7 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
                             if (nodeLabel === shortName) {
                                 let colorMapVal = nodeColorField && nodeLabel;
                                 linkColor = this.widgetService.getColor(this.options.database.name, this.options.table.name, nodeColorField,
-                                    colorMapVal).toRgb();
+                                    colorMapVal).getComputedCss(this.visualization);
                                 break;
                             }
                         }
@@ -877,7 +880,7 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
                 if (edgeColorField && this.prettifiedEdgeLabels.length === 0) {
                     let colorMapVal = edgeColorField && edgeType;
                     edgeColor = this.widgetService.getColor(this.options.database.name, this.options.table.name, edgeColorField,
-                        colorMapVal).toRgb();
+                        colorMapVal).getComputedCss(this.visualization);
                 }
 
                 let edgeColorObject = { color: edgeColor, highlight: edgeColor};
@@ -893,7 +896,7 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
                                 let colorMapVal = edgeColorField && edgeLabel;
                                 edgeType = edgeLabel;
                                 edgeColor = this.widgetService.getColor(this.options.database.name, this.options.table.name, edgeColorField,
-                                    colorMapVal).toRgb();
+                                    colorMapVal).getComputedCss(this.visualization);
                                 edgeColorObject = { color: edgeColor, highlight: edgeColor};
                                 break;
                             }
@@ -993,9 +996,17 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
         this.resetGraphData();
     }
 
+    /**
+     * Returns an object containing the ElementRef objects for the visualization.
+     *
+     * @return {any} Object containing:  {ElementRef} headerText, {ElementRef} infoText, {ElementRef} visualization
+     * @override
+     */
     getElementRefs() {
         return {
-            //
+            visualization: this.visualization,
+            headerText: this.headerText,
+            infoText: this.infoText
         };
     }
 

--- a/src/app/components/text-cloud/text-cloud.component.spec.ts
+++ b/src/app/components/text-cloud/text-cloud.component.spec.ts
@@ -21,13 +21,17 @@ import { Injector } from '@angular/core';
 
 import { TextCloudComponent } from './text-cloud.component';
 import { ExportControlComponent } from '../export-control/export-control.component';
+import { UnsharedFilterComponent } from '../unshared-filter/unshared-filter.component';
+
+import { AbstractWidgetService } from '../../services/abstract.widget.service';
 import { ConnectionService } from '../../services/connection.service';
 import { DatasetService } from '../../services/dataset.service';
 import { FilterService } from '../../services/filter.service';
+import { WidgetService } from '../../services/widget.service';
+
 import { NeonGTDConfig } from '../../neon-gtd-config';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { AppMaterialModule } from '../../app.material.module';
-import { UnsharedFilterComponent } from '../unshared-filter/unshared-filter.component';
 import { neonVariables } from '../../neon-namespaces';
 
 import * as neon from 'neon-framework';
@@ -47,6 +51,7 @@ describe('Component: TextCloud', () => {
             UnsharedFilterComponent
         ],
         providers: [
+            { provide: AbstractWidgetService, useClass: WidgetService },
             ConnectionService,
             {
                 provide: DatasetService,
@@ -83,7 +88,7 @@ describe('Component: TextCloud', () => {
     it('has expected class properties', () => {
         expect(component.activeData).toEqual([]);
         expect(component.termsCount).toBe(0);
-        expect(component.textColor).toBe('#ffffff');
+        expect(component.textColor).toBe('#54C8CD');
     });
 
     it('has a subNgOnInit method', () => {
@@ -539,6 +544,7 @@ describe('Component: Textcloud with config', () => {
             UnsharedFilterComponent
         ],
         providers: [
+            { provide: AbstractWidgetService, useClass: WidgetService },
             ConnectionService,
             DatasetService,
             { provide: FilterService, useClass: FilterServiceMock },
@@ -601,6 +607,7 @@ describe('Component: Textcloud with config including filter', () => {
             UnsharedFilterComponent
         ],
         providers: [
+            { provide: AbstractWidgetService, useClass: WidgetService },
             ConnectionService,
             DatasetService,
             { provide: FilterService, useClass: FilterServiceMock },

--- a/src/app/components/text-cloud/text-cloud.component.ts
+++ b/src/app/components/text-cloud/text-cloud.component.ts
@@ -25,6 +25,7 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 
+import { AbstractWidgetService } from '../../services/abstract.widget.service';
 import { ConnectionService } from '../../services/connection.service';
 import { DatasetService } from '../../services/dataset.service';
 import { FilterService } from '../../services/filter.service';
@@ -73,7 +74,8 @@ export class TextCloudComponent extends BaseNeonComponent implements OnInit, OnD
         datasetService: DatasetService,
         filterService: FilterService,
         injector: Injector,
-        ref: ChangeDetectorRef
+        ref: ChangeDetectorRef,
+        protected widgetService: AbstractWidgetService
     ) {
 
         super(
@@ -94,7 +96,7 @@ export class TextCloudComponent extends BaseNeonComponent implements OnInit, OnD
 
     postInit() {
         // This should happen before execute query as #refreshVisualization() depends on this.textCloud
-        this.textColor = this.getPrimaryThemeColor().toHexString();
+        this.textColor = this.widgetService.getThemeAccentColorHex();
         this.updateTextCloudSettings();
 
         this.executeQueryChain();

--- a/src/app/components/timeline/timeline.component.spec.ts
+++ b/src/app/components/timeline/timeline.component.spec.ts
@@ -29,10 +29,12 @@ import { ExportControlComponent } from '../export-control/export-control.compone
 import { TimelineComponent } from './timeline.component';
 import { UnsharedFilterComponent } from '../unshared-filter/unshared-filter.component';
 
+import { AbstractWidgetService } from '../../services/abstract.widget.service';
 import { ConnectionService } from '../../services/connection.service';
 import { DatasetService } from '../../services/dataset.service';
 import { FilterService } from '../../services/filter.service';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
+import { WidgetService } from '../../services/widget.service';
 
 let d3 = require('../../../assets/d3.min.js');
 
@@ -48,6 +50,7 @@ describe('Component: Timeline', () => {
             UnsharedFilterComponent
         ],
         providers: [
+            { provide: AbstractWidgetService, useClass: WidgetService },
             ConnectionService,
             DatasetService,
             FilterService,

--- a/src/app/components/timeline/timeline.component.ts
+++ b/src/app/components/timeline/timeline.component.ts
@@ -27,6 +27,7 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 
+import { AbstractWidgetService } from '../../services/abstract.widget.service';
 import { ConnectionService } from '../../services/connection.service';
 import { DatasetService } from '../../services/dataset.service';
 import { FilterService } from '../../services/filter.service';
@@ -87,7 +88,6 @@ export class TimelineComponent extends BaseNeonComponent implements OnInit, OnDe
         inactiveColor: string
     };
 
-    public defaultActiveColor;
     public timelineChart: TimelineSelectorChart;
     public timelineData: TimelineData = new TimelineData();
 
@@ -96,7 +96,8 @@ export class TimelineComponent extends BaseNeonComponent implements OnInit, OnDe
         datasetService: DatasetService,
         filterService: FilterService,
         injector: Injector,
-        ref: ChangeDetectorRef
+        ref: ChangeDetectorRef,
+        protected widgetService: AbstractWidgetService
     ) {
 
         super(
@@ -146,8 +147,6 @@ export class TimelineComponent extends BaseNeonComponent implements OnInit, OnDe
 
     postInit() {
         this.executeQueryChain();
-
-        this.defaultActiveColor = this.getPrimaryThemeColor();
     }
 
     subNgOnDestroy() {
@@ -334,7 +333,7 @@ export class TimelineComponent extends BaseNeonComponent implements OnInit, OnDe
      */
     filterAndRefreshData() {
         let series: TimelineSeries = {
-            color: this.defaultActiveColor,
+            color: this.widgetService.getThemeMainColorHex(),
             name: 'Total',
             type: 'bar',
             options: {},

--- a/src/app/components/visualization-injector/visualization-injector.component.ts
+++ b/src/app/components/visualization-injector/visualization-injector.component.ts
@@ -48,8 +48,8 @@ import { NeonGridItem } from '../../neon-grid-item';
         QueryBarComponent,
         SampleComponent,
         TextCloudComponent,
-        TimelineComponent,
         ThumbnailGridComponent,
+        TimelineComponent,
         WikiViewerComponent
     ],
     template: `<div #dynamicComponentContainer></div>`
@@ -117,6 +117,7 @@ export class VisualizationInjectorComponent {
             case 'sample': return SampleComponent;
             case 'textCloud': return TextCloudComponent;
             case 'thumbnailGrid': return ThumbnailGridComponent;
+            case 'timeline': return TimelineComponent;
             case 'wikiViewer': return WikiViewerComponent;
 
             default: return null;

--- a/src/app/services/abstract.widget.service.ts
+++ b/src/app/services/abstract.widget.service.ts
@@ -19,6 +19,14 @@ import { BaseLayeredNeonComponent } from '../components/base-neon-component/base
 import { Color, ColorSet } from '../color';
 
 /**
+ * @interface Theme
+ */
+export interface Theme {
+    id: string;
+    name: string;
+}
+
+/**
  * A service for everything a Neon widget needs.
  *
  * @class AbstractWidgetService
@@ -70,10 +78,26 @@ export abstract class AbstractWidgetService {
     /**
      * Returns the list of available application themes.
      *
-     * @return {{id:string,name:string}[]}
+     * @return {Theme[]}
      * @abstract
      */
-    public abstract getThemes(): { id: string, name: string }[];
+    public abstract getThemes(): Theme[];
+
+    /**
+     * Returns the hex for the accent color for the current application theme.
+     *
+     * @return {string}
+     * @abstract
+     */
+    public abstract getThemeAccentColorHex(): string;
+
+    /**
+     * Returns the hex for the main color for the current application theme.
+     *
+     * @return {string}
+     * @abstract
+     */
+    public abstract getThemeMainColorHex(): string;
 
     /**
      * Sets the current application theme to the theme with the given ID.

--- a/src/app/services/widget.service.spec.ts
+++ b/src/app/services/widget.service.spec.ts
@@ -59,6 +59,14 @@ describe('Service: Widget', () => {
         // TODO THOR-936
     }));
 
+    it('getThemeAccentColorHex does return expected theme color', inject([WidgetService], (service: WidgetService) => {
+        // TODO THOR-936
+    }));
+
+    it('getThemeMainColorHex does return expected theme color', inject([WidgetService], (service: WidgetService) => {
+        // TODO THOR-936
+    }));
+
     it('setTheme does update theme ID', inject([WidgetService], (service: WidgetService) => {
         // TODO THOR-936
     }));

--- a/src/app/services/widget.service.ts
+++ b/src/app/services/widget.service.ts
@@ -14,12 +14,26 @@
  *
  */
 import { Injectable } from '@angular/core';
-import { AbstractWidgetService } from './abstract.widget.service';
+import { AbstractWidgetService, Theme } from './abstract.widget.service';
 import { BaseNeonComponent } from '../components/base-neon-component/base-neon.component';
 import { BaseLayeredNeonComponent } from '../components/base-neon-component/base-layered-neon.component';
 import { Color, ColorSet } from '../color';
 import { DatasetService } from './dataset.service';
 import * as neon from 'neon-framework';
+
+/**
+ * @class NeonTheme
+ */
+export class NeonTheme implements Theme {
+    /**
+     * @constructor
+     * @arg {string} accent The accent color.
+     * @arg {string} id The theme ID.
+     * @arg {string} main The main color.
+     * @arg {string} name The theme name.
+     */
+    constructor(public accent: string, public id: string, public main: string, public name: string) {}
+}
 
 /**
  * A service for everything a Neon Dashboard widget needs.
@@ -28,20 +42,9 @@ import * as neon from 'neon-framework';
  */
 @Injectable()
 export class WidgetService extends AbstractWidgetService {
-    public static THEME_DARK: { id: string, name: string } = {
-        id: 'neon-dark',
-        name: 'Dark'
-    };
-
-    public static THEME_GREEN: { id: string, name: string } = {
-        id: 'neon-green',
-        name: 'Green'
-    };
-
-    public static THEME_TEAL: { id: string, name: string } = {
-        id: 'neon-teal',
-        name: 'Teal'
-    };
+    public static THEME_DARK: Theme = new NeonTheme('#01B7C1', 'neon-dark', '#515861', 'Dark');
+    public static THEME_GREEN: Theme = new NeonTheme('#FFA600', 'neon-green', '#39B54A', 'Green');
+        public static THEME_TEAL: Theme = new NeonTheme('#54C8CD', 'neon-teal', '#367588', 'Teal');
 
     // TODO Let different databases and tables in the same dataset have different color maps.
     private colorKeyToColorSet: Map<string, ColorSet> = new Map<string, ColorSet>();
@@ -114,10 +117,10 @@ export class WidgetService extends AbstractWidgetService {
     /**
      * Returns the list of available application themes.
      *
-     * @return {{id:string,name:string}[]}
+     * @return {Theme[]}
      * @override
      */
-    public getThemes(): { id: string, name: string }[] {
+    public getThemes(): Theme[] {
         return [
             // TODO THOR-853 Add dark theme
             // WidgetService.THEME_DARK,
@@ -125,6 +128,26 @@ export class WidgetService extends AbstractWidgetService {
             // WidgetService.THEME_GREEN,
             WidgetService.THEME_TEAL
         ];
+    }
+
+    /**
+     * Returns the hex for the accent color for the current application theme.
+     *
+     * @return {string}
+     * @override
+     */
+    public getThemeAccentColorHex(): string {
+        return (this.getThemes().filter((theme) => theme.id === this.currentThemeId)[0] as NeonTheme).accent;
+    }
+
+    /**
+     * Returns the hex for the main color for the current application theme.
+     *
+     * @return {string}
+     * @override
+     */
+    public getThemeMainColorHex(): string {
+        return (this.getThemes().filter((theme) => theme.id === this.currentThemeId)[0] as NeonTheme).main;
     }
 
     /**

--- a/src/themes/neon-dark-theme.scss
+++ b/src/themes/neon-dark-theme.scss
@@ -145,59 +145,59 @@ $dark-theme: (
     --color-set-dark-7: rgb(199,165,0); // #C7A500 yellow
     --color-set-dark-8: rgb(54,154,82); // #369A52 sea green
 
-    --color-set-1-opacity-66: rgba(94,80,143,0.66);
-    --color-set-2-opacity-66: rgba(255,135,55,0.66);
-    --color-set-3-opacity-66: rgba(179,79,146,0.66);
-    --color-set-4-opacity-66: rgba(177,194,54,0.66);
-    --color-set-5-opacity-66: rgba(243,88,112,0.66);
-    --color-set-6-opacity-66: rgba(0,153,255,0.66);
-    --color-set-7-opacity-66: rgba(255,214,0,0.66);
-    --color-set-8-opacity-66: rgba(106,204,127,0.66);
+    --color-set-1-transparency-medium: rgba(94,80,143,0.66);
+    --color-set-2-transparency-medium: rgba(255,135,55,0.66);
+    --color-set-3-transparency-medium: rgba(179,79,146,0.66);
+    --color-set-4-transparency-medium: rgba(177,194,54,0.66);
+    --color-set-5-transparency-medium: rgba(243,88,112,0.66);
+    --color-set-6-transparency-medium: rgba(0,153,255,0.66);
+    --color-set-7-transparency-medium: rgba(255,214,0,0.66);
+    --color-set-8-transparency-medium: rgba(106,204,127,0.66);
 
-    --color-set-light-1-opacity-66: rgba(141,124,192,0.66);
-    --color-set-light-2-opacity-66: rgba(255,184,102,0.66);
-    --color-set-light-3-opacity-66: rgba(231,127,194,0.66);
-    --color-set-light-4-opacity-66: rgba(230,245,105,0.66);
-    --color-set-light-5-opacity-66: rgba(255,139,158,0.66);
-    --color-set-light-6-opacity-66: rgba(105,204,255,0.66);
-    --color-set-light-7-opacity-66: rgba(255,255,82,0.66);
-    --color-set-light-8-opacity-66: rgba(54,154,82,0.66);
+    --color-set-light-1-transparency-medium: rgba(141,124,192,0.66);
+    --color-set-light-2-transparency-medium: rgba(255,184,102,0.66);
+    --color-set-light-3-transparency-medium: rgba(231,127,194,0.66);
+    --color-set-light-4-transparency-medium: rgba(230,245,105,0.66);
+    --color-set-light-5-transparency-medium: rgba(255,139,158,0.66);
+    --color-set-light-6-transparency-medium: rgba(105,204,255,0.66);
+    --color-set-light-7-transparency-medium: rgba(255,255,82,0.66);
+    --color-set-light-8-transparency-medium: rgba(54,154,82,0.66);
 
-    --color-set-dark-1-opacity-66: rgba(49,39,97,0.66);
-    --color-set-dark-2-opacity-66: rgba(198,88,0,0.66);
-    --color-set-dark-3-opacity-66: rgba(129,29,100,0.66);
-    --color-set-dark-4-opacity-66: rgba(126,146,0,0.66);
-    --color-set-dark-5-opacity-66: rgba(187,30,69,0.66);
-    --color-set-dark-6-opacity-66: rgba(0,108,203,0.66);
-    --color-set-dark-7-opacity-66: rgba(199,165,0,0.66);
-    --color-set-dark-8-opacity-66: rgba(54,154,82,0.66);
+    --color-set-dark-1-transparency-medium: rgba(49,39,97,0.66);
+    --color-set-dark-2-transparency-medium: rgba(198,88,0,0.66);
+    --color-set-dark-3-transparency-medium: rgba(129,29,100,0.66);
+    --color-set-dark-4-transparency-medium: rgba(126,146,0,0.66);
+    --color-set-dark-5-transparency-medium: rgba(187,30,69,0.66);
+    --color-set-dark-6-transparency-medium: rgba(0,108,203,0.66);
+    --color-set-dark-7-transparency-medium: rgba(199,165,0,0.66);
+    --color-set-dark-8-transparency-medium: rgba(54,154,82,0.66);
 
-    --color-set-1-opacity-33: rgba(94,80,143,0.33);
-    --color-set-2-opacity-33: rgba(255,135,55,0.33);
-    --color-set-3-opacity-33: rgba(179,79,146,0.33);
-    --color-set-4-opacity-33: rgba(177,194,54,0.33);
-    --color-set-5-opacity-33: rgba(243,88,112,0.33);
-    --color-set-6-opacity-33: rgba(0,153,255,0.33);
-    --color-set-7-opacity-33: rgba(255,214,0,0.33);
-    --color-set-8-opacity-33: rgba(106,204,127,0.33);
+    --color-set-1-transparency-high: rgba(94,80,143,0.33);
+    --color-set-2-transparency-high: rgba(255,135,55,0.33);
+    --color-set-3-transparency-high: rgba(179,79,146,0.33);
+    --color-set-4-transparency-high: rgba(177,194,54,0.33);
+    --color-set-5-transparency-high: rgba(243,88,112,0.33);
+    --color-set-6-transparency-high: rgba(0,153,255,0.33);
+    --color-set-7-transparency-high: rgba(255,214,0,0.33);
+    --color-set-8-transparency-high: rgba(106,204,127,0.33);
 
-    --color-set-light-1-opacity-33: rgba(141,124,192,0.33);
-    --color-set-light-2-opacity-33: rgba(255,184,102,0.33);
-    --color-set-light-3-opacity-33: rgba(231,127,194,0.33);
-    --color-set-light-4-opacity-33: rgba(230,245,105,0.33);
-    --color-set-light-5-opacity-33: rgba(255,139,158,0.33);
-    --color-set-light-6-opacity-33: rgba(105,204,255,0.33);
-    --color-set-light-7-opacity-33: rgba(255,255,82,0.33);
-    --color-set-light-8-opacity-33: rgba(54,154,82,0.33);
+    --color-set-light-1-transparency-high: rgba(141,124,192,0.33);
+    --color-set-light-2-transparency-high: rgba(255,184,102,0.33);
+    --color-set-light-3-transparency-high: rgba(231,127,194,0.33);
+    --color-set-light-4-transparency-high: rgba(230,245,105,0.33);
+    --color-set-light-5-transparency-high: rgba(255,139,158,0.33);
+    --color-set-light-6-transparency-high: rgba(105,204,255,0.33);
+    --color-set-light-7-transparency-high: rgba(255,255,82,0.33);
+    --color-set-light-8-transparency-high: rgba(54,154,82,0.33);
 
-    --color-set-dark-1-opacity-33: rgba(49,39,97,0.33);
-    --color-set-dark-2-opacity-33: rgba(198,88,0,0.33);
-    --color-set-dark-3-opacity-33: rgba(129,29,100,0.33);
-    --color-set-dark-4-opacity-33: rgba(126,146,0,0.33);
-    --color-set-dark-5-opacity-33: rgba(187,30,69,0.33);
-    --color-set-dark-6-opacity-33: rgba(0,108,203,0.33);
-    --color-set-dark-7-opacity-33: rgba(199,165,0,0.33);
-    --color-set-dark-8-opacity-33: rgba(54,154,82,0.33);
+    --color-set-dark-1-transparency-high: rgba(49,39,97,0.33);
+    --color-set-dark-2-transparency-high: rgba(198,88,0,0.33);
+    --color-set-dark-3-transparency-high: rgba(129,29,100,0.33);
+    --color-set-dark-4-transparency-high: rgba(126,146,0,0.33);
+    --color-set-dark-5-transparency-high: rgba(187,30,69,0.33);
+    --color-set-dark-6-transparency-high: rgba(0,108,203,0.33);
+    --color-set-dark-7-transparency-high: rgba(199,165,0,0.33);
+    --color-set-dark-8-transparency-high: rgba(54,154,82,0.33);
 
     &.mat-autocomplete-panel {
         background: #303030;

--- a/src/themes/neon-dark-theme.scss
+++ b/src/themes/neon-dark-theme.scss
@@ -118,6 +118,87 @@ $dark-theme: (
     --color-text-header: #666666;
     --color-text-main: #333333;
 
+    --color-set-1: rgb(94,80,143); // #5E508F deep purple
+    --color-set-2: rgb(255,135,55); // #FF8737 orange
+    --color-set-3: rgb(179,79,146); // #B34F92 purple
+    --color-set-4: rgb(177,194,54); // #B1C236 lime
+    --color-set-5: rgb(243,88,112); // #F35870 pink
+    --color-set-6: rgb(0,153,255); // #0099FF blue
+    --color-set-7: rgb(255,214,0); // #FFD600 yellow
+    --color-set-8: rgb(106,204,127); // #6ACC7F sea green
+
+    --color-set-light-1: rgb(141,124,192); // #8D7CC0 deep purple
+    --color-set-light-2: rgb(255,184,102); // #FFB866 orange
+    --color-set-light-3: rgb(231,127,194); // #E77FC2 purple
+    --color-set-light-4: rgb(230,245,105); // #E6F569 lime
+    --color-set-light-5: rgb(255,139,158); // #FF8B9E pink
+    --color-set-light-6: rgb(105,204,255); // #69CCFF blue
+    --color-set-light-7: rgb(255,255,82); // #FFFF52 yellow
+    --color-set-light-8: rgb(54,154,82); // #369A52 sea green
+
+    --color-set-dark-1: rgb(49,39,97); // #312761 deep purple
+    --color-set-dark-2: rgb(198,88,0); // #C65800 orange
+    --color-set-dark-3: rgb(129,29,100); // #811D64 purple
+    --color-set-dark-4: rgb(126,146,0); // #7E9200 lime
+    --color-set-dark-5: rgb(187,30,69); // #BB1E45 pink
+    --color-set-dark-6: rgb(0,108,203); // #006CCB blue
+    --color-set-dark-7: rgb(199,165,0); // #C7A500 yellow
+    --color-set-dark-8: rgb(54,154,82); // #369A52 sea green
+
+    --color-set-1-opacity-66: rgba(94,80,143,0.66);
+    --color-set-2-opacity-66: rgba(255,135,55,0.66);
+    --color-set-3-opacity-66: rgba(179,79,146,0.66);
+    --color-set-4-opacity-66: rgba(177,194,54,0.66);
+    --color-set-5-opacity-66: rgba(243,88,112,0.66);
+    --color-set-6-opacity-66: rgba(0,153,255,0.66);
+    --color-set-7-opacity-66: rgba(255,214,0,0.66);
+    --color-set-8-opacity-66: rgba(106,204,127,0.66);
+
+    --color-set-light-1-opacity-66: rgba(141,124,192,0.66);
+    --color-set-light-2-opacity-66: rgba(255,184,102,0.66);
+    --color-set-light-3-opacity-66: rgba(231,127,194,0.66);
+    --color-set-light-4-opacity-66: rgba(230,245,105,0.66);
+    --color-set-light-5-opacity-66: rgba(255,139,158,0.66);
+    --color-set-light-6-opacity-66: rgba(105,204,255,0.66);
+    --color-set-light-7-opacity-66: rgba(255,255,82,0.66);
+    --color-set-light-8-opacity-66: rgba(54,154,82,0.66);
+
+    --color-set-dark-1-opacity-66: rgba(49,39,97,0.66);
+    --color-set-dark-2-opacity-66: rgba(198,88,0,0.66);
+    --color-set-dark-3-opacity-66: rgba(129,29,100,0.66);
+    --color-set-dark-4-opacity-66: rgba(126,146,0,0.66);
+    --color-set-dark-5-opacity-66: rgba(187,30,69,0.66);
+    --color-set-dark-6-opacity-66: rgba(0,108,203,0.66);
+    --color-set-dark-7-opacity-66: rgba(199,165,0,0.66);
+    --color-set-dark-8-opacity-66: rgba(54,154,82,0.66);
+
+    --color-set-1-opacity-33: rgba(94,80,143,0.33);
+    --color-set-2-opacity-33: rgba(255,135,55,0.33);
+    --color-set-3-opacity-33: rgba(179,79,146,0.33);
+    --color-set-4-opacity-33: rgba(177,194,54,0.33);
+    --color-set-5-opacity-33: rgba(243,88,112,0.33);
+    --color-set-6-opacity-33: rgba(0,153,255,0.33);
+    --color-set-7-opacity-33: rgba(255,214,0,0.33);
+    --color-set-8-opacity-33: rgba(106,204,127,0.33);
+
+    --color-set-light-1-opacity-33: rgba(141,124,192,0.33);
+    --color-set-light-2-opacity-33: rgba(255,184,102,0.33);
+    --color-set-light-3-opacity-33: rgba(231,127,194,0.33);
+    --color-set-light-4-opacity-33: rgba(230,245,105,0.33);
+    --color-set-light-5-opacity-33: rgba(255,139,158,0.33);
+    --color-set-light-6-opacity-33: rgba(105,204,255,0.33);
+    --color-set-light-7-opacity-33: rgba(255,255,82,0.33);
+    --color-set-light-8-opacity-33: rgba(54,154,82,0.33);
+
+    --color-set-dark-1-opacity-33: rgba(49,39,97,0.33);
+    --color-set-dark-2-opacity-33: rgba(198,88,0,0.33);
+    --color-set-dark-3-opacity-33: rgba(129,29,100,0.33);
+    --color-set-dark-4-opacity-33: rgba(126,146,0,0.33);
+    --color-set-dark-5-opacity-33: rgba(187,30,69,0.33);
+    --color-set-dark-6-opacity-33: rgba(0,108,203,0.33);
+    --color-set-dark-7-opacity-33: rgba(199,165,0,0.33);
+    --color-set-dark-8-opacity-33: rgba(54,154,82,0.33);
+
     &.mat-autocomplete-panel {
         background: #303030;
         color: white;

--- a/src/themes/neon-dark-theme.scss
+++ b/src/themes/neon-dark-theme.scss
@@ -20,14 +20,14 @@ $dark-theme-white-darker: #D7D7D7;
 
 $dark-theme-base: (
     50: $dark-theme-primary-lighter,
-    100: $dark-theme-primary-lighter,
-    200: $dark-theme-primary-lighter,
-    300: $dark-theme-primary,
-    400: $dark-theme-primary,
+    100: #96C1CC,
+    200: #7EAEBB,
+    300: #669BAA,
+    400: #4E8899,
     500: $dark-theme-primary,
-    600: $dark-theme-primary,
-    700: $dark-theme-primary-darker,
-    800: $dark-theme-primary-darker,
+    600: #31697B,
+    700: #2D5E6E,
+    800: #295361,
     900: $dark-theme-primary-darker,
     A100: $dark-theme-accent-lighter,
     A200: $dark-theme-accent-lighter,
@@ -47,7 +47,7 @@ $dark-theme-base: (
         A100: $dark-theme-grey-darker,
         A200: $dark-theme-grey-darker,
         A400: $dark-theme-grey-darker,
-        A700: $dark-theme-grey-lighter
+        A700: $dark-theme-white-lighter
     )
 );
 
@@ -109,10 +109,10 @@ $dark-theme: (
     /* DO NOT USE SASS VARIABLES ($VAR) HERE!  YOU MUST HARDCODE ALL COLORS! */
     --color-accent: #54C8CD;
     --color-accent-contrast: #333333;
-    --color-accent-opaque: rgb(84,200,205,0.4);
+    --color-accent-transparent: rgba(84,200,205,0.33);
     --color-primary: #27607E;
     --color-primary-contrast: #F2F2F2;
-    --color-primary-opaque: rgb(39,96,126,0.4);
+    --color-primary-transparent: rgba(39,96,126,0.33);
     --color-background: #F2F2F2;
     --color-background-contrast: #D7D7D7;
     --color-text-header: #666666;

--- a/src/themes/neon-green-theme.scss
+++ b/src/themes/neon-green-theme.scss
@@ -20,14 +20,14 @@ $green-theme-white-darker: #D7D7D7;
 
 $green-theme-base: (
     50: $green-theme-primary-lighter,
-    100: $green-theme-primary-lighter,
-    200: $green-theme-primary-lighter,
-    300: $green-theme-primary,
-    400: $green-theme-primary,
+    100: #96C1CC,
+    200: #7EAEBB,
+    300: #669BAA,
+    400: #4E8899,
     500: $green-theme-primary,
-    600: $green-theme-primary,
-    700: $green-theme-primary-darker,
-    800: $green-theme-primary-darker,
+    600: #31697B,
+    700: #2D5E6E,
+    800: #295361,
     900: $green-theme-primary-darker,
     A100: $green-theme-accent-lighter,
     A200: $green-theme-accent-lighter,
@@ -47,7 +47,7 @@ $green-theme-base: (
         A100: $green-theme-grey-darker,
         A200: $green-theme-grey-darker,
         A400: $green-theme-grey-darker,
-        A700: $green-theme-grey-lighter
+        A700: $green-theme-white-lighter
     )
 );
 
@@ -109,10 +109,10 @@ $green-theme: (
     /* DO NOT USE SASS VARIABLES ($VAR) HERE!  YOU MUST HARDCODE ALL COLORS! */
     --color-accent: #54C8CD;
     --color-accent-contrast: #333333;
-    --color-accent-opaque: rgba(84,200,205,0.4);
+    --color-accent-transparent: rgba(84,200,205,0.33);
     --color-primary: #27607E;
     --color-primary-contrast: #F2F2F2;
-    --color-primary-opaque: rgba(39,96,126,0.4);
+    --color-primary-transparent: rgba(39,96,126,0.33);
     --color-background: #F2F2F2;
     --color-background-contrast: #D7D7D7;
     --color-text-header: #666666;

--- a/src/themes/neon-green-theme.scss
+++ b/src/themes/neon-green-theme.scss
@@ -109,14 +109,95 @@ $green-theme: (
     /* DO NOT USE SASS VARIABLES ($VAR) HERE!  YOU MUST HARDCODE ALL COLORS! */
     --color-accent: #54C8CD;
     --color-accent-contrast: #333333;
-    --color-accent-opaque: rgb(84,200,205,0.4);
+    --color-accent-opaque: rgba(84,200,205,0.4);
     --color-primary: #27607E;
     --color-primary-contrast: #F2F2F2;
-    --color-primary-opaque: rgb(39,96,126,0.4);
+    --color-primary-opaque: rgba(39,96,126,0.4);
     --color-background: #F2F2F2;
     --color-background-contrast: #D7D7D7;
     --color-text-header: #666666;
     --color-text-main: #333333;
+
+    --color-set-1: rgb(94,80,143); // #5E508F deep purple
+    --color-set-2: rgb(255,135,55); // #FF8737 orange
+    --color-set-3: rgb(179,79,146); // #B34F92 purple
+    --color-set-4: rgb(177,194,54); // #B1C236 lime
+    --color-set-5: rgb(243,88,112); // #F35870 pink
+    --color-set-6: rgb(0,153,255); // #0099FF blue
+    --color-set-7: rgb(255,214,0); // #FFD600 yellow
+    --color-set-8: rgb(106,204,127); // #6ACC7F sea green
+
+    --color-set-light-1: rgb(141,124,192); // #8D7CC0 deep purple
+    --color-set-light-2: rgb(255,184,102); // #FFB866 orange
+    --color-set-light-3: rgb(231,127,194); // #E77FC2 purple
+    --color-set-light-4: rgb(230,245,105); // #E6F569 lime
+    --color-set-light-5: rgb(255,139,158); // #FF8B9E pink
+    --color-set-light-6: rgb(105,204,255); // #69CCFF blue
+    --color-set-light-7: rgb(255,255,82); // #FFFF52 yellow
+    --color-set-light-8: rgb(54,154,82); // #369A52 sea green
+
+    --color-set-dark-1: rgb(49,39,97); // #312761 deep purple
+    --color-set-dark-2: rgb(198,88,0); // #C65800 orange
+    --color-set-dark-3: rgb(129,29,100); // #811D64 purple
+    --color-set-dark-4: rgb(126,146,0); // #7E9200 lime
+    --color-set-dark-5: rgb(187,30,69); // #BB1E45 pink
+    --color-set-dark-6: rgb(0,108,203); // #006CCB blue
+    --color-set-dark-7: rgb(199,165,0); // #C7A500 yellow
+    --color-set-dark-8: rgb(54,154,82); // #369A52 sea green
+
+    --color-set-1-opacity-66: rgba(94,80,143,0.66);
+    --color-set-2-opacity-66: rgba(255,135,55,0.66);
+    --color-set-3-opacity-66: rgba(179,79,146,0.66);
+    --color-set-4-opacity-66: rgba(177,194,54,0.66);
+    --color-set-5-opacity-66: rgba(243,88,112,0.66);
+    --color-set-6-opacity-66: rgba(0,153,255,0.66);
+    --color-set-7-opacity-66: rgba(255,214,0,0.66);
+    --color-set-8-opacity-66: rgba(106,204,127,0.66);
+
+    --color-set-light-1-opacity-66: rgba(141,124,192,0.66);
+    --color-set-light-2-opacity-66: rgba(255,184,102,0.66);
+    --color-set-light-3-opacity-66: rgba(231,127,194,0.66);
+    --color-set-light-4-opacity-66: rgba(230,245,105,0.66);
+    --color-set-light-5-opacity-66: rgba(255,139,158,0.66);
+    --color-set-light-6-opacity-66: rgba(105,204,255,0.66);
+    --color-set-light-7-opacity-66: rgba(255,255,82,0.66);
+    --color-set-light-8-opacity-66: rgba(54,154,82,0.66);
+
+    --color-set-dark-1-opacity-66: rgba(49,39,97,0.66);
+    --color-set-dark-2-opacity-66: rgba(198,88,0,0.66);
+    --color-set-dark-3-opacity-66: rgba(129,29,100,0.66);
+    --color-set-dark-4-opacity-66: rgba(126,146,0,0.66);
+    --color-set-dark-5-opacity-66: rgba(187,30,69,0.66);
+    --color-set-dark-6-opacity-66: rgba(0,108,203,0.66);
+    --color-set-dark-7-opacity-66: rgba(199,165,0,0.66);
+    --color-set-dark-8-opacity-66: rgba(54,154,82,0.66);
+
+    --color-set-1-opacity-33: rgba(94,80,143,0.33);
+    --color-set-2-opacity-33: rgba(255,135,55,0.33);
+    --color-set-3-opacity-33: rgba(179,79,146,0.33);
+    --color-set-4-opacity-33: rgba(177,194,54,0.33);
+    --color-set-5-opacity-33: rgba(243,88,112,0.33);
+    --color-set-6-opacity-33: rgba(0,153,255,0.33);
+    --color-set-7-opacity-33: rgba(255,214,0,0.33);
+    --color-set-8-opacity-33: rgba(106,204,127,0.33);
+
+    --color-set-light-1-opacity-33: rgba(141,124,192,0.33);
+    --color-set-light-2-opacity-33: rgba(255,184,102,0.33);
+    --color-set-light-3-opacity-33: rgba(231,127,194,0.33);
+    --color-set-light-4-opacity-33: rgba(230,245,105,0.33);
+    --color-set-light-5-opacity-33: rgba(255,139,158,0.33);
+    --color-set-light-6-opacity-33: rgba(105,204,255,0.33);
+    --color-set-light-7-opacity-33: rgba(255,255,82,0.33);
+    --color-set-light-8-opacity-33: rgba(54,154,82,0.33);
+
+    --color-set-dark-1-opacity-33: rgba(49,39,97,0.33);
+    --color-set-dark-2-opacity-33: rgba(198,88,0,0.33);
+    --color-set-dark-3-opacity-33: rgba(129,29,100,0.33);
+    --color-set-dark-4-opacity-33: rgba(126,146,0,0.33);
+    --color-set-dark-5-opacity-33: rgba(187,30,69,0.33);
+    --color-set-dark-6-opacity-33: rgba(0,108,203,0.33);
+    --color-set-dark-7-opacity-33: rgba(199,165,0,0.33);
+    --color-set-dark-8-opacity-33: rgba(54,154,82,0.33);
 
     &.mat-autocomplete-panel {
         background: white;

--- a/src/themes/neon-green-theme.scss
+++ b/src/themes/neon-green-theme.scss
@@ -145,59 +145,59 @@ $green-theme: (
     --color-set-dark-7: rgb(199,165,0); // #C7A500 yellow
     --color-set-dark-8: rgb(54,154,82); // #369A52 sea green
 
-    --color-set-1-opacity-66: rgba(94,80,143,0.66);
-    --color-set-2-opacity-66: rgba(255,135,55,0.66);
-    --color-set-3-opacity-66: rgba(179,79,146,0.66);
-    --color-set-4-opacity-66: rgba(177,194,54,0.66);
-    --color-set-5-opacity-66: rgba(243,88,112,0.66);
-    --color-set-6-opacity-66: rgba(0,153,255,0.66);
-    --color-set-7-opacity-66: rgba(255,214,0,0.66);
-    --color-set-8-opacity-66: rgba(106,204,127,0.66);
+    --color-set-1-transparency-medium: rgba(94,80,143,0.66);
+    --color-set-2-transparency-medium: rgba(255,135,55,0.66);
+    --color-set-3-transparency-medium: rgba(179,79,146,0.66);
+    --color-set-4-transparency-medium: rgba(177,194,54,0.66);
+    --color-set-5-transparency-medium: rgba(243,88,112,0.66);
+    --color-set-6-transparency-medium: rgba(0,153,255,0.66);
+    --color-set-7-transparency-medium: rgba(255,214,0,0.66);
+    --color-set-8-transparency-medium: rgba(106,204,127,0.66);
 
-    --color-set-light-1-opacity-66: rgba(141,124,192,0.66);
-    --color-set-light-2-opacity-66: rgba(255,184,102,0.66);
-    --color-set-light-3-opacity-66: rgba(231,127,194,0.66);
-    --color-set-light-4-opacity-66: rgba(230,245,105,0.66);
-    --color-set-light-5-opacity-66: rgba(255,139,158,0.66);
-    --color-set-light-6-opacity-66: rgba(105,204,255,0.66);
-    --color-set-light-7-opacity-66: rgba(255,255,82,0.66);
-    --color-set-light-8-opacity-66: rgba(54,154,82,0.66);
+    --color-set-light-1-transparency-medium: rgba(141,124,192,0.66);
+    --color-set-light-2-transparency-medium: rgba(255,184,102,0.66);
+    --color-set-light-3-transparency-medium: rgba(231,127,194,0.66);
+    --color-set-light-4-transparency-medium: rgba(230,245,105,0.66);
+    --color-set-light-5-transparency-medium: rgba(255,139,158,0.66);
+    --color-set-light-6-transparency-medium: rgba(105,204,255,0.66);
+    --color-set-light-7-transparency-medium: rgba(255,255,82,0.66);
+    --color-set-light-8-transparency-medium: rgba(54,154,82,0.66);
 
-    --color-set-dark-1-opacity-66: rgba(49,39,97,0.66);
-    --color-set-dark-2-opacity-66: rgba(198,88,0,0.66);
-    --color-set-dark-3-opacity-66: rgba(129,29,100,0.66);
-    --color-set-dark-4-opacity-66: rgba(126,146,0,0.66);
-    --color-set-dark-5-opacity-66: rgba(187,30,69,0.66);
-    --color-set-dark-6-opacity-66: rgba(0,108,203,0.66);
-    --color-set-dark-7-opacity-66: rgba(199,165,0,0.66);
-    --color-set-dark-8-opacity-66: rgba(54,154,82,0.66);
+    --color-set-dark-1-transparency-medium: rgba(49,39,97,0.66);
+    --color-set-dark-2-transparency-medium: rgba(198,88,0,0.66);
+    --color-set-dark-3-transparency-medium: rgba(129,29,100,0.66);
+    --color-set-dark-4-transparency-medium: rgba(126,146,0,0.66);
+    --color-set-dark-5-transparency-medium: rgba(187,30,69,0.66);
+    --color-set-dark-6-transparency-medium: rgba(0,108,203,0.66);
+    --color-set-dark-7-transparency-medium: rgba(199,165,0,0.66);
+    --color-set-dark-8-transparency-medium: rgba(54,154,82,0.66);
 
-    --color-set-1-opacity-33: rgba(94,80,143,0.33);
-    --color-set-2-opacity-33: rgba(255,135,55,0.33);
-    --color-set-3-opacity-33: rgba(179,79,146,0.33);
-    --color-set-4-opacity-33: rgba(177,194,54,0.33);
-    --color-set-5-opacity-33: rgba(243,88,112,0.33);
-    --color-set-6-opacity-33: rgba(0,153,255,0.33);
-    --color-set-7-opacity-33: rgba(255,214,0,0.33);
-    --color-set-8-opacity-33: rgba(106,204,127,0.33);
+    --color-set-1-transparency-high: rgba(94,80,143,0.33);
+    --color-set-2-transparency-high: rgba(255,135,55,0.33);
+    --color-set-3-transparency-high: rgba(179,79,146,0.33);
+    --color-set-4-transparency-high: rgba(177,194,54,0.33);
+    --color-set-5-transparency-high: rgba(243,88,112,0.33);
+    --color-set-6-transparency-high: rgba(0,153,255,0.33);
+    --color-set-7-transparency-high: rgba(255,214,0,0.33);
+    --color-set-8-transparency-high: rgba(106,204,127,0.33);
 
-    --color-set-light-1-opacity-33: rgba(141,124,192,0.33);
-    --color-set-light-2-opacity-33: rgba(255,184,102,0.33);
-    --color-set-light-3-opacity-33: rgba(231,127,194,0.33);
-    --color-set-light-4-opacity-33: rgba(230,245,105,0.33);
-    --color-set-light-5-opacity-33: rgba(255,139,158,0.33);
-    --color-set-light-6-opacity-33: rgba(105,204,255,0.33);
-    --color-set-light-7-opacity-33: rgba(255,255,82,0.33);
-    --color-set-light-8-opacity-33: rgba(54,154,82,0.33);
+    --color-set-light-1-transparency-high: rgba(141,124,192,0.33);
+    --color-set-light-2-transparency-high: rgba(255,184,102,0.33);
+    --color-set-light-3-transparency-high: rgba(231,127,194,0.33);
+    --color-set-light-4-transparency-high: rgba(230,245,105,0.33);
+    --color-set-light-5-transparency-high: rgba(255,139,158,0.33);
+    --color-set-light-6-transparency-high: rgba(105,204,255,0.33);
+    --color-set-light-7-transparency-high: rgba(255,255,82,0.33);
+    --color-set-light-8-transparency-high: rgba(54,154,82,0.33);
 
-    --color-set-dark-1-opacity-33: rgba(49,39,97,0.33);
-    --color-set-dark-2-opacity-33: rgba(198,88,0,0.33);
-    --color-set-dark-3-opacity-33: rgba(129,29,100,0.33);
-    --color-set-dark-4-opacity-33: rgba(126,146,0,0.33);
-    --color-set-dark-5-opacity-33: rgba(187,30,69,0.33);
-    --color-set-dark-6-opacity-33: rgba(0,108,203,0.33);
-    --color-set-dark-7-opacity-33: rgba(199,165,0,0.33);
-    --color-set-dark-8-opacity-33: rgba(54,154,82,0.33);
+    --color-set-dark-1-transparency-high: rgba(49,39,97,0.33);
+    --color-set-dark-2-transparency-high: rgba(198,88,0,0.33);
+    --color-set-dark-3-transparency-high: rgba(129,29,100,0.33);
+    --color-set-dark-4-transparency-high: rgba(126,146,0,0.33);
+    --color-set-dark-5-transparency-high: rgba(187,30,69,0.33);
+    --color-set-dark-6-transparency-high: rgba(0,108,203,0.33);
+    --color-set-dark-7-transparency-high: rgba(199,165,0,0.33);
+    --color-set-dark-8-transparency-high: rgba(54,154,82,0.33);
 
     &.mat-autocomplete-panel {
         background: white;

--- a/src/themes/neon-teal-theme.scss
+++ b/src/themes/neon-teal-theme.scss
@@ -18,14 +18,14 @@ $teal-theme-white-darker: #D7D7D7;
 
 $teal-theme-base: (
     50: $teal-theme-primary-lighter,
-    100: $teal-theme-primary-lighter,
-    200: $teal-theme-primary-lighter,
-    300: $teal-theme-primary,
-    400: $teal-theme-primary,
+    100: #96C1CC,
+    200: #7EAEBB,
+    300: #669BAA,
+    400: #4E8899,
     500: $teal-theme-primary,
-    600: $teal-theme-primary,
-    700: $teal-theme-primary-darker,
-    800: $teal-theme-primary-darker,
+    600: #31697B,
+    700: #2D5E6E,
+    800: #295361,
     900: $teal-theme-primary-darker,
     A100: $teal-theme-accent-lighter,
     A200: $teal-theme-accent-lighter,
@@ -45,7 +45,7 @@ $teal-theme-base: (
         A100: $teal-theme-grey-darker,
         A200: $teal-theme-grey-darker,
         A400: $teal-theme-grey-darker,
-        A700: $teal-theme-grey-lighter
+        A700: $teal-theme-white-lighter
     )
 );
 
@@ -88,8 +88,8 @@ $teal-theme-foreground: (
     slider-off-active: rgba(black, 0.38),
 );
 
-$teal-theme-primary-palette: mat-palette($teal-theme-base, 500, 100, 700);
-$teal-theme-accent-palette: mat-palette($teal-theme-base, A400, A200, A700);
+$teal-theme-primary-palette: mat-palette($teal-theme-base, 500, 50, 900);
+$teal-theme-accent-palette: mat-palette($teal-theme-base, A400, A100, A700);
 $teal-theme-warn-palette: mat-palette($mat-red, A400, A200, A700);
 
 $teal-theme: (
@@ -107,10 +107,10 @@ $teal-theme: (
     /* DO NOT USE SASS VARIABLES ($VAR) HERE!  YOU MUST HARDCODE ALL COLORS! */
     --color-accent: #54C8CD;
     --color-accent-contrast: #333333;
-    --color-accent-opaque: rgb(84,200,205,0.4);
+    --color-accent-transparent: rgba(84,200,205,0.33);
     --color-primary: #367588;
     --color-primary-contrast: #F2F2F2;
-    --color-primary-opaque: rgb(54, 117, 136, 0.4);
+    --color-primary-transparent: rgba(54, 117, 136, 0.33);
     --color-background: #F2F2F2;
     --color-background-contrast: #D7D7D7;
     --color-text-header: #666666;

--- a/src/themes/neon-teal-theme.scss
+++ b/src/themes/neon-teal-theme.scss
@@ -143,59 +143,59 @@ $teal-theme: (
     --color-set-dark-7: rgb(199,165,0); // #C7A500 yellow
     --color-set-dark-8: rgb(54,154,82); // #369A52 sea green
 
-    --color-set-1-opacity-66: rgba(94,80,143,0.66);
-    --color-set-2-opacity-66: rgba(255,135,55,0.66);
-    --color-set-3-opacity-66: rgba(179,79,146,0.66);
-    --color-set-4-opacity-66: rgba(177,194,54,0.66);
-    --color-set-5-opacity-66: rgba(243,88,112,0.66);
-    --color-set-6-opacity-66: rgba(0,153,255,0.66);
-    --color-set-7-opacity-66: rgba(255,214,0,0.66);
-    --color-set-8-opacity-66: rgba(106,204,127,0.66);
+    --color-set-1-transparency-medium: rgba(94,80,143,0.66);
+    --color-set-2-transparency-medium: rgba(255,135,55,0.66);
+    --color-set-3-transparency-medium: rgba(179,79,146,0.66);
+    --color-set-4-transparency-medium: rgba(177,194,54,0.66);
+    --color-set-5-transparency-medium: rgba(243,88,112,0.66);
+    --color-set-6-transparency-medium: rgba(0,153,255,0.66);
+    --color-set-7-transparency-medium: rgba(255,214,0,0.66);
+    --color-set-8-transparency-medium: rgba(106,204,127,0.66);
 
-    --color-set-light-1-opacity-66: rgba(141,124,192,0.66);
-    --color-set-light-2-opacity-66: rgba(255,184,102,0.66);
-    --color-set-light-3-opacity-66: rgba(231,127,194,0.66);
-    --color-set-light-4-opacity-66: rgba(230,245,105,0.66);
-    --color-set-light-5-opacity-66: rgba(255,139,158,0.66);
-    --color-set-light-6-opacity-66: rgba(105,204,255,0.66);
-    --color-set-light-7-opacity-66: rgba(255,255,82,0.66);
-    --color-set-light-8-opacity-66: rgba(54,154,82,0.66);
+    --color-set-light-1-transparency-medium: rgba(141,124,192,0.66);
+    --color-set-light-2-transparency-medium: rgba(255,184,102,0.66);
+    --color-set-light-3-transparency-medium: rgba(231,127,194,0.66);
+    --color-set-light-4-transparency-medium: rgba(230,245,105,0.66);
+    --color-set-light-5-transparency-medium: rgba(255,139,158,0.66);
+    --color-set-light-6-transparency-medium: rgba(105,204,255,0.66);
+    --color-set-light-7-transparency-medium: rgba(255,255,82,0.66);
+    --color-set-light-8-transparency-medium: rgba(54,154,82,0.66);
 
-    --color-set-dark-1-opacity-66: rgba(49,39,97,0.66);
-    --color-set-dark-2-opacity-66: rgba(198,88,0,0.66);
-    --color-set-dark-3-opacity-66: rgba(129,29,100,0.66);
-    --color-set-dark-4-opacity-66: rgba(126,146,0,0.66);
-    --color-set-dark-5-opacity-66: rgba(187,30,69,0.66);
-    --color-set-dark-6-opacity-66: rgba(0,108,203,0.66);
-    --color-set-dark-7-opacity-66: rgba(199,165,0,0.66);
-    --color-set-dark-8-opacity-66: rgba(54,154,82,0.66);
+    --color-set-dark-1-transparency-medium: rgba(49,39,97,0.66);
+    --color-set-dark-2-transparency-medium: rgba(198,88,0,0.66);
+    --color-set-dark-3-transparency-medium: rgba(129,29,100,0.66);
+    --color-set-dark-4-transparency-medium: rgba(126,146,0,0.66);
+    --color-set-dark-5-transparency-medium: rgba(187,30,69,0.66);
+    --color-set-dark-6-transparency-medium: rgba(0,108,203,0.66);
+    --color-set-dark-7-transparency-medium: rgba(199,165,0,0.66);
+    --color-set-dark-8-transparency-medium: rgba(54,154,82,0.66);
 
-    --color-set-1-opacity-33: rgba(94,80,143,0.33);
-    --color-set-2-opacity-33: rgba(255,135,55,0.33);
-    --color-set-3-opacity-33: rgba(179,79,146,0.33);
-    --color-set-4-opacity-33: rgba(177,194,54,0.33);
-    --color-set-5-opacity-33: rgba(243,88,112,0.33);
-    --color-set-6-opacity-33: rgba(0,153,255,0.33);
-    --color-set-7-opacity-33: rgba(255,214,0,0.33);
-    --color-set-8-opacity-33: rgba(106,204,127,0.33);
+    --color-set-1-transparency-high: rgba(94,80,143,0.33);
+    --color-set-2-transparency-high: rgba(255,135,55,0.33);
+    --color-set-3-transparency-high: rgba(179,79,146,0.33);
+    --color-set-4-transparency-high: rgba(177,194,54,0.33);
+    --color-set-5-transparency-high: rgba(243,88,112,0.33);
+    --color-set-6-transparency-high: rgba(0,153,255,0.33);
+    --color-set-7-transparency-high: rgba(255,214,0,0.33);
+    --color-set-8-transparency-high: rgba(106,204,127,0.33);
 
-    --color-set-light-1-opacity-33: rgba(141,124,192,0.33);
-    --color-set-light-2-opacity-33: rgba(255,184,102,0.33);
-    --color-set-light-3-opacity-33: rgba(231,127,194,0.33);
-    --color-set-light-4-opacity-33: rgba(230,245,105,0.33);
-    --color-set-light-5-opacity-33: rgba(255,139,158,0.33);
-    --color-set-light-6-opacity-33: rgba(105,204,255,0.33);
-    --color-set-light-7-opacity-33: rgba(255,255,82,0.33);
-    --color-set-light-8-opacity-33: rgba(54,154,82,0.33);
+    --color-set-light-1-transparency-high: rgba(141,124,192,0.33);
+    --color-set-light-2-transparency-high: rgba(255,184,102,0.33);
+    --color-set-light-3-transparency-high: rgba(231,127,194,0.33);
+    --color-set-light-4-transparency-high: rgba(230,245,105,0.33);
+    --color-set-light-5-transparency-high: rgba(255,139,158,0.33);
+    --color-set-light-6-transparency-high: rgba(105,204,255,0.33);
+    --color-set-light-7-transparency-high: rgba(255,255,82,0.33);
+    --color-set-light-8-transparency-high: rgba(54,154,82,0.33);
 
-    --color-set-dark-1-opacity-33: rgba(49,39,97,0.33);
-    --color-set-dark-2-opacity-33: rgba(198,88,0,0.33);
-    --color-set-dark-3-opacity-33: rgba(129,29,100,0.33);
-    --color-set-dark-4-opacity-33: rgba(126,146,0,0.33);
-    --color-set-dark-5-opacity-33: rgba(187,30,69,0.33);
-    --color-set-dark-6-opacity-33: rgba(0,108,203,0.33);
-    --color-set-dark-7-opacity-33: rgba(199,165,0,0.33);
-    --color-set-dark-8-opacity-33: rgba(54,154,82,0.33);
+    --color-set-dark-1-transparency-high: rgba(49,39,97,0.33);
+    --color-set-dark-2-transparency-high: rgba(198,88,0,0.33);
+    --color-set-dark-3-transparency-high: rgba(129,29,100,0.33);
+    --color-set-dark-4-transparency-high: rgba(126,146,0,0.33);
+    --color-set-dark-5-transparency-high: rgba(187,30,69,0.33);
+    --color-set-dark-6-transparency-high: rgba(0,108,203,0.33);
+    --color-set-dark-7-transparency-high: rgba(199,165,0,0.33);
+    --color-set-dark-8-transparency-high: rgba(54,154,82,0.33);
 
     &.mat-autocomplete-panel {
         background: white;

--- a/src/themes/neon-teal-theme.scss
+++ b/src/themes/neon-teal-theme.scss
@@ -116,6 +116,87 @@ $teal-theme: (
     --color-text-header: #666666;
     --color-text-main: #333333;
 
+    --color-set-1: rgb(94,80,143); // #5E508F deep purple
+    --color-set-2: rgb(255,135,55); // #FF8737 orange
+    --color-set-3: rgb(179,79,146); // #B34F92 purple
+    --color-set-4: rgb(177,194,54); // #B1C236 lime
+    --color-set-5: rgb(243,88,112); // #F35870 pink
+    --color-set-6: rgb(0,153,255); // #0099FF blue
+    --color-set-7: rgb(255,214,0); // #FFD600 yellow
+    --color-set-8: rgb(106,204,127); // #6ACC7F sea green
+
+    --color-set-light-1: rgb(141,124,192); // #8D7CC0 deep purple
+    --color-set-light-2: rgb(255,184,102); // #FFB866 orange
+    --color-set-light-3: rgb(231,127,194); // #E77FC2 purple
+    --color-set-light-4: rgb(230,245,105); // #E6F569 lime
+    --color-set-light-5: rgb(255,139,158); // #FF8B9E pink
+    --color-set-light-6: rgb(105,204,255); // #69CCFF blue
+    --color-set-light-7: rgb(255,255,82); // #FFFF52 yellow
+    --color-set-light-8: rgb(54,154,82); // #369A52 sea green
+
+    --color-set-dark-1: rgb(49,39,97); // #312761 deep purple
+    --color-set-dark-2: rgb(198,88,0); // #C65800 orange
+    --color-set-dark-3: rgb(129,29,100); // #811D64 purple
+    --color-set-dark-4: rgb(126,146,0); // #7E9200 lime
+    --color-set-dark-5: rgb(187,30,69); // #BB1E45 pink
+    --color-set-dark-6: rgb(0,108,203); // #006CCB blue
+    --color-set-dark-7: rgb(199,165,0); // #C7A500 yellow
+    --color-set-dark-8: rgb(54,154,82); // #369A52 sea green
+
+    --color-set-1-opacity-66: rgba(94,80,143,0.66);
+    --color-set-2-opacity-66: rgba(255,135,55,0.66);
+    --color-set-3-opacity-66: rgba(179,79,146,0.66);
+    --color-set-4-opacity-66: rgba(177,194,54,0.66);
+    --color-set-5-opacity-66: rgba(243,88,112,0.66);
+    --color-set-6-opacity-66: rgba(0,153,255,0.66);
+    --color-set-7-opacity-66: rgba(255,214,0,0.66);
+    --color-set-8-opacity-66: rgba(106,204,127,0.66);
+
+    --color-set-light-1-opacity-66: rgba(141,124,192,0.66);
+    --color-set-light-2-opacity-66: rgba(255,184,102,0.66);
+    --color-set-light-3-opacity-66: rgba(231,127,194,0.66);
+    --color-set-light-4-opacity-66: rgba(230,245,105,0.66);
+    --color-set-light-5-opacity-66: rgba(255,139,158,0.66);
+    --color-set-light-6-opacity-66: rgba(105,204,255,0.66);
+    --color-set-light-7-opacity-66: rgba(255,255,82,0.66);
+    --color-set-light-8-opacity-66: rgba(54,154,82,0.66);
+
+    --color-set-dark-1-opacity-66: rgba(49,39,97,0.66);
+    --color-set-dark-2-opacity-66: rgba(198,88,0,0.66);
+    --color-set-dark-3-opacity-66: rgba(129,29,100,0.66);
+    --color-set-dark-4-opacity-66: rgba(126,146,0,0.66);
+    --color-set-dark-5-opacity-66: rgba(187,30,69,0.66);
+    --color-set-dark-6-opacity-66: rgba(0,108,203,0.66);
+    --color-set-dark-7-opacity-66: rgba(199,165,0,0.66);
+    --color-set-dark-8-opacity-66: rgba(54,154,82,0.66);
+
+    --color-set-1-opacity-33: rgba(94,80,143,0.33);
+    --color-set-2-opacity-33: rgba(255,135,55,0.33);
+    --color-set-3-opacity-33: rgba(179,79,146,0.33);
+    --color-set-4-opacity-33: rgba(177,194,54,0.33);
+    --color-set-5-opacity-33: rgba(243,88,112,0.33);
+    --color-set-6-opacity-33: rgba(0,153,255,0.33);
+    --color-set-7-opacity-33: rgba(255,214,0,0.33);
+    --color-set-8-opacity-33: rgba(106,204,127,0.33);
+
+    --color-set-light-1-opacity-33: rgba(141,124,192,0.33);
+    --color-set-light-2-opacity-33: rgba(255,184,102,0.33);
+    --color-set-light-3-opacity-33: rgba(231,127,194,0.33);
+    --color-set-light-4-opacity-33: rgba(230,245,105,0.33);
+    --color-set-light-5-opacity-33: rgba(255,139,158,0.33);
+    --color-set-light-6-opacity-33: rgba(105,204,255,0.33);
+    --color-set-light-7-opacity-33: rgba(255,255,82,0.33);
+    --color-set-light-8-opacity-33: rgba(54,154,82,0.33);
+
+    --color-set-dark-1-opacity-33: rgba(49,39,97,0.33);
+    --color-set-dark-2-opacity-33: rgba(198,88,0,0.33);
+    --color-set-dark-3-opacity-33: rgba(129,29,100,0.33);
+    --color-set-dark-4-opacity-33: rgba(126,146,0,0.33);
+    --color-set-dark-5-opacity-33: rgba(187,30,69,0.33);
+    --color-set-dark-6-opacity-33: rgba(0,108,203,0.33);
+    --color-set-dark-7-opacity-33: rgba(199,165,0,0.33);
+    --color-set-dark-8-opacity-33: rgba(54,154,82,0.33);
+
     &.mat-autocomplete-panel {
         background: white;
         color: rgba(black, 0.87);


### PR DESCRIPTION
I changed the ColorSets (that supply the colors for the charts/points/etc.) to use CSS custom properties rather than hard-coded values.  The custom properties are needed for the colors to update whenever the theme is changed.  I also had to change Color to handle CSS strings rather than RGB values.  I added hex codes to the WidgetService for the main and accent colors for all themes.

Please note that the Dark and Green themes are just copies of the Teal theme for now (there's already a TODO with a JIRA ticket number in them).  Thanks!