### PR TITLE
Install neon-framework from Github

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "lodash": "4.15.0",
     "moment": "2.18.1",
     "moment-timezone": "0.5.13",
-    "neon-framework": "1.3.5",
+    "neon-framework": "git+https://github.com/NextCenturyCorporation/neon-framework.git",
     "npm-license-crawler": "^0.1.9",
     "reflect-metadata": "0.1.10",
     "requirejs": "2.3.5",


### PR DESCRIPTION
Extracted the Neon framework client from the server repo. This points Neon dash to the new code.