### PR TITLE
Full-Dashboard Tabs (VERDI Master)

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -75,12 +75,18 @@
     </div>
 
     <div class="neon-dash" mat-fill layout="col">
-        <div [ngGrid]="gridConfig" #grid>
-            <div *ngFor="let widgetGridItem of widgetGridItems; let i = index;" [(ngGridItem)]="widgetGridItem.config"
-                    name="widgetGridItem.id" id="widgetGridItem.id" (onResizeStart)="onResizeStart(i, $event)"
-                    (onResizeStop)="onResizeStop(i, $event)" (onDragStop)="onDragStop(i, $event)">
-                <app-visualization-container [visualization]="widgetGridItem"></app-visualization-container>
-                <ng-content></ng-content>
+        <mat-tab-group *ngIf="tabbedGrid.length > 1" [(selectedIndex)]="selectedTabIndex">
+            <mat-tab class="tab" *ngFor="let tab of tabbedGrid" [label]="tab.name"></mat-tab>
+        </mat-tab-group>
+
+        <div class="neon-grid">
+            <div [ngGrid]="gridConfig" #grid>
+                <div *ngFor="let widgetGridItem of tabbedGrid[selectedTabIndex].list; let i = index;" [(ngGridItem)]="widgetGridItem.config"
+                        name="widgetGridItem.id" id="widgetGridItem.id" (onResizeStart)="onResizeStart(i, $event)"
+                        (onResizeStop)="onResizeStop(i, $event)" (onDragStop)="onDragStop(i, $event)">
+                    <app-visualization-container [visualization]="widgetGridItem"></app-visualization-container>
+                    <ng-content></ng-content>
+                </div>
             </div>
         </div>
     </div>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -38,6 +38,7 @@
 }
 
 .neon-dash {
+    background-color: var(--color-background, white);
     /* 60 = 50 px toolbar + 10 px neon-grid padding */
     height: calc(100% - 60px);
     overflow-y: auto;

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -38,18 +38,25 @@
 }
 
 .neon-dash {
-    background-color: var(--color-background, white);
-    /* 60 = 50 px toolbar + 10 px padding */
+    /* 60 = 50 px toolbar + 10 px neon-grid padding */
     height: calc(100% - 60px);
-    padding: 5px;
     overflow-y: auto;
+}
+
+.neon-grid {
+    background-color: var(--color-background, white);
+    padding: 5px;
+}
+
+mat-tab-group,
+.header-toggle-container {
+    /* Subtract 15px for the scrollbar.  Not an ideal fix since it also applies without the scrollbar present. */
+    width: calc(100% - 15px);
 }
 
 .header-toggle-container {
     z-index: 9999;
     position: absolute;
-    /* Subtract 15px for the scrollbar.  Not an ideal fix since it also applies without the scrollbar present. */
-    width: calc(100% - 15px);
 
     .filters-container {
         width: 100%;

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -296,7 +296,7 @@ describe('App', () => {
             widgetGridItem: widgetGridItem1
         });
 
-        expect(component.widgetGridItems).toEqual([{
+        expect(component.tabbedGrid[0].list).toEqual([{
             col: 2,
             config: {
                 borderSize: 10,
@@ -331,7 +331,7 @@ describe('App', () => {
             widgetGridItem: widgetGridItem1
         });
 
-        expect(component.widgetGridItems).toEqual([{
+        expect(component.tabbedGrid[0].list).toEqual([{
             col: 2,
             config: {
                 borderSize: 10,
@@ -357,7 +357,7 @@ describe('App', () => {
             widgetGridItem: widgetGridItem1
         });
 
-        expect(component.widgetGridItems).toEqual([{
+        expect(component.tabbedGrid[0].list).toEqual([{
             config: {
                 borderSize: 10,
                 col: 1,
@@ -377,7 +377,7 @@ describe('App', () => {
             widgetGridItem: widgetGridItem2
         });
 
-        expect(component.widgetGridItems).toEqual([{
+        expect(component.tabbedGrid[0].list).toEqual([{
             config: {
                 borderSize: 10,
                 col: 1,
@@ -407,7 +407,7 @@ describe('App', () => {
             widgetGridItem: widgetGridItem3
         });
 
-        expect(component.widgetGridItems).toEqual([{
+        expect(component.tabbedGrid[0].list).toEqual([{
             config: {
                 borderSize: 10,
                 col: 1,
@@ -447,7 +447,7 @@ describe('App', () => {
             widgetGridItem: widgetGridItem4
         });
 
-        expect(component.widgetGridItems).toEqual([{
+        expect(component.tabbedGrid[0].list).toEqual([{
             config: {
                 borderSize: 10,
                 col: 1,
@@ -491,7 +491,7 @@ describe('App', () => {
     }));
 
     it('addWidget does set the position of the given widget with unspecified position and add it to the middle of the grid', async(() => {
-        component.widgetGridItems = [{
+        component.tabbedGrid[0].list = [{
             config: {
                 borderSize: 10,
                 col: 1,
@@ -541,7 +541,7 @@ describe('App', () => {
             widgetGridItem: widgetGridItem1
         });
 
-        expect(component.widgetGridItems).toEqual([{
+        expect(component.tabbedGrid[0].list).toEqual([{
             config: {
                 borderSize: 10,
                 col: 1,
@@ -595,7 +595,7 @@ describe('App', () => {
     }));
 
     it('clearDashboard does delete all elements from the grid', async(() => {
-        component.widgetGridItems = [{
+        component.tabbedGrid[0].list = [{
             config: {
                 borderSize: 10,
                 col: 1,
@@ -619,7 +619,7 @@ describe('App', () => {
 
         component.clearDashboard();
 
-        expect(component.widgetGridItems).toEqual([]);
+        expect(component.tabbedGrid[0].list).toEqual([]);
     }));
 
     it('contractWidget does update the size and position of the given widget to its previous config', async(() => {
@@ -659,7 +659,7 @@ describe('App', () => {
     }));
 
     it('deleteWidget does delete the widget from the grid', async(() => {
-        component.widgetGridItems = [{
+        component.tabbedGrid[0].list = [{
             config: {
                 borderSize: 10,
                 col: 1,
@@ -685,7 +685,7 @@ describe('App', () => {
             id: 'a'
         });
 
-        expect(component.widgetGridItems).toEqual([{
+        expect(component.tabbedGrid[0].list).toEqual([{
             config: {
                 borderSize: 10,
                 col: 2,
@@ -733,7 +733,7 @@ describe('App', () => {
     it('getMaxColInUse does return expected number', async(() => {
         expect(component.getMaxColInUse()).toEqual(0);
 
-        component.widgetGridItems = [{
+        component.tabbedGrid[0].list = [{
             config: {
                 borderSize: 10,
                 col: 1,
@@ -747,7 +747,7 @@ describe('App', () => {
 
         expect(component.getMaxColInUse()).toEqual(1);
 
-        component.widgetGridItems = [{
+        component.tabbedGrid[0].list = [{
             config: {
                 borderSize: 10,
                 col: 1,
@@ -775,7 +775,7 @@ describe('App', () => {
     it('getMaxRowInUse does return expected number', async(() => {
         expect(component.getMaxRowInUse()).toEqual(0);
 
-        component.widgetGridItems = [{
+        component.tabbedGrid[0].list = [{
             config: {
                 borderSize: 10,
                 col: 1,
@@ -789,7 +789,7 @@ describe('App', () => {
 
         expect(component.getMaxRowInUse()).toEqual(1);
 
-        component.widgetGridItems = [{
+        component.tabbedGrid[0].list = [{
             config: {
                 borderSize: 10,
                 col: 1,
@@ -830,7 +830,7 @@ describe('App', () => {
 
         expect(widgetGridItem1.config.row).toEqual(1);
 
-        component.widgetGridItems = [{
+        component.tabbedGrid[0].list = [{
             config: {
                 borderSize: 10,
                 col: 1,
@@ -949,7 +949,7 @@ describe('App', () => {
 
         expect(component.widgetFits(widgetGridItem1)).toEqual(true);
 
-        component.widgetGridItems = [{
+        component.tabbedGrid[0].list = [{
             config: {
                 borderSize: 10,
                 col: 1,
@@ -963,7 +963,7 @@ describe('App', () => {
 
         expect(component.widgetFits(widgetGridItem1)).toEqual(true);
 
-        component.widgetGridItems = [{
+        component.tabbedGrid[0].list = [{
             config: {
                 borderSize: 10,
                 col: 1,
@@ -977,7 +977,7 @@ describe('App', () => {
 
         expect(component.widgetFits(widgetGridItem1)).toEqual(false);
 
-        component.widgetGridItems = [{
+        component.tabbedGrid[0].list = [{
             config: {
                 borderSize: 10,
                 col: 2,
@@ -991,7 +991,7 @@ describe('App', () => {
 
         expect(component.widgetFits(widgetGridItem1)).toEqual(false);
 
-        component.widgetGridItems = [{
+        component.tabbedGrid[0].list = [{
             config: {
                 borderSize: 10,
                 col: 1,
@@ -1015,7 +1015,7 @@ describe('App', () => {
 
         expect(component.widgetFits(widgetGridItem1)).toEqual(true);
 
-        component.widgetGridItems = [{
+        component.tabbedGrid[0].list = [{
             config: {
                 borderSize: 10,
                 col: 1,

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -188,7 +188,7 @@ export class AppComponent implements AfterViewInit, OnInit, OnDestroy {
      *
      * @arg {{widgetGridItem:NeonGridItem}} eventMessage
      */
-    addWidget(eventMessage: { gridName: string, widgetGridItem: NeonGridItem }) {
+    addWidget(eventMessage: { gridName?: string, widgetGridItem: NeonGridItem }) {
         let widgetGridItem: NeonGridItem = eventMessage.widgetGridItem;
 
         // Set default grid item config properties for the Neon dashboard.
@@ -206,7 +206,7 @@ export class AppComponent implements AfterViewInit, OnInit, OnDestroy {
         // Find the right tab, or create a new one if needed.
         let index = -1;
         this.tabbedGrid.forEach((grid, i) => {
-            if (grid.name === eventMessage.gridName) {
+            if (grid.name === (eventMessage.gridName || '')) {
                 index = i;
             }
         });
@@ -218,7 +218,7 @@ export class AppComponent implements AfterViewInit, OnInit, OnDestroy {
 
             this.tabbedGrid.push({
                 list: [],
-                name: eventMessage.gridName
+                name: (eventMessage.gridName || '')
             });
             index = this.tabbedGrid.length - 1;
         }

--- a/src/app/components/dataset-selector/dataset-selector.component.ts
+++ b/src/app/components/dataset-selector/dataset-selector.component.ts
@@ -112,7 +112,6 @@ export class DatasetSelectorComponent implements OnInit, OnDestroy {
         info: '',
         data: false
     };
-    @Output() gridItemsChanged: EventEmitter<number> = new EventEmitter<number>();
     @Output() activeDatasetChanged: EventEmitter<any> = new EventEmitter<any>();
 
     private messenger: neon.eventing.Messenger;
@@ -175,13 +174,24 @@ export class DatasetSelectorComponent implements OnInit, OnDestroy {
                     }
 
                     this.messenger.publish(neonEvents.DASHBOARD_CLEAR, {});
-                    message.dashboard.forEach((widgetGridItem) => {
-                        this.messenger.publish(neonEvents.WIDGET_ADD, {
-                            widgetGridItem: widgetGridItem
+
+                    let gridNameToLayout = !Array.isArray(this.layouts[layoutName]) ? this.layouts[layoutName] : {
+                        '': this.layouts[layoutName]
+                    };
+
+                    // Recreate the layout each time to ensure all visualizations are using the new dataset.
+                    // Use an empty array of visualizations if the new dataset has no defined layout.
+                    Object.keys(gridNameToLayout).forEach((gridName) => {
+                        let layout = gridNameToLayout[gridName];
+                        layout.forEach((widgetGridItem) => {
+                            this.messenger.publish(neonEvents.WIDGET_ADD, {
+                                gridName: gridName,
+                                widgetGridItem: _.cloneDeep(widgetGridItem)
+                            });
                         });
                     });
+
                     this.activeDatasetChanged.emit(this.activeDataset);
-                    this.gridItemsChanged.emit(message.dashboard.length);
                 }
             }
         });
@@ -244,22 +254,29 @@ export class DatasetSelectorComponent implements OnInit, OnDestroy {
      */
     updateLayout(loadDashboardState: boolean) {
         let layoutName = this.datasetService.getLayout();
-        let layout = this.layouts[layoutName] || [];
+        let layoutConfig = this.layouts[layoutName] || [];
 
         // Clear any old filters prior to loading the new layout and dataset.
         this.messenger.clearFiltersSilently();
 
         this.messenger.publish(neonEvents.DASHBOARD_CLEAR, {});
 
+        let gridNameToLayout = !Array.isArray(layoutConfig) ? layoutConfig : {
+            '': layoutConfig
+        };
+
         // Recreate the layout each time to ensure all visualizations are using the new dataset.
         // Use an empty array of visualizations if the new dataset has no defined layout.
-        for (let widgetGridItem of layout) {
-            this.messenger.publish(neonEvents.WIDGET_ADD, {
-                widgetGridItem: _.cloneDeep(widgetGridItem)
+        Object.keys(gridNameToLayout).forEach((gridName) => {
+            let layout = gridNameToLayout[gridName];
+            layout.forEach((widgetGridItem) => {
+                this.messenger.publish(neonEvents.WIDGET_ADD, {
+                    gridName: gridName,
+                    widgetGridItem: _.cloneDeep(widgetGridItem)
+                });
             });
-        }
+        });
 
-        this.gridItemsChanged.emit(layout.length);
         this.activeDatasetChanged.emit(this.activeDataset);
         this.parameterService.addFiltersFromUrl(!loadDashboardState);
     }

--- a/src/app/components/dataset-selector/dataset-selector.component.ts
+++ b/src/app/components/dataset-selector/dataset-selector.component.ts
@@ -182,7 +182,7 @@ export class DatasetSelectorComponent implements OnInit, OnDestroy {
                     // Recreate the layout each time to ensure all visualizations are using the new dataset.
                     // Use an empty array of visualizations if the new dataset has no defined layout.
                     Object.keys(gridNameToLayout).forEach((gridName) => {
-                        let layout = gridNameToLayout[gridName];
+                        let layout = gridNameToLayout[gridName] || [];
                         layout.forEach((widgetGridItem) => {
                             this.messenger.publish(neonEvents.WIDGET_ADD, {
                                 gridName: gridName,
@@ -268,7 +268,7 @@ export class DatasetSelectorComponent implements OnInit, OnDestroy {
         // Recreate the layout each time to ensure all visualizations are using the new dataset.
         // Use an empty array of visualizations if the new dataset has no defined layout.
         Object.keys(gridNameToLayout).forEach((gridName) => {
-            let layout = gridNameToLayout[gridName];
+            let layout = gridNameToLayout[gridName] || [];
             layout.forEach((widgetGridItem) => {
                 this.messenger.publish(neonEvents.WIDGET_ADD, {
                     gridName: gridName,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -394,7 +394,13 @@ body {
 .mat-tab-label {
     height: 30px !important;
     min-width: unset !important;
+    opacity: unset !important;
     padding: 5px 10px !important;
+}
+
+.mat-tab-label:hover,
+.mat-tab-label-active {
+    background-color: var(--color-background-contrast);
 }
 
 .mat-toolbar {


### PR DESCRIPTION
Stacey, here are the changes that I implemented to support full-dashboard tabs on VMAP.  Please take a look and see if they are useful to you on AIDA.

The old config file "layouts" syntax still works, so this merge won't break any our your existing configs:

```
layouts: {
  layoutName: [{
    // widget 1
  }, {
    // widget 2
  }]
}
```

Optionally, you can nest any layout within named tab objects to create tabs in the dashboard:

```
layouts: {
  layoutName: {
    tabAName: [{
      // widget 1
    }, {
      // widget 2
    }],
    tabBName: [{
      // widget 3
    }, {
      // widget 4
    }]
  }
}
```

Known issues:
- Switching tabs doesn't clear the filters (though we could probably add a call to filterService.clearFilters pretty easily).
- Switching tabs doesn't save any config/layout changes you've made.

Please let me know if you have any questions.  Thanks!