### PR TITLE
THOR-1046 Fix Database, Table, and Layer Changes in Gear Component

### DIFF
--- a/src/app/components/annotation-viewer/annotation-viewer.component.ts
+++ b/src/app/components/annotation-viewer/annotation-viewer.component.ts
@@ -876,7 +876,7 @@ export class AnnotationViewerComponent extends BaseNeonComponent implements OnIn
 
             // This will ignore a filter with multiple clauses.
             if (!neonFilter.filter.whereClause.whereClauses) {
-                let field = this.findField(this.options.fields, neonFilter.filter.whereClause.lhs);
+                let field = this.options.findField(neonFilter.filter.whereClause.lhs);
                 let value = neonFilter.filter.whereClause.rhs;
                 if (this.isVisualizationFilterUnique(field.columnName, value)) {
                     this.addVisualizationFilter(this.createVisualizationFilter(neonFilter.id, field.columnName, field.prettyName, value));

--- a/src/app/components/data-table/data-table.component.ts
+++ b/src/app/components/data-table/data-table.component.ts
@@ -262,7 +262,7 @@ export class DataTableComponent extends BaseNeonComponent implements OnInit, OnD
     initializeHeadersFromFieldsConfig() {
         let existingFields = [];
         for (let fieldConfig of this.options.fieldsConfig) {
-            let fieldObject = this.findField(this.options.fields, fieldConfig.name);
+            let fieldObject = this.options.findField(fieldConfig.name);
             if (fieldObject && fieldObject.columnName) {
                 existingFields.push(fieldObject.columnName);
                 this.headers.push({
@@ -295,7 +295,7 @@ export class DataTableComponent extends BaseNeonComponent implements OnInit, OnD
      */
     getColumnWidth(fieldConfig) {
         for (let miniArray of this.options.customColumnWidths) {
-            let name = this.translateFieldKeyToValue(miniArray[0]);
+            let name = this.datasetService.translateFieldKeyToValue(miniArray[0]);
             if (fieldConfig === name) {
                 return miniArray[1];
             }
@@ -341,7 +341,7 @@ export class DataTableComponent extends BaseNeonComponent implements OnInit, OnD
         let colName = header.columnName;
         let pName = header.prettyName;
         for (let exception of this.options.exceptionsToStatus) {
-            let name = this.translateFieldKeyToValue(exception);
+            let name = this.datasetService.translateFieldKeyToValue(exception);
             if (colName === name || pName === name) {
                 return true;
             }
@@ -352,7 +352,7 @@ export class DataTableComponent extends BaseNeonComponent implements OnInit, OnD
     sortOrderedHeaders(unordered) {
         let sorted = [];
         for (let exception of this.options.exceptionsToStatus) {
-            let header = this.translateFieldKeyToValue(exception);
+            let header = this.datasetService.translateFieldKeyToValue(exception);
             let headerToPush = this.getHeaderByName(header, unordered);
             if (headerToPush !== null) {
                 sorted.push(headerToPush);
@@ -593,7 +593,7 @@ export class DataTableComponent extends BaseNeonComponent implements OnInit, OnD
         this.filters = [];
         for (let neonFilter of neonFilters) {
             if (!neonFilter.filter.whereClause.whereClauses) {
-                let field = this.findField(this.options.fields, neonFilter.filter.whereClause.lhs);
+                let field = this.options.findField(neonFilter.filter.whereClause.lhs);
                 let value = neonFilter.filter.whereClause.rhs;
                 this.addLocalFilter({
                     id: neonFilter.id,
@@ -732,7 +732,7 @@ export class DataTableComponent extends BaseNeonComponent implements OnInit, OnD
                 obj[this.options.idField.columnName] === selected[0][this.options.idField.columnName])[0];
 
             this.options.filterFields.forEach((filterField: any) => {
-                let filterFieldObject = this.findField(this.options.fields, filterField.columnName);
+                let filterFieldObject = this.options.findField(filterField.columnName);
                 let value = (this.options.idField.columnName.length === 0) ? selected[0][filterFieldObject.columnName] :
                     dataObject[filterFieldObject.columnName];
                 let filter = this.createFilterObject(filterFieldObject.columnName, value, filterFieldObject.prettyName);

--- a/src/app/components/document-viewer/document-viewer.component.ts
+++ b/src/app/components/document-viewer/document-viewer.component.ts
@@ -279,7 +279,7 @@ export class DocumentViewerComponent extends BaseNeonComponent implements OnInit
         let activeItemText = this.createTableRowText(activeItemData, arrayFilter);
         if (activeItemText) {
             activeItem.rows.push({
-                name: name || (this.findField(this.options.fields, field) || this.createEmptyField()).prettyName || field,
+                name: name || (this.options.findField(field) || this.createEmptyField()).prettyName || field,
                 text: activeItemText
             });
         }

--- a/src/app/components/filter-builder/filter-builder.component.spec.ts
+++ b/src/app/components/filter-builder/filter-builder.component.spec.ts
@@ -80,7 +80,7 @@ describe('Component: Filter Builder', () => {
         expect(component.clauses[0].operator.value).toEqual('contains');
         expect(component.clauses[0].value).toEqual('');
         expect(component.clauses[0].active).toEqual(false);
-        expect(component.clauses[0].id).toEqual(1);
+        expect(component.clauses[0]._id).toBeDefined();
         expect(component.clauses[0].changeDatabase).toEqual(DatasetServiceMock.DATABASES[0]);
         expect(component.clauses[0].changeTable).toEqual(DatasetServiceMock.TABLES[0]);
         expect(component.clauses[0].changeField).toEqual(new FieldMetaData());
@@ -106,7 +106,7 @@ describe('Component: Filter Builder', () => {
         expect(component.clauses[1].operator.value).toEqual('contains');
         expect(component.clauses[1].value).toEqual('');
         expect(component.clauses[1].active).toEqual(false);
-        expect(component.clauses[1].id).toEqual(2);
+        expect(component.clauses[1]._id).toBeDefined();
         expect(component.clauses[1].changeDatabase).toEqual(DatasetServiceMock.DATABASES[0]);
         expect(component.clauses[1].changeTable).toEqual(DatasetServiceMock.TABLES[0]);
         expect(component.clauses[1].changeField).toEqual(new FieldMetaData());
@@ -380,7 +380,7 @@ describe('Component: Filter Builder with config', () => {
         expect(component.clauses[0].operator.value).toEqual('=');
         expect(component.clauses[0].value).toEqual('testTextValue');
         expect(component.clauses[0].active).toEqual(true);
-        expect(component.clauses[0].id).toEqual(1);
+        expect(component.clauses[0]._id).toBeDefined();
         expect(component.clauses[0].changeDatabase).toEqual(DatasetServiceMock.DATABASES[1]);
         expect(component.clauses[0].changeTable).toEqual(DatasetServiceMock.TABLES[1]);
         expect(component.clauses[0].changeField).toEqual(DatasetServiceMock.TEXT_FIELD);

--- a/src/app/components/filter-builder/filter-builder.component.ts
+++ b/src/app/components/filter-builder/filter-builder.component.ts
@@ -35,6 +35,7 @@ import {
     WidgetFieldOption,
     WidgetNonPrimitiveOption,
     WidgetOption,
+    WidgetOptionCollection,
     WidgetSelectOption
 } from '../../widget-option';
 import * as neon from 'neon-framework';
@@ -60,8 +61,6 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
         { value: '<=', prettyName: '<=' }
     ];
 
-    public counter: number = 0;
-
     constructor(
         datasetService: DatasetService,
         filterService: FilterService,
@@ -83,14 +82,14 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
      * Adds a blank filter clause to the global list.
      */
     addBlankFilterClause() {
-        let clause: FilterClauseMetaData = this.updateDatabasesInOptions(new FilterClauseMetaData());
+        let clause: FilterClauseMetaData = new FilterClauseMetaData(() => []);
+        clause.updateDatabases(this.datasetService);
         clause.database = this.options.database;
         clause.table = this.options.table;
         clause.field = this.createEmptyField();
         clause.operator = this.operators[0];
         clause.value = '';
         clause.active = false;
-        clause.id = ++this.counter;
         clause.changeDatabase = clause.database;
         clause.changeTable = clause.table;
         clause.changeField = clause.field;
@@ -333,7 +332,7 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
 
         clause.active = false;
         clause.database = clause.changeDatabase;
-        this.updateTablesInOptions(clause);
+        clause.updateTables(this.datasetService);
         clause.changeTable = clause.table;
 
         if (this.databaseTableFieldKeysToFilterIds.get(databaseTableFieldKey)) {
@@ -383,7 +382,7 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
 
         clause.active = false;
         clause.table = clause.changeTable;
-        this.updateFieldsInOptions(clause);
+        clause.updateFields(this.datasetService);
 
         if (this.databaseTableFieldKeysToFilterIds.get(databaseTableFieldKey)) {
             this.updateFiltersOfKey(databaseTableFieldKey);
@@ -409,15 +408,16 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
         });
 
         this.options.clauseConfig.forEach((clauseConfig) => {
-            let clause: FilterClauseMetaData = this.updateDatabasesInOptions(new FilterClauseMetaData());
+            let clause: FilterClauseMetaData = new FilterClauseMetaData(() => []);
+            clause.updateDatabases(this.datasetService);
             clause.database = clause.databases.find((database) => {
                 return database.name === clauseConfig.database;
             });
-            this.updateTablesInOptions(clause);
+            clause.updateTables(this.datasetService);
             clause.table = clause.tables.find((table) => {
                 return table.name === clauseConfig.table;
             });
-            this.updateFieldsInOptions(clause);
+            clause.updateFields(this.datasetService);
             clause.field = clause.fields.find((field) => {
                 return field.columnName === clauseConfig.field;
             });
@@ -426,7 +426,6 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
             });
             clause.value = clauseConfig.value;
             clause.active = true;
-            clause.id = ++this.counter;
             clause.changeDatabase = clause.database;
             clause.changeTable = clause.table;
             clause.changeField = clause.field;
@@ -461,7 +460,7 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
      */
     removeClause(clause: FilterClauseMetaData) {
         this.clauses = this.clauses.filter((clauseFromList) => {
-            return clause.id !== clauseFromList.id;
+            return clause._id !== clauseFromList._id;
         });
 
         let databaseTableFieldKey = this.getDatabaseTableFieldKey(clause.database.name, clause.table.name,
@@ -628,19 +627,13 @@ class OperatorMetaData {
     prettyName: string;
 }
 
-class FilterClauseMetaData {
+class FilterClauseMetaData extends WidgetOptionCollection {
     active: boolean;
     changeDatabase: DatabaseMetaData;
     changeTable: TableMetaData;
     changeField: FieldMetaData;
-    database: DatabaseMetaData;
-    databases: DatabaseMetaData[] = [];
     field: FieldMetaData;
-    fields: FieldMetaData[] = [];
-    id: number;
     operator: OperatorMetaData;
-    table: TableMetaData;
-    tables: TableMetaData[] = [];
     value: string;
 }
 

--- a/src/app/components/gear/gear.component.html
+++ b/src/app/components/gear/gear.component.html
@@ -1,11 +1,11 @@
 <form class="gear-container" #optionsFOrm="ngForm">
     <mat-form-field class="option-container">
-        <input matInput placeholder="Title" [(ngModel)]="modifiedOptions.title" (ngModelChange)="updateGearMenuOnDataChange('title')" [name]="modifiedOptions._id + '_title'" required="false">
+        <input matInput placeholder="Title" [(ngModel)]="modifiedOptions.title" (ngModelChange)="updateOnChange('title')" [name]="modifiedOptions._id + '_title'" required="false">
     </mat-form-field>
 
     <!-- MultiLayer Support-->
     <div *ngIf="modifiedOptions.isMultiLayerWidget">
-        <mat-toolbar class="subheader tappable" color="primary" (click)="handleAddLayer()">
+        <mat-toolbar class="subheader tappable" color="primary" (click)="handleCreateLayer()">
             <mat-icon class="neon-icon-small">add_circle</mat-icon>
             <span class="spacer"></span>
             <div>Add Layer</div>
@@ -15,13 +15,13 @@
             <mat-toolbar class="subheader tappable" color="primary" (click)="toggleFilter(layer)">
                 <span>{{ layer.title }}</span>
                 <span class="spacer" *ngIf="modifiedOptions.layers.length > 1"></span>
-                <mat-icon class="neon-icon-small" *ngIf="modifiedOptions.layers.length > 1" (click)="handleRemoveLayer(layer)">delete</mat-icon>
+                <mat-icon class="neon-icon-small" *ngIf="modifiedOptions.layers.length > 1" (click)="handleDeleteLayer(layer)">delete</mat-icon>
                 <span class="spacer"></span>
                 <mat-icon class="neon-icon-small">{{ getIconForFilter(layer) }}</mat-icon>
             </mat-toolbar>
-            <div class="option-well" [hidden]="layerVisible.get(layer._id)">
+            <div class="option-well" [hidden]="layerHidden.get(layer._id)">
                 <mat-form-field class="option-container">
-                    <input matInput placeholder="Title" [(ngModel)]="layer.title" (ngModelChange)="updateGearMenuOnDataChange('title')" [name]="layer._id + '_title'" required="false">
+                    <input matInput placeholder="Title" [(ngModel)]="layer.title" (ngModelChange)="updateOnChange('title')" [name]="layer._id + '_title'" required="false">
                 </mat-form-field>
 
                 <mat-form-field class="option-container">
@@ -38,7 +38,7 @@
                     </mat-select>
                 </mat-form-field>
 
-                <app-options-list [options]=layer [fields]=layer.fields [bindingsList]=getLayerList(layer) [updateOnChange]=updateGearMenuOnDataChange.bind(this) [index]=i>
+                <app-options-list [options]=layer [fields]=layer.fields [bindingsList]=getLayerList(layer) [updateOnChange]=updateOnChange.bind(this) [index]=i>
                 </app-options-list>
             </div>
         </div>
@@ -65,11 +65,11 @@
         </mat-form-field>
 
         <!-- Required Field Config-->
-        <app-options-list [options]=modifiedOptions [fields]=modifiedOptions.fields [bindingsList]=requiredList [updateOnChange]=updateGearMenuOnDataChange.bind(this)>
+        <app-options-list [options]=modifiedOptions [fields]=modifiedOptions.fields [bindingsList]=requiredList [updateOnChange]=updateOnChange.bind(this)>
         </app-options-list>
 
         <!-- Required Non-Field Config-->
-        <app-options-list [options]=modifiedOptions [fields]=modifiedOptions.fields [bindingsList]=requiredListNonField [updateOnChange]=updateGearMenuOnDataChange.bind(this)>
+        <app-options-list [options]=modifiedOptions [fields]=modifiedOptions.fields [bindingsList]=requiredListNonField [updateOnChange]=updateOnChange.bind(this)>
         </app-options-list>
     </div>
 
@@ -81,11 +81,11 @@
 
     <div class="option-well" [hidden]="collapseOptionalOptions">
         <!-- Optional Field Config-->
-        <app-options-list [options]=modifiedOptions [fields]=modifiedOptions.fields [bindingsList]=optionalList [updateOnChange]=updateGearMenuOnDataChange.bind(this)>
+        <app-options-list [options]=modifiedOptions [fields]=modifiedOptions.fields [bindingsList]=optionalList [updateOnChange]=updateOnChange.bind(this)>
         </app-options-list>
 
         <!-- Optional Non-Field Config-->
-        <app-options-list [options]=modifiedOptions [fields]=modifiedOptions.fields [bindingsList]=optionalListNonField [updateOnChange]=updateGearMenuOnDataChange.bind(this)>
+        <app-options-list [options]=modifiedOptions [fields]=modifiedOptions.fields [bindingsList]=optionalListNonField [updateOnChange]=updateOnChange.bind(this)>
         </app-options-list>
     </div>
 
@@ -93,7 +93,7 @@
 </form>
 
 <div class="button-footer" align="right">
-    <button mat-raised-button class="neon-button-large" color="primary" (click)="resetChangeList()">
+    <button mat-raised-button class="neon-button-large" color="primary" (click)="resetOptionsAndClose()">
         Cancel
     </button>
     <button mat-raised-button class="neon-button-large" color="primary" [disabled]="!changeMade" (click)="handleApplyClick()">

--- a/src/app/components/gear/gear.component.html
+++ b/src/app/components/gear/gear.component.html
@@ -1,30 +1,44 @@
 <form class="gear-container" #optionsFOrm="ngForm">
     <mat-form-field class="option-container">
-        <input matInput placeholder="Title" [(ngModel)]="options.title" name="Title" required="false">
+        <input matInput placeholder="Title" [(ngModel)]="modifiedOptions.title" (ngModelChange)="updateGearMenuOnDataChange('title')" [name]="modifiedOptions._id + '_title'" required="false">
     </mat-form-field>
 
     <!-- MultiLayer Support-->
-    <div *ngIf="options.isMultiLayerWidget">
-        <mat-toolbar class="subheader tappable" color="primary" (click)="addLayer()">
+    <div *ngIf="modifiedOptions.isMultiLayerWidget">
+        <mat-toolbar class="subheader tappable" color="primary" (click)="handleAddLayer()">
             <mat-icon class="neon-icon-small">add_circle</mat-icon>
             <span class="spacer"></span>
             <div>Add Layer</div>
         </mat-toolbar>
 
-        <div *ngFor="let layer of options.layers; let i = index;">
+        <div *ngFor="let layer of modifiedOptions.layers; let i = index;">
             <mat-toolbar class="subheader tappable" color="primary" (click)="toggleFilter(layer)">
                 <span>{{ layer.title }}</span>
-                <span class="spacer" *ngIf="options.layers.length > 1"></span>
-                <mat-icon class="neon-icon-small" *ngIf="options.layers.length > 1" (click)="removeLayer(layer)">delete</mat-icon>
+                <span class="spacer" *ngIf="modifiedOptions.layers.length > 1"></span>
+                <mat-icon class="neon-icon-small" *ngIf="modifiedOptions.layers.length > 1" (click)="handleRemoveLayer(layer)">delete</mat-icon>
                 <span class="spacer"></span>
                 <mat-icon class="neon-icon-small">{{ getIconForFilter(layer) }}</mat-icon>
             </mat-toolbar>
             <div class="option-well" [hidden]="layerVisible.get(layer._id)">
-                <app-options-list [databases]=layer.databases [fields]=layer.fields [tables]=layer.tables
-                    [optionsList]=getLayerList(layer) [handleChangeData]=handleChangeData [handleChangeDatabase]=handleChangeDatabase
-                    [handleChangeLimit]=handleChangeLimit [handleChangeFilterField]=handleChangeFilterField
-                    [handleChangeSubcomponentType]=handleChangeSubcomponentType [handleChangeTable]=handleChangeTable
-                    [handleDataChange]=handleDataChange.bind(this) [index]=i>
+                <mat-form-field class="option-container">
+                    <input matInput placeholder="Title" [(ngModel)]="layer.title" (ngModelChange)="updateGearMenuOnDataChange('title')" [name]="layer._id + '_title'" required="false">
+                </mat-form-field>
+
+                <mat-form-field class="option-container">
+                    <mat-select placeholder="Database" [(ngModel)]="layer.database" required="true" [name]="layer._id + '_database'"
+                        (ngModelChange)="handleChangeDatabase(layer)" [disabled]="layer.databases.length < 2">
+                        <mat-option *ngFor="let database of layer.databases" [value]="database">{{ database.prettyName }}</mat-option>
+                    </mat-select>
+                </mat-form-field>
+
+                <mat-form-field class="option-container">
+                    <mat-select placeholder="Table" [(ngModel)]="layer.table" required="true" [name]="layer._id + '_table'"
+                        (ngModelChange)="handleChangeTable(layer)" [disabled]="layer.tables.length < 2">
+                        <mat-option *ngFor="let table of layer.tables" [value]="table">{{ table.prettyName }}</mat-option>
+                    </mat-select>
+                </mat-form-field>
+
+                <app-options-list [options]=layer [fields]=layer.fields [bindingsList]=getLayerList(layer) [updateOnChange]=updateGearMenuOnDataChange.bind(this) [index]=i>
                 </app-options-list>
             </div>
         </div>
@@ -36,32 +50,26 @@
 
     <!-- Non MultiLayer Support-->
     <div class="option-well">
-        <mat-form-field *ngIf=!options.isMultiLayerWidget class="option-container">
-            <mat-select placeholder="Database" [(ngModel)]="options.database" required="true" name="database"
-                (ngModelChange)="handleChangeDatabase(options)" [disabled]="options.databases.length < 2">
-                <mat-option *ngFor="let database of options.databases" [value]="database">{{ database.prettyName }}</mat-option>
+        <mat-form-field *ngIf=!modifiedOptions.isMultiLayerWidget class="option-container">
+            <mat-select placeholder="Database" [(ngModel)]="modifiedOptions.database" required="true" [name]="modifiedOptions._id + '_database'"
+                (ngModelChange)="handleChangeDatabase(modifiedOptions)" [disabled]="modifiedOptions.databases.length < 2">
+                <mat-option *ngFor="let database of modifiedOptions.databases" [value]="database">{{ database.prettyName }}</mat-option>
             </mat-select>
         </mat-form-field>
 
-        <mat-form-field *ngIf=!options.isMultiLayerWidget class="option-container">
-            <mat-select placeholder="Table" [(ngModel)]="options.table" required="true" name="table" (ngModelChange)="handleChangeTable(options)"
-                [disabled]="options.tables.length < 2">
-                <mat-option *ngFor="let table of options.tables" [value]="table">{{ table.prettyName }}</mat-option>
+        <mat-form-field *ngIf=!modifiedOptions.isMultiLayerWidget class="option-container">
+            <mat-select placeholder="Table" [(ngModel)]="modifiedOptions.table" required="true" [name]="modifiedOptions._id + '_table'"
+                (ngModelChange)="handleChangeTable(modifiedOptions)" [disabled]="modifiedOptions.tables.length < 2">
+                <mat-option *ngFor="let table of modifiedOptions.tables" [value]="table">{{ table.prettyName }}</mat-option>
             </mat-select>
         </mat-form-field>
 
         <!-- Required Field Config-->
-        <app-options-list [databases]=options.databases [fields]=options.fields [tables]=options.tables [optionsList]=requiredList
-            [handleChangeData]=handleChangeData [handleChangeDatabase]=handleChangeDatabase [handleChangeLimit]=handleChangeLimit
-            [handleChangeFilterField]=handleChangeFilterField [handleChangeSubcomponentType]=handleChangeSubcomponentType
-            [handleChangeTable]=handleChangeTable [handleDataChange]=handleDataChange.bind(this)>
+        <app-options-list [options]=modifiedOptions [fields]=modifiedOptions.fields [bindingsList]=requiredList [updateOnChange]=updateGearMenuOnDataChange.bind(this)>
         </app-options-list>
 
         <!-- Required Non-Field Config-->
-        <app-options-list [databases]=options.databases [fields]=options.fields [tables]=options.tables [optionsList]=requiredListNonField
-            [handleChangeData]=handleChangeData [handleChangeDatabase]=handleChangeDatabase [handleChangeLimit]=handleChangeLimit
-            [handleChangeFilterField]=handleChangeFilterField [handleChangeSubcomponentType]=handleChangeSubcomponentType
-            [handleChangeTable]=handleChangeTable [handleDataChange]=handleDataChange.bind(this)>
+        <app-options-list [options]=modifiedOptions [fields]=modifiedOptions.fields [bindingsList]=requiredListNonField [updateOnChange]=updateGearMenuOnDataChange.bind(this)>
         </app-options-list>
     </div>
 
@@ -73,17 +81,11 @@
 
     <div class="option-well" [hidden]="collapseOptionalOptions">
         <!-- Optional Field Config-->
-        <app-options-list [databases]=options.databases [fields]=options.fields [tables]=options.tables [optionsList]=optionalList
-            [handleChangeData]=handleChangeData [handleChangeDatabase]=handleChangeDatabase [handleChangeLimit]=handleChangeLimit
-            [handleChangeFilterField]=handleChangeFilterField [handleChangeSubcomponentType]=handleChangeSubcomponentType
-            [handleChangeTable]=handleChangeTable [handleDataChange]=handleDataChange.bind(this)>
+        <app-options-list [options]=modifiedOptions [fields]=modifiedOptions.fields [bindingsList]=optionalList [updateOnChange]=updateGearMenuOnDataChange.bind(this)>
         </app-options-list>
 
         <!-- Optional Non-Field Config-->
-        <app-options-list [databases]=options.databases [fields]=options.fields [tables]=options.tables [optionsList]=optionalListNonField
-            [handleChangeData]=handleChangeData [handleChangeDatabase]=handleChangeDatabase [handleChangeLimit]=handleChangeLimit
-            [handleChangeFilterField]=handleChangeFilterField [handleChangeSubcomponentType]=handleChangeSubcomponentType
-            [handleChangeTable]=handleChangeTable [handleDataChange]=handleDataChange.bind(this)>
+        <app-options-list [options]=modifiedOptions [fields]=modifiedOptions.fields [bindingsList]=optionalListNonField [updateOnChange]=updateGearMenuOnDataChange.bind(this)>
         </app-options-list>
     </div>
 
@@ -94,7 +96,7 @@
     <button mat-raised-button class="neon-button-large" color="primary" (click)="resetChangeList()">
         Cancel
     </button>
-    <button mat-raised-button class="neon-button-large" color="primary" [disabled]="disableApplyButton()" (click)="handleApplyClick()">
+    <button mat-raised-button class="neon-button-large" color="primary" [disabled]="!changeMade" (click)="handleApplyClick()">
         Apply Changes
     </button>
 </div>

--- a/src/app/components/gear/gear.component.spec.ts
+++ b/src/app/components/gear/gear.component.spec.ts
@@ -82,7 +82,7 @@ describe('Component: Gear Component', () => {
     });
 
     it('class options properties are set to expected defaults', () => {
-        expect(component.options).toBeDefined();
+        expect(component.modifiedOptions).toBeDefined();
         expect(component.collapseOptionalOptions).toEqual(true);
         expect(component.layerVisible).toBeDefined();
     });
@@ -93,18 +93,10 @@ describe('Component: Gear Component', () => {
         expect(component.getIconForOptions()).toEqual('keyboard_arrow_up');
     });
 
-    it('returns expected title', () => {
-        let title = new WidgetFreeTextOption('title', 'title', 'default title');
-        component.options.inject(title);
-        expect(component.getTitle()).toBeDefined();
-        expect(component.getTitle()).toEqual('default title');
-    });
-
     it('calls expected functions', () => {
-        let spyCSO = spyOn(component, 'cleanShowOptions');
-        let spyCOL = spyOn(component, 'constructOptionsLists');
+        let spy = spyOn(component, 'createGearMenuData');
 
-        let options = new WidgetOptionCollection();
+        let options = new WidgetOptionCollection(() => []);
         let title = new WidgetFreeTextOption('title', 'title', 'default title');
         options.inject(title);
         let message = {
@@ -112,8 +104,7 @@ describe('Component: Gear Component', () => {
         };
 
         component.updateOptions(message);
-        expect(spyCSO).toHaveBeenCalledTimes(1);
-        expect(spyCOL).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('toggleOptionalOptions changes value', () => {

--- a/src/app/components/gear/gear.component.spec.ts
+++ b/src/app/components/gear/gear.component.spec.ts
@@ -44,7 +44,7 @@ import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 import { AbstractWidgetService } from '../../services/abstract.widget.service';
 import { WidgetService } from '../../services/widget.service';
 
-import { WidgetOptionCollection, WidgetFreeTextOption } from '../../widget-option';
+import { OptionChoices, WidgetOptionCollection, WidgetFieldOption, WidgetFreeTextOption, WidgetSelectOption } from '../../widget-option';
 
 /* tslint:disable:component-class-suffix */
 
@@ -82,35 +82,596 @@ describe('Component: Gear Component', () => {
     });
 
     it('class options properties are set to expected defaults', () => {
-        expect(component.modifiedOptions).toBeDefined();
+        expect((component as any).originalOptions).not.toBeDefined();
+        expect(component.changeMade).toEqual(false);
         expect(component.collapseOptionalOptions).toEqual(true);
-        expect(component.layerVisible).toBeDefined();
+        expect(component.layerHidden).toEqual(new Map<string, boolean>());
+        expect(component.modifiedOptions.databases).toEqual([]);
+        expect(component.modifiedOptions.fields).toEqual([]);
+        expect(component.modifiedOptions.layers).toEqual([]);
+        expect(component.modifiedOptions.tables).toEqual([]);
     });
 
-    it('returns correct icon', () => {
+    it('getIconForFilter does return expected string', () => {
+        expect(component.getIconForFilter({
+            _id: 'testId1'
+        })).toEqual('keyboard_arrow_up');
+
+        component.layerHidden.set('testId1', true);
+        expect(component.getIconForFilter({
+            _id: 'testId1'
+        })).toEqual('keyboard_arrow_down');
+        expect(component.getIconForFilter({
+            _id: 'testId2'
+        })).toEqual('keyboard_arrow_up');
+
+        component.layerHidden.set('testId1', false);
+        expect(component.getIconForFilter({
+            _id: 'testId1'
+        })).toEqual('keyboard_arrow_up');
+    });
+
+    it('getIconForOptions does return expected string', () => {
         expect(component.getIconForOptions()).toEqual('keyboard_arrow_down');
         component.collapseOptionalOptions = false;
         expect(component.getIconForOptions()).toEqual('keyboard_arrow_up');
     });
 
-    it('calls expected functions', () => {
-        let spy = spyOn(component, 'createGearMenuData');
+    it('getLayerList does return expected list', () => {
+        let layer: any = new WidgetOptionCollection(() => []);
+        expect(component.getLayerList(layer)).toEqual([]);
 
-        let options = new WidgetOptionCollection(() => []);
-        let title = new WidgetFreeTextOption('title', 'title', 'default title');
-        options.inject(title);
-        let message = {
-            options: options
-        };
-
-        component.updateOptions(message);
-        expect(spy).toHaveBeenCalledTimes(1);
+        layer.append(new WidgetFieldOption('field', '', true));
+        layer.append(new WidgetFreeTextOption('freeText', '', ''));
+        layer.append(new WidgetSelectOption('select', '', false, OptionChoices.NoFalseYesTrue));
+        layer.append(new WidgetSelectOption('hidden', '', false, OptionChoices.NoFalseYesTrue, false));
+        expect(component.getLayerList(layer)).toEqual(['field', 'freeText', 'select']);
     });
 
-    it('toggleOptionalOptions changes value', () => {
+    it('handleApplyClick with non-field change does update originalOptions and call handleChangeData', () => {
+        let calledChangeData: number = 0;
+        (component as any).handleChangeData = () => {
+            calledChangeData++;
+        };
+        let calledChangeFilterData: number = 0;
+        (component as any).handleChangeFilterData = () => {
+            calledChangeFilterData++;
+        };
+        let calledCloseSidenav: number = 0;
+        (component as any).closeSidenav = () => {
+            calledCloseSidenav++;
+        };
+
+        (component as any).originalOptions = new WidgetOptionCollection(() => []);
+        (component as any).originalOptions.updateDatabases((component as any).datasetService);
+        (component as any).originalOptions.append(new WidgetFreeTextOption('testOption', '', ''), '');
+
+        component.modifiedOptions = new WidgetOptionCollection(() => []);
+        component.modifiedOptions.updateDatabases((component as any).datasetService);
+        component.modifiedOptions.append(new WidgetFreeTextOption('testOption', '', ''), 'testText');
+
+        expect((component as any).originalOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect((component as any).originalOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect((component as any).originalOptions.testOption).toEqual('');
+        expect(component.modifiedOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect(component.modifiedOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect(component.modifiedOptions.testOption).toEqual('testText');
+
+        component.handleApplyClick();
+        expect((component as any).originalOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect((component as any).originalOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect((component as any).originalOptions.testOption).toEqual('testText');
+        expect(calledChangeData).toEqual(1);
+        expect(calledChangeFilterData).toEqual(0);
+        expect(calledCloseSidenav).toEqual(1);
+        expect(component.changeMade).toEqual(false);
+        expect(component.collapseOptionalOptions).toEqual(true);
+        expect(component.layerHidden).toEqual(new Map<string, boolean>());
+        expect(component.modifiedOptions.databases).toEqual([]);
+        expect(component.modifiedOptions.fields).toEqual([]);
+        expect(component.modifiedOptions.layers).toEqual([]);
+        expect(component.modifiedOptions.tables).toEqual([]);
+    });
+
+    it('handleApplyClick with field change does update originalOptions and call handleChangeFilterData', () => {
+        let calledChangeData: number = 0;
+        (component as any).handleChangeData = () => {
+            calledChangeData++;
+        };
+        let calledChangeFilterData: number = 0;
+        (component as any).handleChangeFilterData = () => {
+            calledChangeFilterData++;
+        };
+        let calledCloseSidenav: number = 0;
+        (component as any).closeSidenav = () => {
+            calledCloseSidenav++;
+        };
+
+        (component as any).originalOptions = new WidgetOptionCollection(() => []);
+        (component as any).originalOptions.updateDatabases((component as any).datasetService);
+        (component as any).originalOptions.append(new WidgetFieldOption('testField', '', true), new FieldMetaData());
+
+        component.modifiedOptions = new WidgetOptionCollection(() => []);
+        component.modifiedOptions.updateDatabases((component as any).datasetService);
+        component.modifiedOptions.append(new WidgetFieldOption('testField', '', true), DatasetServiceMock.NAME_FIELD);
+
+        expect((component as any).originalOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect((component as any).originalOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect((component as any).originalOptions.testField).toEqual(new FieldMetaData());
+        expect(component.modifiedOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect(component.modifiedOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect(component.modifiedOptions.testField).toEqual(DatasetServiceMock.NAME_FIELD);
+
+        component.handleApplyClick();
+        expect((component as any).originalOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect((component as any).originalOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect((component as any).originalOptions.testField).toEqual(DatasetServiceMock.NAME_FIELD);
+        expect(calledChangeData).toEqual(0);
+        expect(calledChangeFilterData).toEqual(1);
+        expect(calledCloseSidenav).toEqual(1);
+        expect(component.changeMade).toEqual(false);
+        expect(component.collapseOptionalOptions).toEqual(true);
+        expect(component.layerHidden).toEqual(new Map<string, boolean>());
+        expect(component.modifiedOptions.databases).toEqual([]);
+        expect(component.modifiedOptions.fields).toEqual([]);
+        expect(component.modifiedOptions.layers).toEqual([]);
+        expect(component.modifiedOptions.tables).toEqual([]);
+    });
+
+    it('handleApplyClick with database change does update originalOptions and call handleChangeFilterData', () => {
+        let calledChangeData: number = 0;
+        (component as any).handleChangeData = () => {
+            calledChangeData++;
+        };
+        let calledChangeFilterData: number = 0;
+        (component as any).handleChangeFilterData = () => {
+            calledChangeFilterData++;
+        };
+        let calledCloseSidenav: number = 0;
+        (component as any).closeSidenav = () => {
+            calledCloseSidenav++;
+        };
+
+        (component as any).originalOptions = new WidgetOptionCollection(() => []);
+        (component as any).originalOptions.updateDatabases((component as any).datasetService);
+
+        component.modifiedOptions = new WidgetOptionCollection(() => []);
+        component.modifiedOptions.updateDatabases((component as any).datasetService);
+        component.modifiedOptions.database = DatasetServiceMock.DATABASES[1];
+
+        expect((component as any).originalOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect((component as any).originalOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect(component.modifiedOptions.database).toEqual(DatasetServiceMock.DATABASES[1]);
+        expect(component.modifiedOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+
+        component.handleApplyClick();
+        expect((component as any).originalOptions.database).toEqual(DatasetServiceMock.DATABASES[1]);
+        expect((component as any).originalOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect(calledChangeData).toEqual(0);
+        expect(calledChangeFilterData).toEqual(1);
+        expect(calledCloseSidenav).toEqual(1);
+        expect(component.changeMade).toEqual(false);
+        expect(component.collapseOptionalOptions).toEqual(true);
+        expect(component.layerHidden).toEqual(new Map<string, boolean>());
+        expect(component.modifiedOptions.databases).toEqual([]);
+        expect(component.modifiedOptions.fields).toEqual([]);
+        expect(component.modifiedOptions.layers).toEqual([]);
+        expect(component.modifiedOptions.tables).toEqual([]);
+    });
+
+    it('handleApplyClick with table change does update originalOptions and call handleChangeFilterData', () => {
+        let calledChangeData: number = 0;
+        (component as any).handleChangeData = () => {
+            calledChangeData++;
+        };
+        let calledChangeFilterData: number = 0;
+        (component as any).handleChangeFilterData = () => {
+            calledChangeFilterData++;
+        };
+        let calledCloseSidenav: number = 0;
+        (component as any).closeSidenav = () => {
+            calledCloseSidenav++;
+        };
+
+        (component as any).originalOptions = new WidgetOptionCollection(() => []);
+        (component as any).originalOptions.updateDatabases((component as any).datasetService);
+
+        component.modifiedOptions = new WidgetOptionCollection(() => []);
+        component.modifiedOptions.updateDatabases((component as any).datasetService);
+        component.modifiedOptions.table = DatasetServiceMock.TABLES[1];
+
+        expect((component as any).originalOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect((component as any).originalOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect(component.modifiedOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect(component.modifiedOptions.table).toEqual(DatasetServiceMock.TABLES[1]);
+
+        component.handleApplyClick();
+        expect((component as any).originalOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect((component as any).originalOptions.table).toEqual(DatasetServiceMock.TABLES[1]);
+        expect(calledChangeData).toEqual(0);
+        expect(calledChangeFilterData).toEqual(1);
+        expect(calledCloseSidenav).toEqual(1);
+        expect(component.changeMade).toEqual(false);
+        expect(component.collapseOptionalOptions).toEqual(true);
+        expect(component.layerHidden).toEqual(new Map<string, boolean>());
+        expect(component.modifiedOptions.databases).toEqual([]);
+        expect(component.modifiedOptions.fields).toEqual([]);
+        expect(component.modifiedOptions.layers).toEqual([]);
+        expect(component.modifiedOptions.tables).toEqual([]);
+    });
+
+    it('handleApplyClick with created layer does update originalOptions and call handleChangeData', () => {
+        let calledChangeData: number = 0;
+        (component as any).handleChangeData = () => {
+            calledChangeData++;
+        };
+        let calledChangeFilterData: number = 0;
+        (component as any).handleChangeFilterData = () => {
+            calledChangeFilterData++;
+        };
+        let calledCloseSidenav: number = 0;
+        (component as any).closeSidenav = () => {
+            calledCloseSidenav++;
+        };
+        let calledFinalizeCreate: number = 0;
+        (component as any).finalizeCreateLayer = () => {
+            calledFinalizeCreate++;
+        };
+        let calledFinalizeDelete: number = 0;
+        (component as any).finalizeDeleteLayer = () => {
+            calledFinalizeDelete++;
+        };
+
+        (component as any).originalOptions = new WidgetOptionCollection(() => []);
+        (component as any).originalOptions.updateDatabases((component as any).datasetService);
+
+        component.modifiedOptions = new WidgetOptionCollection(() => []);
+        component.modifiedOptions.updateDatabases((component as any).datasetService);
+
+        let layer: any = new WidgetOptionCollection(() => []);
+        layer.updateDatabases((component as any).datasetService);
+        component.modifiedOptions.layers.push(layer);
+
+        expect((component as any).originalOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect((component as any).originalOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect((component as any).originalOptions.layers.length).toEqual(0);
+        expect(component.modifiedOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect(component.modifiedOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect(component.modifiedOptions.layers.length).toEqual(1);
+        expect(component.modifiedOptions.layers[0]._id).toEqual(layer._id);
+
+        component.handleApplyClick();
+        expect((component as any).originalOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect((component as any).originalOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect((component as any).originalOptions.layers.length).toEqual(1);
+        expect((component as any).originalOptions.layers[0]._id).toEqual(layer._id);
+        expect(calledChangeData).toEqual(1);
+        expect(calledChangeFilterData).toEqual(0);
+        expect(calledCloseSidenav).toEqual(1);
+        expect(calledFinalizeCreate).toEqual(1);
+        expect(calledFinalizeDelete).toEqual(0);
+        expect(component.changeMade).toEqual(false);
+        expect(component.collapseOptionalOptions).toEqual(true);
+        expect(component.layerHidden).toEqual(new Map<string, boolean>());
+        expect(component.modifiedOptions.databases).toEqual([]);
+        expect(component.modifiedOptions.fields).toEqual([]);
+        expect(component.modifiedOptions.layers).toEqual([]);
+        expect(component.modifiedOptions.tables).toEqual([]);
+    });
+
+    it('handleApplyClick with changed layer does update originalOptions and call handleChangeData', () => {
+        let calledChangeData: number = 0;
+        (component as any).handleChangeData = () => {
+            calledChangeData++;
+        };
+        let calledChangeFilterData: number = 0;
+        (component as any).handleChangeFilterData = () => {
+            calledChangeFilterData++;
+        };
+        let calledCloseSidenav: number = 0;
+        (component as any).closeSidenav = () => {
+            calledCloseSidenav++;
+        };
+        let calledFinalizeCreate: number = 0;
+        (component as any).finalizeCreateLayer = () => {
+            calledFinalizeCreate++;
+        };
+        let calledFinalizeDelete: number = 0;
+        (component as any).finalizeDeleteLayer = () => {
+            calledFinalizeDelete++;
+        };
+
+        (component as any).originalOptions = new WidgetOptionCollection(() => []);
+        (component as any).originalOptions.updateDatabases((component as any).datasetService);
+
+        component.modifiedOptions = new WidgetOptionCollection(() => []);
+        component.modifiedOptions.updateDatabases((component as any).datasetService);
+
+        let layer: any = new WidgetOptionCollection(() => []);
+        layer.updateDatabases((component as any).datasetService);
+        layer.append(new WidgetFreeTextOption('testNestedOption', '', ''), '');
+        (component as any).originalOptions.layers.push(layer);
+        component.modifiedOptions.layers.push(layer.copy());
+        component.modifiedOptions.layers[0].testNestedOption = 'testNestedText';
+
+        expect((component as any).originalOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect((component as any).originalOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect((component as any).originalOptions.layers.length).toEqual(1);
+        expect((component as any).originalOptions.layers[0]._id).toEqual(layer._id);
+        expect((component as any).originalOptions.layers[0].testNestedOption).toEqual('');
+        expect(component.modifiedOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect(component.modifiedOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect(component.modifiedOptions.layers.length).toEqual(1);
+        expect(component.modifiedOptions.layers[0]._id).toEqual(layer._id);
+        expect(component.modifiedOptions.layers[0].testNestedOption).toEqual('testNestedText');
+
+        component.handleApplyClick();
+        expect((component as any).originalOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect((component as any).originalOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect((component as any).originalOptions.layers.length).toEqual(1);
+        expect((component as any).originalOptions.layers[0]._id).toEqual(layer._id);
+        expect((component as any).originalOptions.layers[0].testNestedOption).toEqual('testNestedText');
+        expect(calledChangeData).toEqual(1);
+        expect(calledChangeFilterData).toEqual(0);
+        expect(calledCloseSidenav).toEqual(1);
+        expect(calledFinalizeCreate).toEqual(0);
+        expect(calledFinalizeDelete).toEqual(0);
+        expect(component.changeMade).toEqual(false);
+        expect(component.collapseOptionalOptions).toEqual(true);
+        expect(component.layerHidden).toEqual(new Map<string, boolean>());
+        expect(component.modifiedOptions.databases).toEqual([]);
+        expect(component.modifiedOptions.fields).toEqual([]);
+        expect(component.modifiedOptions.layers).toEqual([]);
+        expect(component.modifiedOptions.tables).toEqual([]);
+    });
+
+    it('handleApplyClick with deleted layer does update originalOptions and call handleChangeData', () => {
+        let calledChangeData: number = 0;
+        (component as any).handleChangeData = () => {
+            calledChangeData++;
+        };
+        let calledChangeFilterData: number = 0;
+        (component as any).handleChangeFilterData = () => {
+            calledChangeFilterData++;
+        };
+        let calledCloseSidenav: number = 0;
+        (component as any).closeSidenav = () => {
+            calledCloseSidenav++;
+        };
+        let calledFinalizeCreate: number = 0;
+        (component as any).finalizeCreateLayer = () => {
+            calledFinalizeCreate++;
+        };
+        let calledFinalizeDelete: number = 0;
+        (component as any).finalizeDeleteLayer = () => {
+            calledFinalizeDelete++;
+        };
+
+        (component as any).originalOptions = new WidgetOptionCollection(() => []);
+        (component as any).originalOptions.updateDatabases((component as any).datasetService);
+
+        let layer: any = new WidgetOptionCollection(() => []);
+        layer.updateDatabases((component as any).datasetService);
+        (component as any).originalOptions.layers.push(layer);
+
+        component.modifiedOptions = new WidgetOptionCollection(() => []);
+        component.modifiedOptions.updateDatabases((component as any).datasetService);
+
+        expect((component as any).originalOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect((component as any).originalOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect((component as any).originalOptions.layers.length).toEqual(1);
+        expect((component as any).originalOptions.layers[0]._id).toEqual(layer._id);
+        expect(component.modifiedOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect(component.modifiedOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect(component.modifiedOptions.layers.length).toEqual(0);
+
+        component.handleApplyClick();
+        expect((component as any).originalOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect((component as any).originalOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect((component as any).originalOptions.layers.length).toEqual(0);
+        expect(calledChangeData).toEqual(1);
+        expect(calledChangeFilterData).toEqual(0);
+        expect(calledCloseSidenav).toEqual(1);
+        expect(calledFinalizeCreate).toEqual(0);
+        expect(calledFinalizeDelete).toEqual(1);
+        expect(component.changeMade).toEqual(false);
+        expect(component.collapseOptionalOptions).toEqual(true);
+        expect(component.layerHidden).toEqual(new Map<string, boolean>());
+        expect(component.modifiedOptions.databases).toEqual([]);
+        expect(component.modifiedOptions.fields).toEqual([]);
+        expect(component.modifiedOptions.layers).toEqual([]);
+        expect(component.modifiedOptions.tables).toEqual([]);
+    });
+
+    it('handleApplyClick with many changes does update originalOptions and call expected function', () => {
+        let calledChangeData: number = 0;
+        (component as any).handleChangeData = () => {
+            calledChangeData++;
+        };
+        let calledChangeFilterData: number = 0;
+        (component as any).handleChangeFilterData = () => {
+            calledChangeFilterData++;
+        };
+        let calledCloseSidenav: number = 0;
+        (component as any).closeSidenav = () => {
+            calledCloseSidenav++;
+        };
+        let calledFinalizeCreate: number = 0;
+        (component as any).finalizeCreateLayer = () => {
+            calledFinalizeCreate++;
+        };
+        let calledFinalizeDelete: number = 0;
+        (component as any).finalizeDeleteLayer = () => {
+            calledFinalizeDelete++;
+        };
+
+        (component as any).originalOptions = new WidgetOptionCollection(() => []);
+        (component as any).originalOptions.updateDatabases((component as any).datasetService);
+        (component as any).originalOptions.append(new WidgetFreeTextOption('testOption', '', ''), '');
+        (component as any).originalOptions.append(new WidgetFieldOption('testField', '', true), new FieldMetaData());
+
+        component.modifiedOptions = new WidgetOptionCollection(() => []);
+        component.modifiedOptions.updateDatabases((component as any).datasetService);
+        component.modifiedOptions.database = DatasetServiceMock.DATABASES[1];
+        component.modifiedOptions.table = DatasetServiceMock.TABLES[1];
+        component.modifiedOptions.append(new WidgetFreeTextOption('testOption', '', ''), 'testText');
+        component.modifiedOptions.append(new WidgetFieldOption('testField', '', true), DatasetServiceMock.NAME_FIELD);
+
+        let layer: any = new WidgetOptionCollection(() => []);
+        layer.updateDatabases((component as any).datasetService);
+        layer.append(new WidgetFreeTextOption('testNestedOption', '', ''), '');
+        (component as any).originalOptions.layers.push(layer);
+        component.modifiedOptions.layers.push(layer.copy());
+        component.modifiedOptions.layers[0].testNestedOption = 'testNestedText';
+
+        expect((component as any).originalOptions.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect((component as any).originalOptions.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect((component as any).originalOptions.testOption).toEqual('');
+        expect((component as any).originalOptions.testField).toEqual(new FieldMetaData());
+        expect((component as any).originalOptions.layers.length).toEqual(1);
+        expect((component as any).originalOptions.layers[0]._id).toEqual(layer._id);
+        expect((component as any).originalOptions.layers[0].testNestedOption).toEqual('');
+        expect(component.modifiedOptions.database).toEqual(DatasetServiceMock.DATABASES[1]);
+        expect(component.modifiedOptions.table).toEqual(DatasetServiceMock.TABLES[1]);
+        expect(component.modifiedOptions.testOption).toEqual('testText');
+        expect(component.modifiedOptions.testField).toEqual(DatasetServiceMock.NAME_FIELD);
+        expect(component.modifiedOptions.layers.length).toEqual(1);
+        expect(component.modifiedOptions.layers[0]._id).toEqual(layer._id);
+        expect(component.modifiedOptions.layers[0].testNestedOption).toEqual('testNestedText');
+
+        component.handleApplyClick();
+        expect((component as any).originalOptions.database).toEqual(DatasetServiceMock.DATABASES[1]);
+        expect((component as any).originalOptions.table).toEqual(DatasetServiceMock.TABLES[1]);
+        expect((component as any).originalOptions.testOption).toEqual('testText');
+        expect((component as any).originalOptions.testField).toEqual(DatasetServiceMock.NAME_FIELD);
+        expect((component as any).originalOptions.layers.length).toEqual(1);
+        expect((component as any).originalOptions.layers[0]._id).toEqual(layer._id);
+        expect((component as any).originalOptions.layers[0].testNestedOption).toEqual('testNestedText');
+        expect(calledChangeData).toEqual(0);
+        expect(calledChangeFilterData).toEqual(1);
+        expect(calledCloseSidenav).toEqual(1);
+        expect(calledFinalizeCreate).toEqual(0);
+        expect(calledFinalizeDelete).toEqual(0);
+        expect(component.changeMade).toEqual(false);
+        expect(component.collapseOptionalOptions).toEqual(true);
+        expect(component.layerHidden).toEqual(new Map<string, boolean>());
+        expect(component.modifiedOptions.databases).toEqual([]);
+        expect(component.modifiedOptions.fields).toEqual([]);
+        expect(component.modifiedOptions.layers).toEqual([]);
+        expect(component.modifiedOptions.tables).toEqual([]);
+    });
+
+    it('handleChangeDatabase does update tables', () => {
+        let called: number = 0;
+        let options: any = {
+            updateTables: () => {
+                called++;
+            }
+        };
+
+        component.handleChangeDatabase(options);
+        expect(called).toEqual(1);
+        expect(component.changeMade).toEqual(true);
+    });
+
+    it('handleChangeTable does update fields', () => {
+        let called: number = 0;
+        let options: any = {
+            updateFields: () => {
+                called++;
+            }
+        };
+
+        component.handleChangeTable(options);
+        expect(called).toEqual(1);
+        expect(component.changeMade).toEqual(true);
+    });
+
+    it('handleCreateLayer does call createLayer', () => {
+        let called: number = 0;
+        (component as any).createLayer = () => {
+            called++;
+            return {
+                _id: 'testId' + called
+            };
+        };
+
+        component.handleCreateLayer();
+        expect(called).toEqual(1);
+        expect(component.layerHidden.get('testId1')).toEqual(false);
+        expect(component.changeMade).toEqual(true);
+    });
+
+    it('handleDeleteLayer does call deleteLayer', () => {
+        component.layerHidden.set('testId1', true);
+        let called: number = 0;
+        (component as any).deleteLayer = () => {
+            called++;
+        };
+
+        component.handleDeleteLayer({
+            _id: 'testId1'
+        });
+        expect(called).toEqual(1);
+        expect(component.layerHidden.has('testId1')).toEqual(false);
+        expect(component.changeMade).toEqual(true);
+    });
+
+    it('toggleFilter does update layerHidden', () => {
+        component.layerHidden.set('testId1', true);
+        component.layerHidden.set('testId2', true);
+
+        component.toggleFilter({
+            _id: 'testId1'
+        });
+        expect(component.layerHidden.get('testId1')).toEqual(false);
+        expect(component.layerHidden.get('testId2')).toEqual(true);
+
+        component.toggleFilter({
+            _id: 'testId2'
+        });
+        expect(component.layerHidden.get('testId1')).toEqual(false);
+        expect(component.layerHidden.get('testId2')).toEqual(false);
+
+        component.toggleFilter({
+            _id: 'testId1'
+        });
+        expect(component.layerHidden.get('testId1')).toEqual(true);
+        expect(component.layerHidden.get('testId2')).toEqual(false);
+    });
+
+    it('toggleOptionalOptions does update collapseOptionalOptions', () => {
         expect(component.collapseOptionalOptions).toEqual(true);
         component.toggleOptionalOptions();
         expect(component.collapseOptionalOptions).toEqual(false);
     });
 
+    it('updateOnChange does update changeMade', () => {
+        expect(component.changeMade).toEqual(false);
+        component.updateOnChange('testBindingKey1');
+        expect(component.changeMade).toEqual(true);
+        component.updateOnChange('testBindingKey2');
+        expect(component.changeMade).toEqual(true);
+    });
+
+    it('does have expected default HTML elements', () => {
+        // TODO
+    });
+
+    it('resetOptionsAndClose does reset HTML elements and close gear menu', () => {
+        // TODO
+        // component.resetOptionsAndClose();
+        // expect(component.changeMage).toEqual(false);
+        // expect(component.collapseOptionalOptions).toEqual(true);
+        // expect(component.layerHidden).toEqual(new Map<string, boolean>());
+    });
+
+    it('publishing a message on the options channel does set HTML elements', () => {
+        // TODO
+        // let messenger = new neon.eventing.Messenger;
+        // messenger.publish('options', {});
+        // expect(component.changeMage).toEqual(false);
+        // expect(component.collapseOptionalOptions).toEqual(true);
+        // expect(component.layerHidden).toEqual(new Map<string, boolean>());
+    });
 });

--- a/src/app/components/map/map.component.spec.ts
+++ b/src/app/components/map/map.component.spec.ts
@@ -167,7 +167,7 @@ function updateMapLayer1(component: TestMapComponent) {
     (component as any).layerIdToActiveData.set('testLayer1', new TransformedVisualizationData([{}]));
     (component as any).layerIdToElementCount.set('testLayer1', 1);
 
-    component.options.layers[0] = new WidgetOptionCollection(undefined, {});
+    component.options.layers[0] = new WidgetOptionCollection(() => [], undefined, {});
     component.options.layers[0]._id = 'testLayer1';
     component.options.layers[0].databases = [];
     component.options.layers[0].database = new DatabaseMetaData('testDatabase1');
@@ -192,7 +192,7 @@ function updateMapLayer2(component: TestMapComponent) {
     (component as any).layerIdToActiveData.set('testLayer2', new TransformedVisualizationData([{}, {}, {}, {}, {}, {}, {}, {}, {}, {}]));
     (component as any).layerIdToElementCount.set('testLayer2', 10);
 
-    component.options.layers[1] = new WidgetOptionCollection(undefined, {});
+    component.options.layers[1] = new WidgetOptionCollection(() => [], undefined, {});
     component.options.layers[1]._id = 'testLayer2';
     component.options.layers[1].databases = [];
     component.options.layers[1].database = new DatabaseMetaData('testDatabase2');

--- a/src/app/components/network-graph/network-graph.component.ts
+++ b/src/app/components/network-graph/network-graph.component.ts
@@ -655,7 +655,7 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
         this.filters = [];
         for (let neonFilter of neonFilters) {
             if (!neonFilter.filter.whereClause.whereClauses) {
-                let field = this.findField(this.options.fields, neonFilter.filter.whereClause.lhs);
+                let field = this.options.findField(neonFilter.filter.whereClause.lhs);
                 let value = neonFilter.filter.whereClause.rhs;
                 let myFilter = {
                     id: neonFilter.id,

--- a/src/app/components/news-feed/news-feed.component.ts
+++ b/src/app/components/news-feed/news-feed.component.ts
@@ -415,7 +415,7 @@ export class NewsFeedComponent extends BaseNeonComponent implements OnInit, OnDe
 
         for (let neonFilter of neonFilters) {
             if (!neonFilter.filter.whereClause.whereClauses) {
-                let field = this.findField(this.options.fields, neonFilter.filter.whereClause.lhs);
+                let field = this.options.findField(neonFilter.filter.whereClause.lhs);
                 let value = neonFilter.filter.whereClause.rhs;
                 let filter = {
                     id: neonFilter.id,

--- a/src/app/components/options-list/options-list.component.html
+++ b/src/app/components/options-list/options-list.component.html
@@ -1,54 +1,41 @@
-<div *ngFor="let option of optionsList">
-    <!-- Database Option Type-->
-    <mat-form-field class="option-container" *ngIf="checkOptionType(option.optionType, 'DATABASE')">
-        <mat-select placeholder="Database" [(ngModel)]="option.valueCurrent" required="true" name="{{option.valueCurrent}} database"
-            (ngModelChange)="handleChangeDatabase(option)">
-            <mat-option *ngFor="let database of databases" [value]="database">{{ database.prettyName }}</mat-option>
-        </mat-select>
-    </mat-form-field>
-    <!-- Table Option Type-->
-    <mat-form-field class="option-container" *ngIf="checkOptionType(option.optionType, 'TABLE')">
-        <mat-select placeholder="Table" [(ngModel)]="option.valueCurrent" required="true" name="{{option.valueCurrent}} table" (ngModelChange)="handleChangeTable(option)">
-            <mat-option *ngFor="let table of tables" [value]="table">{{ table.prettyName }}</mat-option>
-        </mat-select>
-    </mat-form-field>
+<div *ngFor="let bindingKey of bindingsList">
     <!-- Select Option Type-->
-    <mat-form-field class="option-container" *ngIf="checkOptionType(option.optionType, 'SELECT')">
-        <mat-select option.prettyName placeholder={{option.prettyName}} [ngModel]="option.valueCurrent"
-            name="{{option.prettyName}} Select" (ngModelChange)="handleListDataChange(option, $event)">
-            <mat-option *ngFor="let choice of option.valueChoices" [value]="choice.variable">
+    <mat-form-field class="option-container" *ngIf="getOption(bindingKey).optionType == 'SELECT'">
+        <mat-select placeholder={{getOption(bindingKey).prettyName}} [(ngModel)]="options[bindingKey]"
+            [name]="options._id + '_' + bindingKey" (ngModelChange)="updateOnChange(bindingKey)">
+            <mat-option *ngFor="let choice of getOption(bindingKey).valueChoices" [value]="choice.variable">
                 {{ choice.prettyName }}
             </mat-option>
         </mat-select>
     </mat-form-field>
     <!-- Field Option Type-->
-    <mat-form-field class="option-container" *ngIf="checkOptionType(option.optionType, 'FIELD')">
-        <mat-select option.prettyName placeholder={{option.prettyName}} [ngModel]="option.valueCurrent"
-            name="{{option.prettyName}} Field" (ngModelChange)="handleListDataChange(option, $event)">
+    <mat-form-field class="option-container" *ngIf="getOption(bindingKey).optionType == 'FIELD'">
+        <mat-select placeholder={{getOption(bindingKey).prettyName}} [(ngModel)]="options[bindingKey]"
+            [name]="options._id + '_' + bindingKey" (ngModelChange)="updateOnChange(bindingKey)">
             <mat-option *ngFor="let field of fields" [value]="field">{{ field.prettyName }}</mat-option>
         </mat-select>
     </mat-form-field>
     <!-- Free Text Option Type-->
-    <div mat-fill class="flex center" *ngIf="checkOptionType(option.optionType, 'FREE_TEXT')">
-        <mat-form-field class='option-container' option.prettyName>
-            <input matInput placeholder={{option.prettyName}} [ngModel]="option.valueCurrent" name="{{option.prettyName}} Free"
-                (ngModelChange)="handleListDataChange(option, $event)" required="true">
+    <div mat-fill class="flex center" *ngIf="getOption(bindingKey).optionType == 'FREE_TEXT'">
+        <mat-form-field class='option-container'>
+            <input matInput placeholder={{getOption(bindingKey).prettyName}} [(ngModel)]="options[bindingKey]"
+                [name]="options._id + '_' + bindingKey" (ngModelChange)="updateOnChange(bindingKey)" required="true">
         </mat-form-field>
     </div>
     <!-- Field Array Option Type-->
-    <div mat-fill class="flex center" *ngIf="checkOptionType(option.optionType, 'FIELD_ARRAY')">
+    <div mat-fill class="flex center" *ngIf="getOption(bindingKey).optionType == 'FIELD_ARRAY'">
         <mat-form-field class='option-container'>
-            <mat-select placeholder={{option.prettyName}} [ngModel]="option.valueCurrent" name="{{option.prettyName}} Field Array"
-                (ngModelChange)="handleListDataChange(option, $event)" multiple>
+            <mat-select placeholder={{getOption(bindingKey).prettyName}} [(ngModel)]="options[bindingKey]"
+                [name]="options._id + '_' + bindingKey" (ngModelChange)="updateOnChange(bindingKey)" multiple>
                 <mat-option *ngFor="let field of fields" [value]="field">{{ field.prettyName }}</mat-option>
             </mat-select>
         </mat-form-field>
     </div>
     <!-- Multiple Select Option Type-->
-    <div mat-fill class="flex center" *ngIf="checkOptionType(option.optionType, 'MULTIPLE_SELECT')">
+    <div mat-fill class="flex center" *ngIf="getOption(bindingKey).optionType == 'MULTIPLE_SELECT'">
         <mat-form-field class='option-container'>
-            <mat-select placeholder={{option.prettyName}} [ngModel]="option.valueCurrent" name="{{option.prettyName}} Multiple Select"
-                (ngModelChange)="handleListDataChange(option, $event)" multiple>
+            <mat-select placeholder={{getOption(bindingKey).prettyName}} [(ngModel)]="options[bindingKey]"
+                [name]="options._id + '_' + bindingKey" (ngModelChange)="updateOnChange(bindingKey)" multiple>
                 <mat-option *ngFor="let field of fields" [value]="field">{{ field }}</mat-option>
             </mat-select>
         </mat-form-field>

--- a/src/app/components/options-list/options-list.component.ts
+++ b/src/app/components/options-list/options-list.component.ts
@@ -19,9 +19,8 @@ import {
     Input,
     ViewEncapsulation
 } from '@angular/core';
-
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
-import { WidgetFieldOption, WidgetOption, WidgetOptionCollection } from '../../widget-option';
+import { FieldMetaData } from '../../dataset';
+import { WidgetOption } from '../../widget-option';
 
 @Component({
     selector: 'app-options-list',
@@ -31,39 +30,17 @@ import { WidgetFieldOption, WidgetOption, WidgetOptionCollection } from '../../w
     changeDetection: ChangeDetectionStrategy.Default
 })
 export class OptionsListComponent {
-    @Input() optionsList: any[];
+    @Input() bindingsList: string[];
+    @Input() fields: FieldMetaData[];
     @Input() index: number;
-    @Input() databases: any[];
-    @Input() fields: any[];
-    @Input() tables: any[];
+    @Input() options: any;
+    @Input() updateOnChange: Function;
 
-    @Input() handleChangeData: Function;
-    @Input() handleChangeDatabase: Function;
-    @Input() handleChangeLimit: Function;
-    @Input() handleChangeFilterField: Function;
-    @Input() handleChangeSubcomponentType: Function;
-    @Input() handleChangeTable: Function;
-    @Input() handleDataChange: Function;
-
-    isLayer: boolean = false;
-    newList: any[];
-    constructor(public widgetService: AbstractWidgetService) {
-        this.newList = [];
+    constructor() {
+        // Do nothing.
     }
 
-    checkOptionType(currentType: string, checkType) {
-        if (currentType === checkType) {
-            return true;
-        }
-        return false;
+    getOption(bindingKey: string): WidgetOption {
+        return this.options.access(bindingKey);
     }
-
-    handleListDataChange(widgetOption, newValue) {
-        if (this.index) {
-            this.handleDataChange(widgetOption, newValue, this.index);
-        } else {
-            this.handleDataChange(widgetOption, newValue, this.index);
-        }
-    }
-
 }

--- a/src/app/components/options-list/options-list.component.ts
+++ b/src/app/components/options-list/options-list.component.ts
@@ -40,7 +40,13 @@ export class OptionsListComponent {
         // Do nothing.
     }
 
-    getOption(bindingKey: string): WidgetOption {
+    /**
+     * Returns the WidgetOption at the given binding key.
+     *
+     * @arg {string} bindingKey
+     * @return {WidgetOption}
+     */
+    public getOption(bindingKey: string): WidgetOption {
         return this.options.access(bindingKey);
     }
 }

--- a/src/app/components/sample/sample.component.ts
+++ b/src/app/components/sample/sample.component.ts
@@ -479,7 +479,7 @@ export class SampleComponent extends BaseNeonComponent implements OnInit, OnDest
 
             // This will ignore a filter with multiple clauses.
             if (!neonFilter.filter.whereClause.whereClauses) {
-                let field = this.findField(this.options.fields, neonFilter.filter.whereClause.lhs);
+                let field = this.options.findField(neonFilter.filter.whereClause.lhs);
                 let value = neonFilter.filter.whereClause.rhs;
                 if (this.isVisualizationFilterUnique(field.columnName, value)) {
                     this.addVisualizationFilter(this.createVisualizationFilter(neonFilter.id, field.columnName, field.prettyName, value));

--- a/src/app/components/text-cloud/text-cloud.component.ts
+++ b/src/app/components/text-cloud/text-cloud.component.ts
@@ -287,7 +287,7 @@ export class TextCloudComponent extends BaseNeonComponent implements OnInit, OnD
         this.filters = [];
         for (let neonFilter of neonFilters) {
             if (!neonFilter.filter.whereClause.whereClauses) {
-                let field = this.findField(this.options.fields, neonFilter.filter.whereClause.lhs);
+                let field = this.options.findField(neonFilter.filter.whereClause.lhs);
                 let value = neonFilter.filter.whereClause.rhs;
                 let filter = {
                     id: neonFilter.id,

--- a/src/app/components/thumbnail-grid/thumbnail-grid.component.ts
+++ b/src/app/components/thumbnail-grid/thumbnail-grid.component.ts
@@ -823,7 +823,7 @@ export class ThumbnailGridComponent extends BaseNeonComponent implements OnInit,
 
         for (let neonFilter of neonFilters) {
             if (!neonFilter.filter.whereClause.whereClauses) {
-                let field = this.findField(this.options.fields, neonFilter.filter.whereClause.lhs);
+                let field = this.options.findField(neonFilter.filter.whereClause.lhs);
                 let value = neonFilter.filter.whereClause.rhs;
                 let filter = {
                     id: neonFilter.id,

--- a/src/app/services/dataset.service.ts
+++ b/src/app/services/dataset.service.ts
@@ -1137,4 +1137,22 @@ export class DatasetService {
             return DatasetService.getFieldNameByKey(currentConfig, key);
         }
     }
+
+    /**
+     * If field key is referenced in config file, find field value using current dashboard.
+     *
+     * @arg {string} fieldKey
+     * @return {string}
+     */
+    public translateFieldKeyToValue(fieldKey: string): string {
+        let currentDashboard = this.getCurrentDashboard();
+
+        // If the field key does exist in the dashboard...
+        if (fieldKey && currentDashboard && currentDashboard.fields && currentDashboard.fields[fieldKey]) {
+            return this.getFieldNameFromCurrentDashboardByKey(fieldKey);
+        }
+
+        // If the field key is just a field name or does not exist in the dashboard...
+        return fieldKey;
+    }
 }

--- a/src/app/widget-option.spec.ts
+++ b/src/app/widget-option.spec.ts
@@ -14,18 +14,61 @@
  *
  */
 import { ReflectiveInjector } from '@angular/core';
-import { WidgetSelectOption, WidgetOptionCollection } from './widget-option';
+import { inject } from '@angular/core/testing';
+
+import { DatabaseMetaData, FieldMetaData, TableMetaData } from './dataset';
+import { DatasetService } from './services/dataset.service';
+import {
+    WidgetDatabaseOption,
+    WidgetFieldOption,
+    WidgetFieldArrayOption,
+    WidgetSelectOption,
+    WidgetOptionCollection,
+    WidgetTableOption
+} from './widget-option';
+
+import { initializeTestBed } from '../testUtils/initializeTestBed';
+import { DatasetServiceMock } from '../testUtils/MockServices/DatasetServiceMock';
+
+import * as _ from 'lodash';
 
 describe('WidgetOptionCollection', () => {
     let options: any;
 
+    initializeTestBed('Widget Collection', {
+        providers: [
+            { provide: DatasetService, useClass: DatasetServiceMock }
+        ]
+    });
+
     beforeEach(() => {
-        options = new WidgetOptionCollection(ReflectiveInjector.resolveAndCreate([{
+        options = new WidgetOptionCollection(() => [], ReflectiveInjector.resolveAndCreate([{
             provide: 'keyA',
             useValue: 'provideA'
         }, {
             provide: 'keyB',
             useValue: 'provideB'
+        }, {
+            provide: 'testDate',
+            useValue: 'testDateField'
+        }, {
+            provide: 'testFake',
+            useValue: 'testFakeField'
+        }, {
+            provide: 'testList',
+            useValue: ['testDateField', 'testFakeField', 'testNameField', 'testSizeField']
+        }, {
+            provide: 'testName',
+            useValue: 'testNameField'
+        }, {
+            provide: 'testSize',
+            useValue: 'testSizeField'
+        }, {
+            provide: 'testFieldKey',
+            useValue: 'field_key_1'
+        }, {
+            provide: 'testListWithFieldKey',
+            useValue: ['field_key_1', 'testNameField']
         }]));
     });
 
@@ -66,6 +109,69 @@ describe('WidgetOptionCollection', () => {
         options.keyA = 'newA';
         expect(options.keyA).toEqual('newA');
     });
+
+    it('find field functions do not error if fields are not set', inject([DatasetService], (datasetService: DatasetService) => {
+        expect(options.findField('testNameField')).toEqual(undefined);
+        expect(options.findFieldObject(datasetService, 'testName')).toEqual(new FieldMetaData());
+        expect(options.findFieldObjects(datasetService, 'testList')).toEqual([]);
+    }));
+
+    it('findField does return expected object or undefined', () => {
+        options.fields = DatasetServiceMock.FIELDS;
+
+        expect(options.findField('testDateField')).toEqual(DatasetServiceMock.DATE_FIELD);
+        expect(options.findField('testNameField')).toEqual(DatasetServiceMock.NAME_FIELD);
+        expect(options.findField('testSizeField')).toEqual(DatasetServiceMock.SIZE_FIELD);
+        expect(options.findField('testFakeField')).toEqual(undefined);
+    });
+
+    it('findField does work as expected if given an array index', () => {
+        options.fields = DatasetServiceMock.FIELDS;
+
+        let dateIndex = _.findIndex(DatasetServiceMock.FIELDS, (fieldObject) => {
+            return fieldObject.columnName === 'testDateField';
+        });
+        let nameIndex = _.findIndex(DatasetServiceMock.FIELDS, (fieldObject) => {
+            return fieldObject.columnName === 'testNameField';
+        });
+        let sizeIndex = _.findIndex(DatasetServiceMock.FIELDS, (fieldObject) => {
+            return fieldObject.columnName === 'testSizeField';
+        });
+
+        expect(options.findField('' + dateIndex)).toEqual(DatasetServiceMock.DATE_FIELD);
+        expect(options.findField('' + nameIndex)).toEqual(DatasetServiceMock.NAME_FIELD);
+        expect(options.findField('' + sizeIndex)).toEqual(DatasetServiceMock.SIZE_FIELD);
+        expect(options.findField('' + DatasetServiceMock.FIELDS.length)).toEqual(undefined);
+        expect(options.findField('-1')).toEqual(undefined);
+        expect(options.findField('abcd')).toEqual(undefined);
+    });
+
+    it('findFieldObject does return expected object', inject([DatasetService], (datasetService: DatasetService) => {
+        options.fields = DatasetServiceMock.FIELDS;
+
+        expect(options.findFieldObject(datasetService, 'testDate')).toEqual(DatasetServiceMock.DATE_FIELD);
+        expect(options.findFieldObject(datasetService, 'testName')).toEqual(DatasetServiceMock.NAME_FIELD);
+        expect(options.findFieldObject(datasetService, 'testSize')).toEqual(DatasetServiceMock.SIZE_FIELD);
+        expect(options.findFieldObject(datasetService, 'testFieldKey')).toEqual(DatasetServiceMock.FIELD_KEY_FIELD);
+        expect(options.findFieldObject(datasetService, 'testFake')).toEqual(new FieldMetaData());
+        expect(options.findFieldObject(datasetService, 'fakeBind')).toEqual(new FieldMetaData());
+    }));
+
+    it('findFieldObjects does return expected array', inject([DatasetService], (datasetService: DatasetService) => {
+        options.fields = DatasetServiceMock.FIELDS;
+
+        expect(options.findFieldObjects(datasetService, 'testList')).toEqual([
+            DatasetServiceMock.DATE_FIELD,
+            DatasetServiceMock.NAME_FIELD,
+            DatasetServiceMock.SIZE_FIELD
+        ]);
+        expect(options.findFieldObjects(datasetService, 'testListWithFieldKey')).toEqual([
+            DatasetServiceMock.FIELD_KEY_FIELD,
+            DatasetServiceMock.NAME_FIELD
+        ]);
+        expect(options.findFieldObjects(datasetService, 'testName')).toEqual([]);
+        expect(options.findFieldObjects(datasetService, 'fakeBind')).toEqual([]);
+    }));
 
     it('inject does add given widget option with provided binding', () => {
         options.inject(new WidgetSelectOption('keyA', 'labelA', 'defaultA', []));
@@ -137,6 +243,12 @@ describe('WidgetOptionCollection', () => {
     });
 
     it('list does return an array of all widget options', () => {
+        let databaseOption = new WidgetDatabaseOption();
+        databaseOption.valueCurrent = new DatabaseMetaData();
+        let tableOption = new WidgetTableOption();
+        tableOption.valueCurrent = new TableMetaData();
+        expect(options.list()).toEqual([databaseOption, tableOption]);
+
         let widgetOption1 = new WidgetSelectOption('key1', 'label1', 'default1', []);
         let widgetOption2 = new WidgetSelectOption('key2', 'label2', 'default2', []);
 
@@ -146,6 +258,221 @@ describe('WidgetOptionCollection', () => {
         expect(widgetOption1.valueCurrent).toEqual('current1');
         expect(widgetOption2.valueCurrent).toEqual('current2');
 
-        expect(options.list()).toEqual([widgetOption1, widgetOption2]);
+        expect(options.list()).toEqual([databaseOption, tableOption, widgetOption1, widgetOption2]);
     });
+
+    it('updateDatabases does update databases, tables, and fields', inject([DatasetService], (datasetService: DatasetService) => {
+        options.databases = [];
+        options.database = new DatabaseMetaData();
+        options.tables = [];
+        options.table = new TableMetaData();
+        options.fields = [];
+
+        options.updateDatabases(datasetService);
+
+        expect(options.databases).toEqual(DatasetServiceMock.DATABASES);
+        expect(options.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect(options.tables).toEqual(DatasetServiceMock.TABLES);
+        expect(options.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect(options.fields).toEqual(DatasetServiceMock.FIELDS);
+    }));
+
+    it('updateFields does update fields', inject([DatasetService], (datasetService: DatasetService) => {
+        options.databases = DatasetServiceMock.DATABASES;
+        options.database = DatasetServiceMock.DATABASES[0];
+        options.tables = DatasetServiceMock.TABLES;
+        options.table = DatasetServiceMock.TABLES[0];
+        options.fields = [];
+
+        options.updateFields(datasetService);
+
+        expect(options.databases).toEqual(DatasetServiceMock.DATABASES);
+        expect(options.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect(options.tables).toEqual(DatasetServiceMock.TABLES);
+        expect(options.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect(options.fields).toEqual(DatasetServiceMock.FIELDS);
+    }));
+
+    it('updateTables does update tables and fields', inject([DatasetService], (datasetService: DatasetService) => {
+        options.databases = DatasetServiceMock.DATABASES;
+        options.database = DatasetServiceMock.DATABASES[0];
+        options.tables = [];
+        options.table = new TableMetaData();
+        options.fields = [];
+
+        options.updateTables(datasetService);
+
+        expect(options.databases).toEqual(DatasetServiceMock.DATABASES);
+        expect(options.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect(options.tables).toEqual(DatasetServiceMock.TABLES);
+        expect(options.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect(options.fields).toEqual(DatasetServiceMock.FIELDS);
+    }));
+});
+
+describe('WidgetOptionCollection with custom fields', () => {
+    let options: any;
+
+    initializeTestBed('Widget Collection', {
+        providers: [
+            { provide: DatasetService, useClass: DatasetServiceMock }
+        ]
+    });
+
+    beforeEach(() => {
+        options = new WidgetOptionCollection(() => {
+            return [
+                new WidgetFieldOption('testCustomField', 'Test Custom Field', false),
+                new WidgetFieldArrayOption('testCustomFieldArray', 'Test Custom Field Array', false)
+            ];
+        }, ReflectiveInjector.resolveAndCreate([]));
+    });
+
+    it('updateDatabases does update databases, tables, and fields', inject([DatasetService], (datasetService: DatasetService) => {
+        options.databases = [];
+        options.database = new DatabaseMetaData();
+        options.tables = [];
+        options.table = new TableMetaData();
+        options.fields = [];
+        options.testCustomField = null;
+        options.testCustomFieldArray = null;
+
+        options.updateDatabases(datasetService);
+
+        expect(options.databases).toEqual(DatasetServiceMock.DATABASES);
+        expect(options.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect(options.tables).toEqual(DatasetServiceMock.TABLES);
+        expect(options.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect(options.fields).toEqual(DatasetServiceMock.FIELDS);
+        expect(options.testCustomField).toEqual(new FieldMetaData());
+        expect(options.testCustomFieldArray).toEqual([]);
+    }));
+
+    it('updateFields does update fields', inject([DatasetService], (datasetService: DatasetService) => {
+        options.databases = DatasetServiceMock.DATABASES;
+        options.database = DatasetServiceMock.DATABASES[0];
+        options.tables = DatasetServiceMock.TABLES;
+        options.table = DatasetServiceMock.TABLES[0];
+        options.fields = [];
+        options.testCustomField = null;
+        options.testCustomFieldArray = null;
+
+        options.updateFields(datasetService);
+
+        expect(options.databases).toEqual(DatasetServiceMock.DATABASES);
+        expect(options.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect(options.tables).toEqual(DatasetServiceMock.TABLES);
+        expect(options.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect(options.fields).toEqual(DatasetServiceMock.FIELDS);
+        expect(options.testCustomField).toEqual(new FieldMetaData());
+        expect(options.testCustomFieldArray).toEqual([]);
+    }));
+
+    it('updateTables does update tables and fields', inject([DatasetService], (datasetService: DatasetService) => {
+        options.databases = DatasetServiceMock.DATABASES;
+        options.database = DatasetServiceMock.DATABASES[0];
+        options.tables = [];
+        options.table = new TableMetaData();
+        options.fields = [];
+        options.testCustomField = null;
+        options.testCustomFieldArray = null;
+
+        options.updateTables(datasetService);
+
+        expect(options.databases).toEqual(DatasetServiceMock.DATABASES);
+        expect(options.database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect(options.tables).toEqual(DatasetServiceMock.TABLES);
+        expect(options.table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect(options.fields).toEqual(DatasetServiceMock.FIELDS);
+        expect(options.testCustomField).toEqual(new FieldMetaData());
+        expect(options.testCustomFieldArray).toEqual([]);
+    }));
+});
+
+describe('WidgetOptionCollection with bindings and custom fields', () => {
+    let options: any;
+
+    initializeTestBed('Widget Collection', {
+        providers: [
+            { provide: DatasetService, useClass: DatasetServiceMock }
+        ]
+    });
+
+    beforeEach(() => {
+        options = new WidgetOptionCollection(() => {
+            return [
+                new WidgetFieldOption('testCustomField', 'Test Custom Field', false),
+                new WidgetFieldArrayOption('testCustomFieldArray', 'Test Custom Field Array', false)
+            ];
+        }, ReflectiveInjector.resolveAndCreate([{
+            provide: 'tableKey',
+            useValue: 'table_key_2'
+        }, {
+            provide: 'testCustomField',
+            useValue: 'testTextField'
+        }, {
+            provide: 'testCustomFieldArray',
+            useValue: ['testNameField', 'testTypeField']
+        }]));
+    });
+
+    it('updateDatabases does update databases, tables, and fields', inject([DatasetService], (datasetService: DatasetService) => {
+        options.databases = [];
+        options.database = new DatabaseMetaData();
+        options.tables = [];
+        options.table = new TableMetaData();
+        options.fields = [];
+        options.testCustomField = null;
+        options.testCustomFieldArray = null;
+
+        options.updateDatabases(datasetService);
+
+        expect(options.databases).toEqual(DatasetServiceMock.DATABASES);
+        expect(options.database).toEqual(DatasetServiceMock.DATABASES[1]);
+        expect(options.tables).toEqual(DatasetServiceMock.TABLES);
+        expect(options.table).toEqual(DatasetServiceMock.TABLES[1]);
+        expect(options.fields).toEqual(DatasetServiceMock.FIELDS);
+        expect(options.testCustomField).toEqual(DatasetServiceMock.TEXT_FIELD);
+        expect(options.testCustomFieldArray).toEqual([DatasetServiceMock.NAME_FIELD, DatasetServiceMock.TYPE_FIELD]);
+    }));
+
+    it('updateFields does update fields', inject([DatasetService], (datasetService: DatasetService) => {
+        options.databases = DatasetServiceMock.DATABASES;
+        options.database = DatasetServiceMock.DATABASES[1];
+        options.tables = DatasetServiceMock.TABLES;
+        options.table = DatasetServiceMock.TABLES[1];
+        options.fields = [];
+        options.testCustomField = null;
+        options.testCustomFieldArray = null;
+
+        options.updateFields(datasetService);
+
+        expect(options.databases).toEqual(DatasetServiceMock.DATABASES);
+        expect(options.database).toEqual(DatasetServiceMock.DATABASES[1]);
+        expect(options.tables).toEqual(DatasetServiceMock.TABLES);
+        expect(options.table).toEqual(DatasetServiceMock.TABLES[1]);
+        expect(options.fields).toEqual(DatasetServiceMock.FIELDS);
+        expect(options.testCustomField).toEqual(DatasetServiceMock.TEXT_FIELD);
+        expect(options.testCustomFieldArray).toEqual([DatasetServiceMock.NAME_FIELD, DatasetServiceMock.TYPE_FIELD]);
+    }));
+
+    it('updateTables does update tables and fields', inject([DatasetService], (datasetService: DatasetService) => {
+        options.databases = DatasetServiceMock.DATABASES;
+        options.database = DatasetServiceMock.DATABASES[1];
+        options.tables = [];
+        options.table = new TableMetaData();
+        options.fields = [];
+        options.testCustomField = null;
+        options.testCustomFieldArray = null;
+
+        options.updateTables(datasetService);
+
+        expect(options.databases).toEqual(DatasetServiceMock.DATABASES);
+        expect(options.database).toEqual(DatasetServiceMock.DATABASES[1]);
+        expect(options.tables).toEqual(DatasetServiceMock.TABLES);
+        expect(options.table).toEqual(DatasetServiceMock.TABLES[1]);
+        expect(options.fields).toEqual(DatasetServiceMock.FIELDS);
+        expect(options.testCustomField).toEqual(DatasetServiceMock.TEXT_FIELD);
+        expect(options.testCustomFieldArray).toEqual([DatasetServiceMock.NAME_FIELD, DatasetServiceMock.TYPE_FIELD]);
+    }));
 });

--- a/src/app/widget-option.ts
+++ b/src/app/widget-option.ts
@@ -15,7 +15,9 @@
  */
 import { Injector } from '@angular/core';
 import { AggregationType } from './services/abstract.search.service';
+import { DatasetService } from './services/dataset.service';
 import { DatabaseMetaData, FieldMetaData, TableMetaData } from './dataset';
+import * as _ from 'lodash';
 import * as uuidv4 from 'uuid/v4';
 
 type OptionCallback = (options: any) => boolean;
@@ -237,21 +239,30 @@ export class WidgetOptionCollection {
     private _collection: { [bindingKey: string]: WidgetOption; } = {};
 
     public _id: string;
+    public database: DatabaseMetaData = null;
     public databases: DatabaseMetaData[] = [];
     public fields: FieldMetaData[] = [];
     public isMultiLayerWidget: boolean = false;
     public layers: WidgetOptionCollection[] = [];
     public layeredWidget: boolean = false;
+    public table: TableMetaData = null;
     public tables: TableMetaData[] = [];
 
     /**
      * @constructor
+     * @arg {function} createFieldOptionsCallback A callback function to create the field options.
      * @arg {Injector} [injector] An injector with bindings; if undefined, uses config.
      * @arg {any} [config] An object with bindings; used if injector is undefined.
      */
-    constructor(protected injector?: Injector, protected config?: any) {
+    constructor(
+        protected createFieldOptionsCallback: () => (WidgetFieldOption | WidgetFieldArrayOption)[],
+        protected injector?: Injector,
+        protected config?: any
+    ) {
         // TODO Do not use a default _id.  Throw an error if undefined!
         this._id = (this.injector ? this.injector.get('_id', uuidv4()) : ((this.config || {})._id || uuidv4()));
+        this.append(new WidgetDatabaseOption(), new DatabaseMetaData());
+        this.append(new WidgetTableOption(), new TableMetaData());
     }
 
     /**
@@ -282,6 +293,73 @@ export class WidgetOptionCollection {
     }
 
     /**
+     * Returns a copy of this object.
+     *
+     * @return {WidgetOptionCollection}
+     */
+    public copy(): WidgetOptionCollection {
+        let copy = new WidgetOptionCollection(this.createFieldOptionsCallback, this.injector, this.config);
+        copy._id = this._id;
+        copy.database = this.database;
+        copy.databases = this.databases;
+        copy.fields = this.fields;
+        copy.isMultiLayerWidget = this.isMultiLayerWidget;
+        copy.layers = this.layers.map((layer) => layer.copy());
+        copy.layeredWidget = this.layeredWidget;
+        copy.table = this.table;
+        copy.tables = this.tables;
+        this.list().forEach((option: WidgetOption) => {
+            copy.append(_.cloneDeep(option), option.valueCurrent);
+        });
+        return copy;
+    }
+
+    /**
+     * Returns the field object with the given column name or undefinied if the field does not exist.
+     *
+     * @arg {string} columnName
+     * @return {FieldMetaData}
+     */
+    public findField(columnName: string): FieldMetaData {
+        let outputFields = !columnName ? [] : this.fields.filter((field: FieldMetaData) => field.columnName === columnName);
+
+        if (!outputFields.length && this.fields.length) {
+            // Check if the column name is actually an array index rather than a name.
+            let fieldIndex = parseInt(columnName, 10);
+            if (!isNaN(fieldIndex) && fieldIndex < this.fields.length) {
+                outputFields = [this.fields[fieldIndex]];
+            }
+        }
+
+        return outputFields.length ? outputFields[0] : undefined;
+    }
+
+    /**
+     * Returns the field object for the given binding key or an empty field object.
+     *
+     * @arg {DatasetService} datasetService
+     * @arg {string} bindingKey
+     * @return {FieldMetaData}
+     */
+    public findFieldObject(datasetService: DatasetService, bindingKey: string): FieldMetaData {
+        let fieldKey = (this.config || {})[bindingKey] || (this.injector ? this.injector.get(bindingKey, '') : '');
+        return this.findField(datasetService.translateFieldKeyToValue(fieldKey)) || new FieldMetaData();
+    }
+
+    /**
+     * Returns the array of field objects for the given binding key or an array of empty field objects.
+     *
+     * @arg {DatasetService} datasetService
+     * @arg {string} bindingKey
+     * @return {FieldMetaData[]}
+     */
+    public findFieldObjects(datasetService: DatasetService, bindingKey: string): FieldMetaData[] {
+        let bindings = (this.config || {})[bindingKey] || (this.injector ? this.injector.get(bindingKey, []) : []);
+        return (Array.isArray(bindings) ? bindings : []).map((fieldKey) => this.findField(datasetService.translateFieldKeyToValue(
+            fieldKey))).filter((fieldsObject) => !!fieldsObject);
+    }
+
+    /**
      * Injects the given option(s) into this collection.
      *
      * @arg {WidgetOption|WidgetOption[]} options
@@ -300,6 +378,92 @@ export class WidgetOptionCollection {
      */
     public list(): WidgetOption[] {
         return Object.keys(this._collection).map((property) => this.access(property));
+    }
+
+    /**
+     * Updates all the databases, tables, and fields in the options.
+     *
+     * @arg {DatasetService} datasetService
+     */
+    public updateDatabases(datasetService: DatasetService): void {
+        this.databases = datasetService.getDatabases();
+        this.database = this.databases[0] || this.database;
+
+        if (this.databases.length) {
+            let tableKey = (this.config || {}).tableKey || (this.injector ? this.injector.get('tableKey', null) : null);
+            let currentDashboard = datasetService.getCurrentDashboard();
+            let configDatabase: any;
+
+            if (tableKey && currentDashboard && currentDashboard.tables && currentDashboard.tables[tableKey]) {
+                configDatabase = datasetService.getDatabaseNameFromCurrentDashboardByKey(tableKey);
+
+                if (configDatabase) {
+                    for (let database of this.databases) {
+                        if (configDatabase === database.name) {
+                            this.database = database;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        return this.updateTables(datasetService);
+    }
+
+    /**
+     * Updates all the fields in the options.
+     *
+     * @arg {DatasetService} datasetService
+     */
+    public updateFields(datasetService: DatasetService): void {
+        if (this.database && this.table) {
+            // Sort the fields that are displayed in the dropdowns in the options menus alphabetically.
+            this.fields = datasetService.getSortedFields(this.database.name, this.table.name, true).filter((field) => {
+                return (field && field.columnName);
+            });
+
+            // Create the field options and assign the default value as FieldMetaData objects.
+            this.createFieldOptionsCallback().forEach((fieldsOption) => {
+                if (fieldsOption.optionType === OptionType.FIELD) {
+                    this.append(fieldsOption, this.findFieldObject(datasetService, fieldsOption.bindingKey));
+                }
+                if (fieldsOption.optionType === OptionType.FIELD_ARRAY) {
+                    this.append(fieldsOption, this.findFieldObjects(datasetService, fieldsOption.bindingKey));
+                }
+            });
+        }
+    }
+
+    /**
+     * Updates all the tables and fields in the options.
+     *
+     * @arg {DatasetService} datasetService
+     */
+    public updateTables(datasetService: DatasetService): void {
+        this.tables = this.database ? datasetService.getTables(this.database.name) : [];
+        this.table = this.tables[0] || this.table;
+
+        if (this.tables.length > 0) {
+            let tableKey = (this.config || {}).tableKey || (this.injector ? this.injector.get('tableKey', null) : null);
+            let currentDashboard = datasetService.getCurrentDashboard();
+            let configTable: any;
+
+            if (tableKey && currentDashboard && currentDashboard.tables && currentDashboard.tables[tableKey]) {
+                configTable = datasetService.getTableNameFromCurrentDashboardByKey(tableKey);
+
+                if (configTable) {
+                    for (let table of this.tables) {
+                        if (configTable === table.name) {
+                            this.table = table;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        return this.updateFields(datasetService);
     }
 
 }

--- a/src/testUtils/MockServices/DatasetServiceMock.ts
+++ b/src/testUtils/MockServices/DatasetServiceMock.ts
@@ -15,7 +15,7 @@
  */
 import * as neon from 'neon-framework';
 
-import { DatabaseMetaData, FieldMetaData, TableMetaData, DashboardOptions } from '../../app/dataset';
+import { Dashboard, DashboardOptions, DatabaseMetaData, Datastore, FieldMetaData, TableMetaData } from '../../app/dataset';
 import { DatasetService } from '../../app/services/dataset.service';
 import { NeonGTDConfig } from '../../app/neon-gtd-config';
 
@@ -69,49 +69,48 @@ export class DatasetServiceMock extends DatasetService {
 
     constructor() {
         super(new NeonGTDConfig());
-        this.setActiveDataset({
-            databases: DatasetServiceMock.DATABASES,
-            name: 'datastore1',
-            type: 'testDatastore',
-            host: 'testHostname'
-        });
+        let datastore: Datastore = new Datastore('datastore1', 'testHostname', 'testDatastore');
+        datastore.databases = DatasetServiceMock.DATABASES;
+        this.setActiveDataset(datastore);
+
+        let dashboard: Dashboard = new Dashboard();
 
         let dashboardTableKeys: {[key: string]: string} = {};
         dashboardTableKeys.table_key_1 = 'datastore1.testDatabase1.testTable1';
         dashboardTableKeys.table_key_2 = 'datastore1.testDatabase2.testTable2';
+        dashboard.tables = dashboardTableKeys;
 
         let dashboardFieldKeys: {[key: string]: string} = {};
         dashboardFieldKeys.field_key_1 = 'datastore1.testDatabase1.testTable1.testFieldKeyField';
+        dashboard.fields = dashboardFieldKeys;
 
         let visTitles: {[key: string]: string} = {};
         visTitles.dataTableTitle = 'Documents';
+        dashboard.visualizationTitles = visTitles;
 
-        this.setCurrentDashboard({
-            name: 'Test Discovery Config',
-            layout: 'DISCOVERY',
-            tables: dashboardTableKeys,
-            fields: dashboardFieldKeys,
-            visualizationTitles: visTitles,
-            options: new DashboardOptions(),
-            relations: [{
-                datastore1: {
-                    testDatabase1: {
-                        testTable1: 'testRelationFieldA'
-                    },
-                    testDatabase2: {
-                        testTable2: 'testRelationFieldA'
-                    }
+        dashboard.relations = [{
+            datastore1: {
+                testDatabase1: {
+                    testTable1: 'testRelationFieldA'
+                },
+                testDatabase2: {
+                    testTable2: 'testRelationFieldA'
                 }
-            }, {
-                datastore1: {
-                    testDatabase1: {
-                        testTable1: 'testRelationFieldB'
-                    },
-                    testDatabase2: {
-                        testTable2: 'testRelationFieldB'
-                    }
+            }
+        }, {
+            datastore1: {
+                testDatabase1: {
+                    testTable1: 'testRelationFieldB'
+                },
+                testDatabase2: {
+                    testTable2: 'testRelationFieldB'
                 }
-            }]
-        });
+            }
+        }];
+
+        dashboard.name = 'Test Discovery Config';
+        dashboard.layout = 'DISCOVERY';
+        dashboard.options = new DashboardOptions();
+        this.setCurrentDashboard(dashboard);
     }
 }


### PR DESCRIPTION
Currently, changing the database or table in the widget option (gear) menu immediately updates the widget's options; it does not wait for you to click Apply and is not affected by Cancel.  The same also happened with adding, removing, and changing options of Layers in the Map.

1. I changed the Gear component to create a second WidgetOptionCollection to record modifications (adding `modifiedOptions`) rather than a list of "change" objects (removing `changeList` and `changeLayerList`).

2. I moved the `updateDatabases`, `updateTables`, `updateFields`, and `findField` functions from the BaseNeonComponent to the WidgetOptionCollection (with corresponding unit tests).  The Gear component now calls these functions on the WidgetOptionCollection rather than passing the functions in the event message.  (I also moved `translateFieldKeyToValue` from the BaseNeonComponent to the DatasetService).

3. I separated the BaseNeonComponent's `addLayer` and `removeLayer` functions into multiple functions (one to initialize the change, a second to update the widget itself) that are sent individually to the Gear component.

4. I added static dropdowns for the title, database, and table for layers in the Gear component, changed input element "name" attributes to be unique, and removed some unused functions.

5. I changed the OptionList to accept a WidgetOptionCollection, list of binding keys (to show from the WidgetOptionCollection), and list of fields (needed because, if I just used `options.fields`, the the dropdowns wouldn't update).  I also removed the database and table dropdowns (since they're in the Gear component now).

6. I updated the DatasetServiceMock to create real classes to work with the new DatasetService unit tests.

Please let me know if you have any questions.  Thanks!