### PR TITLE
THOR-1074 Removed isMultiLayerWidget property because it is redundant.

### DIFF
--- a/src/app/components/base-neon-component/base-neon.component.spec.ts
+++ b/src/app/components/base-neon-component/base-neon.component.spec.ts
@@ -256,7 +256,6 @@ describe('BaseNeonComponent', () => {
 
         expect((component as any).errorMessage).toEqual('');
         expect((component as any).initializing).toEqual(false);
-        expect((component as any).isMultiLayerWidget).toEqual(false);
         expect((component as any).loadingCount).toEqual(0);
         expect((component as any).redrawOnResize).toEqual(false);
         expect((component as any).selectedDataId).toEqual('');
@@ -308,7 +307,7 @@ describe('BaseNeonComponent', () => {
     });
 
     it('ngAfterViewInit on multi layer widget does work as expected', () => {
-        (component as any).isMultiLayerWidget = true;
+        component.addLayer(component.options);
         let spyConstruct = spyOn(component, 'constructVisualization');
         let spyExecute = spyOn(component, 'executeAllQueryChain');
         component.ngAfterViewInit();
@@ -513,7 +512,6 @@ describe('BaseNeonComponent', () => {
 
     it('createExportData with multiple layers does return expected data', () => {
         // Setup:  Create multiple layers
-        (component as any).isMultiLayerWidget = true;
         component.addLayer(component.options);
         component.addLayer(component.options);
         expect(component.options.layers.length).toEqual(2);
@@ -658,22 +656,27 @@ describe('BaseNeonComponent', () => {
 
     it('deleteLayer does work as expected', () => {
         component.addLayer(component.options);
+        let id1 = component.options.layers[0]._id;
         expect(component.options.layers.length).toEqual(1);
 
-        (component as any).deleteLayer(component.options, component.options.layers[0]);
-        expect(component.options.layers.length).toEqual(0);
+        let result = (component as any).deleteLayer(component.options, component.options.layers[0]);
+        expect(component.options.layers.length).toEqual(1);
+        expect(component.options.layers[0]._id).toEqual(id1);
+        expect(result).toEqual(false);
 
         component.addLayer(component.options);
-        component.addLayer(component.options);
+        let id2 = component.options.layers[1]._id;
         expect(component.options.layers.length).toEqual(2);
-        let expectedId = component.options.layers[1]._id;
 
-        (component as any).deleteLayer(component.options, component.options.layers[0]);
+        result = (component as any).deleteLayer(component.options, component.options.layers[0]);
         expect(component.options.layers.length).toEqual(1);
-        expect(component.options.layers[0]._id).toEqual(expectedId);
+        expect(component.options.layers[0]._id).toEqual(id2);
+        expect(result).toEqual(true);
 
-        (component as any).deleteLayer(component.options, component.options.layers[0]);
-        expect(component.options.layers.length).toEqual(0);
+        result = (component as any).deleteLayer(component.options, component.options.layers[0]);
+        expect(component.options.layers.length).toEqual(1);
+        expect(component.options.layers[0]._id).toEqual(id2);
+        expect(result).toEqual(false);
     });
 
     it('executeAllQueryChain does call executeQueryChain', () => {
@@ -683,7 +686,6 @@ describe('BaseNeonComponent', () => {
         expect(spy.calls.count()).toEqual(1);
         expect(spy.calls.argsFor(0)).toEqual([component.options]);
 
-        (component as any).isMultiLayerWidget = true;
         component.addLayer(component.options);
         component.addLayer(component.options);
         expect(component.options.layers.length).toEqual(2);
@@ -701,7 +703,6 @@ describe('BaseNeonComponent', () => {
         (component as any).executeAllQueryChain();
         expect(spy.calls.count()).toEqual(0);
 
-        (component as any).isMultiLayerWidget = true;
         component.addLayer(component.options);
         component.addLayer(component.options);
         expect(component.options.layers.length).toEqual(2);
@@ -976,8 +977,6 @@ describe('BaseNeonComponent', () => {
     });
 
     it('getButtonText with multiple layers does return expected string', () => {
-        (component as any).isMultiLayerWidget = true;
-
         expect(component.getButtonText()).toEqual('');
 
         let layerA: any = new WidgetOptionCollection(() => [], undefined, {});

--- a/src/app/components/gear/gear.component.html
+++ b/src/app/components/gear/gear.component.html
@@ -4,7 +4,7 @@
     </mat-form-field>
 
     <!-- MultiLayer Support-->
-    <div *ngIf="modifiedOptions.isMultiLayerWidget">
+    <div *ngIf="modifiedOptions.layers.length">
         <mat-toolbar class="subheader tappable" color="primary" (click)="handleCreateLayer()">
             <mat-icon class="neon-icon-small">add_circle</mat-icon>
             <span class="spacer"></span>
@@ -50,14 +50,14 @@
 
     <!-- Non MultiLayer Support-->
     <div class="option-well">
-        <mat-form-field *ngIf=!modifiedOptions.isMultiLayerWidget class="option-container">
+        <mat-form-field *ngIf=!modifiedOptions.layers.length class="option-container">
             <mat-select placeholder="Database" [(ngModel)]="modifiedOptions.database" required="true" [name]="modifiedOptions._id + '_database'"
                 (ngModelChange)="handleChangeDatabase(modifiedOptions)" [disabled]="modifiedOptions.databases.length < 2">
                 <mat-option *ngFor="let database of modifiedOptions.databases" [value]="database">{{ database.prettyName }}</mat-option>
             </mat-select>
         </mat-form-field>
 
-        <mat-form-field *ngIf=!modifiedOptions.isMultiLayerWidget class="option-container">
+        <mat-form-field *ngIf=!modifiedOptions.layers.length class="option-container">
             <mat-select placeholder="Table" [(ngModel)]="modifiedOptions.table" required="true" [name]="modifiedOptions._id + '_table'"
                 (ngModelChange)="handleChangeTable(modifiedOptions)" [disabled]="modifiedOptions.tables.length < 2">
                 <mat-option *ngFor="let table of modifiedOptions.tables" [value]="table">{{ table.prettyName }}</mat-option>

--- a/src/app/components/gear/gear.component.spec.ts
+++ b/src/app/components/gear/gear.component.spec.ts
@@ -607,6 +607,7 @@ describe('Component: Gear Component', () => {
         let called = 0;
         (component as any).deleteLayer = () => {
             called++;
+            return true;
         };
 
         component.handleDeleteLayer({
@@ -615,6 +616,22 @@ describe('Component: Gear Component', () => {
         expect(called).toEqual(1);
         expect(component.layerHidden.has('testId1')).toEqual(false);
         expect(component.changeMade).toEqual(true);
+    });
+
+    it('handleDeleteLayer does not delete a layer if deleteLayer returned false', () => {
+        component.layerHidden.set('testId1', true);
+        let called = 0;
+        (component as any).deleteLayer = () => {
+            called++;
+            return false;
+        };
+
+        component.handleDeleteLayer({
+            _id: 'testId1'
+        });
+        expect(called).toEqual(1);
+        expect(component.layerHidden.get('testId1')).toEqual(true);
+        expect(component.changeMade).toEqual(false);
     });
 
     it('toggleFilter does update layerHidden', () => {

--- a/src/app/components/gear/gear.component.ts
+++ b/src/app/components/gear/gear.component.ts
@@ -30,13 +30,16 @@ import {
     QueryList
 } from '@angular/core';
 
-import { OptionsListComponent } from '../options-list/options-list.component';
-import { FieldMetaData, SimpleFilter, TableMetaData } from '../../dataset';
-import { DatasetService } from '../../services/dataset.service';
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
-import * as neon from 'neon-framework';
-import { OptionType, WidgetFieldOption, WidgetOption, WidgetOptionCollection } from '../../widget-option';
 import { MatSidenav } from '@angular/material';
+
+import { AbstractWidgetService } from '../../services/abstract.widget.service';
+import { DatasetService } from '../../services/dataset.service';
+import { FieldMetaData, SimpleFilter, TableMetaData } from '../../dataset';
+import { OptionType, WidgetFieldOption, WidgetOption, WidgetOptionCollection } from '../../widget-option';
+import { OptionsListComponent } from '../options-list/options-list.component';
+
+import { neonEvents } from '../../neon-namespaces';
+import * as neon from 'neon-framework';
 
 @Component({
     selector: 'app-gear',
@@ -66,7 +69,7 @@ export class GearComponent implements OnInit, OnDestroy {
     private optionalListNonField: string[] = [];
 
     private createLayer: (options: any, layerBinding?: any) => any;
-    private deleteLayer: (options: any, layerOptions: any) => void;
+    private deleteLayer: (options: any, layerOptions: any) => boolean;
     private exportCallbacks: (() => { name: string, data: any }[])[] = [];
     private finalizeCreateLayer: (layerOptions: any) => void;
     private finalizeDeleteLayer: (layerOptions: any) => void;
@@ -264,9 +267,15 @@ export class GearComponent implements OnInit, OnDestroy {
      * Deletes the given layer.
      */
     public handleDeleteLayer(layer: any) {
-        this.deleteLayer(this.modifiedOptions, layer);
-        this.layerHidden.delete(layer._id);
-        this.changeMade = true;
+        let successful: boolean = this.deleteLayer(this.modifiedOptions, layer);
+        if (successful) {
+            this.layerHidden.delete(layer._id);
+            this.changeMade = true;
+        } else {
+            this.messenger.publish(neonEvents.DASHBOARD_ERROR, {
+                message: 'Cannot delete final layer of ' + this.modifiedOptions.title + ' (' + layer.title + ')'
+            });
+        }
     }
 
     private isFilterData(optionType: OptionType): boolean {

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -121,8 +121,6 @@ export class MapComponent extends BaseNeonComponent implements OnInit, OnDestroy
             ref
         );
 
-        this.isMultiLayerWidget = true;
-
         (<any> window).CESIUM_BASE_URL = 'assets/Cesium';
 
         this.updateOnSelectId = true;
@@ -154,7 +152,6 @@ export class MapComponent extends BaseNeonComponent implements OnInit, OnDestroy
     initializeProperties() {
         // Backwards compatibility (mapType deprecated and replaced by type).
         this.options.type = this.injector.get('mapType', this.options.type);
-        this.options.isMultiLayerWidget = true;
     }
 
     /**
@@ -943,5 +940,15 @@ export class MapComponent extends BaseNeonComponent implements OnInit, OnDestroy
      */
     getVisualizationDefaultTitle(): string {
         return 'Map';
+    }
+
+    /**
+     * Returns whether to create a default layer if no layers are configured.
+     *
+     * @return {boolean}
+     * @override
+     */
+    protected shouldCreateDefaultLayer(): boolean {
+        return true;
     }
 }

--- a/src/app/components/network-graph/network-graph.component.spec.ts
+++ b/src/app/components/network-graph/network-graph.component.spec.ts
@@ -275,7 +275,7 @@ describe('Component: NetworkGraph', () => {
         options.isReified = false;
         options.limit = 3;
 
-        component.initializeProperties(); //need isMultiLayerWidget to be true
+        component.initializeProperties();
         component.transformVisualizationQueryResults(options.layers[0], [{
             testNodeIdField: 'nodeId1',
             testNodeNameField: 'nodeName1',

--- a/src/app/components/network-graph/network-graph.component.ts
+++ b/src/app/components/network-graph/network-graph.component.ts
@@ -264,8 +264,6 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
      * @override
      */
     initializeProperties() {
-        this.isMultiLayerWidget = !!this.options.layers.length;
-
         // Backwards compatibility (showOnlyFiltered deprecated due to its redundancy with hideUnfiltered).
         this.options.hideUnfiltered = this.injector.get('showOnlyFiltered', this.options.hideUnfiltered);
 
@@ -719,7 +717,7 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
         this.neonFilters = this.filterService.getFiltersForFields(options.database.name, options.table.name,
             options.filterFields.map((fieldsObject) => fieldsObject.columnName));
 
-        if (this.isMultiLayerWidget) {
+        if (this.options.layers.length) {
             //TODO: clean up node labels for layers
             this.responseData.push({ options: options, results: results });
 
@@ -773,7 +771,7 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
         this.loadingCount++;
 
         let graphProperties = this.options.isReified ? this.createReifiedGraphProperties() :
-            this.isMultiLayerWidget ? this.createMultiTableGraphProperties() :
+            this.options.layers.length ? this.createMultiTableGraphProperties() :
                 this.createTabularGraphProperties();
 
         if (graphProperties) {

--- a/src/app/widget-option.ts
+++ b/src/app/widget-option.ts
@@ -242,9 +242,7 @@ export class WidgetOptionCollection {
     public database: DatabaseMetaData = null;
     public databases: DatabaseMetaData[] = [];
     public fields: FieldMetaData[] = [];
-    public isMultiLayerWidget: boolean = false;
     public layers: WidgetOptionCollection[] = [];
-    public layeredWidget: boolean = false;
     public table: TableMetaData = null;
     public tables: TableMetaData[] = [];
 
@@ -303,9 +301,7 @@ export class WidgetOptionCollection {
         copy.database = this.database;
         copy.databases = this.databases;
         copy.fields = this.fields;
-        copy.isMultiLayerWidget = this.isMultiLayerWidget;
         copy.layers = this.layers.map((layer) => layer.copy());
-        copy.layeredWidget = this.layeredWidget;
         copy.table = this.table;
         copy.tables = this.tables;
         this.list().forEach((option: WidgetOption) => {


### PR DESCRIPTION
Removed `isMultiLayerWidget` from the BaseNeonComponent on Eddie's suggestion.  Most of the time it is redundant with checking if `options.layers.length > 0`.  Users can no longer remove the final layer of a component with existing layers.  I also added the `shouldCreateDefaultLayer` function.