### PR TITLE
Fix for running with AOT builds

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -37,8 +37,11 @@ import { map, catchError } from 'rxjs/operators';
 
 @Injectable()
 export class HttpBasicHandler implements HttpHandler {
+    private backend: HttpBackend;
 
-    constructor(private backend: HttpBackend) {}
+    constructor() {
+        this.backend = new HttpXhrBackend(new BrowserXhr());
+    }
 
     handle(req: HttpRequest<any>): Observable<HttpEvent<any>> {
         return this.backend.handle(req);


### PR DESCRIPTION
For some reason, the HttpBackend injection fails when using an AOT build, but not for JIT.
To fix this, skip injecting the HttpBackend and just initialize it in the constructor