### PR TITLE
THOR-940 THOR-946 Removed use of the filterservice REST endpoint

### DIFF
--- a/src/app/components/save-state/save-state.component.ts
+++ b/src/app/components/save-state/save-state.component.ts
@@ -21,6 +21,7 @@ import { MatDialog, MatDialogRef, MatSnackBar, MatSidenav } from '@angular/mater
 import { AbstractWidgetService } from '../../services/abstract.widget.service';
 import { ConnectionService } from '../../services/connection.service';
 import { DatasetService } from '../../services/dataset.service';
+import { FilterService } from '../../services/filter.service';
 import { ParameterService } from '../../services/parameter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
@@ -62,6 +63,7 @@ export class SaveStateComponent implements OnInit {
     constructor(
         protected connectionService: ConnectionService,
         protected datasetService: DatasetService,
+        protected filterService: FilterService,
         private snackBar: MatSnackBar,
         protected parameterService: ParameterService,
         public widgetService: AbstractWidgetService,
@@ -123,6 +125,9 @@ export class SaveStateComponent implements OnInit {
             });
 
             stateParams.dataset = this.datasetService.getDataset();
+
+            // TODO THOR-1024 Do not save filters within the dataset.
+            (stateParams.dataset as any).filters = this.filterService.getFilters();
 
             connection.saveState(stateParams, (response) => {
                 this.handleSaveStateSuccess(response);

--- a/src/app/neon-namespaces.ts
+++ b/src/app/neon-namespaces.ts
@@ -23,6 +23,7 @@ export namespace neonEvents {
     export const DASHBOARD_ERROR = 'DASHBOARD_ERROR';
     export const DASHBOARD_REFRESH = 'DASHBOARD_REFRESH';
     export const DASHBOARD_STATE = 'DASHBOARD_STATE';
+    export const FILTERS_CHANGED = 'filters_changed'; // Lowercase to maintain backwards compatibility
     export const NEW_DATASET = 'NEW_DATASET';
     export const WIDGET_ADD = 'WIDGET_ADD';
     export const WIDGET_DELETE = 'WIDGET_DELETE';

--- a/src/app/services/parameter.service.ts
+++ b/src/app/services/parameter.service.ts
@@ -317,25 +317,19 @@ export class ParameterService {
 
                 // Update dataset fields, then set as active and update the dashboard
                 this.datasetService.updateDatabases(matchingDataset, connection, (dataset: Dataset) => {
-                    this.filterService.getFilterState(() => {
-                        for (let i = 0; i < dataset.databases.length; i++) {
-                            for (let j = 0; j < dataset.databases[i].tables.length; j++) {
-                                dataset.databases[i].tables[j].mappings = dashboardState.dataset.databases[i].tables[j].mappings;
-                            }
-                        }
+                    // TODO THOR-1024 Do not expect filters within the dataset.
+                    this.filterService.setFilters((dataset as any).filters || []);
 
-                        this.messenger.publish(neonEvents.DASHBOARD_STATE, {
-                            dashboard: dashboardState.dashboard,
-                            dataset: dataset,
-                            dashboardStateId: dashboardStateId
-                        });
-                    }, (response) => {
-                        if (response.responseJSON) {
-                            this.messenger.publish(neonEvents.DASHBOARD_ERROR, {
-                                error: null,
-                                message: response.responseJSON.error
-                            });
+                    for (let i = 0; i < dataset.databases.length; i++) {
+                        for (let j = 0; j < dataset.databases[i].tables.length; j++) {
+                            dataset.databases[i].tables[j].mappings = dashboardState.dataset.databases[i].tables[j].mappings;
                         }
+                    }
+
+                    this.messenger.publish(neonEvents.DASHBOARD_STATE, {
+                        dashboard: dashboardState.dashboard,
+                        dataset: dataset,
+                        dashboardStateId: dashboardStateId
                     });
                 });
             } else {


### PR DESCRIPTION
Removed the use of the filterservice REST endpoint (getFilterState and messenger addFilters, removeFilters, and replaceFilters functions).  Filters are now saved in the Filter Service and are applied to all queries in the Base Neon Component.  Ensured saved state behavior still works.  This task is part of an Epic to change filter behavior within the frontend and will be merged into a feature branch as I continue to work on related tasks and cleanup (WIP).