### PR TITLE
Removes the second jQuery

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -1,68 +1,65 @@
 {
-  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
-  "project": {
-    "name": "neon-gtd",
-    "version": "1.3.0-angular2"
-  },
-  "apps": [
-    {
-      "root": "src",
-      "outDir": "dist",
-      "assets": [
-        "assets",
-        "favicon.ico",
-        "app/config/*.json",
-        "app/config/*.yaml"
-      ],
-      "index": "index.html",
-      "main": "main.ts",
-      "polyfills": "polyfills.ts",
-      "test": "test.ts",
-      "tsconfig": "tsconfig.app.json",
-      "testTsconfig": "tsconfig.spec.json",
-      "prefix": "app",
-      "styles": [
-        "styles.scss",
-        "themes/neon-green-theme.scss",
-        "../node_modules/cesium/Build/Cesium/Widgets/widgets.css",
-        "../node_modules/jsoneditor/dist/jsoneditor.css",
-        "../node_modules/leaflet/dist/leaflet.css",
-        "../node_modules/vis/dist/vis-network.min.css"
-      ],
-      "scripts": [
-          "../node_modules/jsoneditor/dist/jsoneditor.js",
-          "../node_modules/jquery/dist/jquery.min.js"
-      ],
-      "environmentSource": "environments/environment.ts",
-      "environments": {
-        "dev": "environments/environment.ts",
-        "prod": "environments/environment.prod.ts"
-      }
-    }
-  ],
-  "e2e": {
-    "protractor": {
-      "config": "./protractor.conf.js"
-    }
-  },
-  "lint": [
-    {
-      "project": "src/tsconfig.app.json"
+    "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+    "project": {
+        "name": "neon-gtd",
+        "version": "1.3.0-angular2"
     },
-    {
-      "project": "src/tsconfig.spec.json"
+    "apps": [
+        {
+            "root": "src",
+            "outDir": "dist",
+            "assets": [
+                "assets",
+                "favicon.ico",
+                "app/config/*.json",
+                "app/config/*.yaml"
+            ],
+            "index": "index.html",
+            "main": "main.ts",
+            "polyfills": "polyfills.ts",
+            "test": "test.ts",
+            "tsconfig": "tsconfig.app.json",
+            "testTsconfig": "tsconfig.spec.json",
+            "prefix": "app",
+            "styles": [
+                "styles.scss",
+                "themes/neon-green-theme.scss",
+                "../node_modules/cesium/Build/Cesium/Widgets/widgets.css",
+                "../node_modules/jsoneditor/dist/jsoneditor.css",
+                "../node_modules/leaflet/dist/leaflet.css",
+                "../node_modules/vis/dist/vis-network.min.css"
+            ],
+            "scripts": ["../node_modules/jsoneditor/dist/jsoneditor.js"],
+            "environmentSource": "environments/environment.ts",
+            "environments": {
+                "dev": "environments/environment.ts",
+                "prod": "environments/environment.prod.ts"
+            }
+        }
+    ],
+    "e2e": {
+        "protractor": {
+            "config": "./protractor.conf.js"
+        }
     },
-    {
-      "project": "e2e/tsconfig.e2e.json"
+    "lint": [
+        {
+            "project": "src/tsconfig.app.json"
+        },
+        {
+            "project": "src/tsconfig.spec.json"
+        },
+        {
+            "project": "e2e/tsconfig.e2e.json"
+        }
+    ],
+    "test": {
+        "karma": {
+            "config": "./karma.conf.js"
+        }
+    },
+    "defaults": {
+        "styleExt": "css",
+        "component": {}
     }
-  ],
-  "test": {
-    "karma": {
-      "config": "./karma.conf.js"
-    }
-  },
-  "defaults": {
-    "styleExt": "css",
-    "component": {}
-  }
 }

--- a/src/app/components/timeline/TimelineSelectorChart.ts
+++ b/src/app/components/timeline/TimelineSelectorChart.ts
@@ -15,6 +15,8 @@
  */
 /// <reference path="../../../../node_modules/@types/d3/index.d.ts" />
 import * as _ from 'lodash';
+import * as $ from 'jquery';
+
 import { ElementRef } from '@angular/core';
 import { TimelineComponent } from './timeline.component';
 import { Bucketizer } from '../bucketizers/Bucketizer';


### PR DESCRIPTION
jQuery was being included in both the vendor (via `import`) and scripts bundle. This removes the entry for scripts bundle and changes the Timeline Selector Chart to use the imported copy. 