### PR TITLE
Aida 555

### DIFF
--- a/src/app/components/taxonomy-viewer/taxonomy-viewer.component.html
+++ b/src/app/components/taxonomy-viewer/taxonomy-viewer.component.html
@@ -60,7 +60,7 @@
                 <p></p>
 
                 <mat-form-field>
-                    <mat-select placeholder="Parent Field" [(ngModel)]="options.categoryField" required="true"
+                    <mat-select placeholder="Root Field" [(ngModel)]="options.categoryField" required="true"
                                 (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
                         <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}
@@ -70,7 +70,17 @@
                 <p></p>
 
                 <mat-form-field>
-                    <mat-select placeholder="Child Field" [(ngModel)]="options.typeField" required="false"
+                    <mat-select placeholder="Node Field" [(ngModel)]="options.typeField" required="false"
+                                (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
+                        <mat-option [value]="createEmptyField()">(None)</mat-option>
+                        <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}
+                        </mat-option>
+                    </mat-select>
+                </mat-form-field>
+                <p></p>
+
+                <mat-form-field>
+                    <mat-select placeholder="Leaf Field" [(ngModel)]="options.valueField" required="false"
                                 (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
                         <mat-option [value]="createEmptyField()">(None)</mat-option>
                         <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}

--- a/src/app/components/taxonomy-viewer/taxonomy-viewer.component.html
+++ b/src/app/components/taxonomy-viewer/taxonomy-viewer.component.html
@@ -129,61 +129,29 @@
         <div #taxonomyViewer class="taxonomy-viewer-container">
             <tree-root #treeRoot [nodes]="taxonomyGroups" [options]="testOptions">
                 <ng-template #treeNodeFullTemplate let-node let-index="index" let-templates="templates">
-                    <div
-                        [ngClass]="setClassForTreePosition(node, 'tree-node tree-node-level-')"
-                        [class]="node.getClass()"
-                        [class.tree-node-expanded]="node.isExpanded && node.hasChildren"
-                        [class.tree-node-collapsed]="node.isCollapsed && node.hasChildren"
-                        [class.tree-node-leaf]="node.isLeaf"
-                        [class.tree-node-active]="node.isActive"
-                        [class.tree-node-focused]="node.isFocused">
-
-
-                        <tree-node-drop-slot
-                            *ngIf="index === 0"
-                            [dropIndex]="node.index"
-                            [node]="node.parent">
-                        </tree-node-drop-slot>
-
+                    <div [ngClass]="setClassForTreePosition(node, 'tree-node tree-node-level-')" [class]="node.getClass()">
                         <div class="node-wrapper" [style.padding-left]="node.getNodePadding()">
                             <tree-node-expander [node]="node"></tree-node-expander>
-                            <div class="node-content-wrapper"
-                                 (click)="node.mouseAction('click', $event)"
+                            <div class="node-content-wrapper" (click)="node.mouseAction('click', $event)"
                                  (dblclick)="node.mouseAction('dblClick', $event)"
                                  [class.node-content-wrapper-active]="node.isActive"
                                  [class.node-content-wrapper-focused]="node.isFocused">
-
-
                                 <div *ngIf="node.data.description != options.valueField.columnName">
                                     <input
                                         (change)="checkRelatedNodes( node, $event)"
                                         type="checkbox"
                                         [indeterminate]="node.data.indeterminate"
                                         [checked]="node.data.checked">
-                                    <span (click)="onEvent($event, node)">{{ node.data.name }}<span
-                                        *ngIf="node.data.nodeCount > 0"> ({{ node.data.nodeCount }})</span></span>
+                                    <span>{{ node.data.name }}
+                                        <span *ngIf="node.data.nodeCount > 0"> ({{ node.data.nodeCount }})</span>
+                                    </span>
                                 </div>
-                                <div *ngIf="node.data.description == options.valueField.columnName">
-                                <span>{{ node.data.name }}<span *ngIf="node.data.nodeCount > 0">({{ node.data.nodeCount }})</span>
-                                    <!--
-                                    {{index}} {{node.parent.data.children.length}}-->
-                                </span>
+                                <div *ngIf="node.data.description === options.valueField.columnName">
+                                    <span>{{ node.data.name }}<span *ngIf="node.data.nodeCount > 0"></span></span>
                                 </div>
-
-                                <!--                                           <tree-node-content
-                                    [node]="node"
-                                    [index]="index"
-                                    [template]="templates.treeNodeTemplate">
-
-
-                                </tree-node-content>-->
                             </div>
                         </div>
-
-                        <tree-node-children [node]="node" [templates]="templates">
-                        </tree-node-children>
-                        <tree-node-drop-slot [dropIndex]="node.index + 1" [node]="node.parent">
-                        </tree-node-drop-slot>
+                        <tree-node-children [node]="node" [templates]="templates"></tree-node-children>
                     </div>
                 </ng-template>
             </tree-root>

--- a/src/app/components/taxonomy-viewer/taxonomy-viewer.component.html
+++ b/src/app/components/taxonomy-viewer/taxonomy-viewer.component.html
@@ -1,6 +1,7 @@
 <mat-sidenav-container #visualization class="visualization-sidenav">
     <mat-toolbar class="neon-toolbar-thin" color="header" layout-align="space-between center" flex>
-        <div #headerText class="header text pull-left" [matTooltip]="options.title" tooltip-position="below">{{ options.title }}</div>
+        <div #headerText class="header text pull-left" [matTooltip]="options.title" tooltip-position="below">{{ options.title }}
+        </div>
         <span class="fill-remaining"></span>
         <span #infoText class="info text">
             <span class="error-message" *ngIf="errorMessage" [matTooltip]="errorMessage" tooltip-position="below">
@@ -10,7 +11,8 @@
                 {{ getButtonText() }}
             </span>
         </span>
-        <button mat-icon-button aria-label="Settings" matTooltip="Open/Close the Options Menu" tooltip-position="below" (click)="optionsMenu.toggle();">
+        <button mat-icon-button aria-label="Settings" matTooltip="Open/Close the Options Menu" tooltip-position="below"
+                (click)="optionsMenu.toggle();">
             <mat-icon>settings</mat-icon>
         </button>
     </mat-toolbar>
@@ -40,47 +42,59 @@
                 <p></p>
 
                 <mat-form-field>
-                    <mat-select placeholder="Database" [(ngModel)]="options.database" required="true" (ngModelChange)="handleChangeDatabase()" [disabled]="options.databases.length < 2">
-                        <mat-option *ngFor="let database of options.databases" [value]="database">{{ database.prettyName }}</mat-option>
+                    <mat-select placeholder="Database" [(ngModel)]="options.database" required="true"
+                                (ngModelChange)="handleChangeDatabase()" [disabled]="options.databases.length < 2">
+                        <mat-option *ngFor="let database of options.databases" [value]="database">{{ database.prettyName }}
+                        </mat-option>
                     </mat-select>
                 </mat-form-field>
                 <p></p>
 
                 <mat-form-field>
-                    <mat-select placeholder="Table" [(ngModel)]="options.table" required="true" (ngModelChange)="handleChangeTable()" [disabled]="options.tables.length < 2">
-                        <mat-option *ngFor="let table of options.tables" [value]="table">{{ table.prettyName }}</mat-option>
+                    <mat-select placeholder="Table" [(ngModel)]="options.table" required="true"
+                                (ngModelChange)="handleChangeTable()" [disabled]="options.tables.length < 2">
+                        <mat-option *ngFor="let table of options.tables" [value]="table">{{ table.prettyName }}
+                        </mat-option>
                     </mat-select>
                 </mat-form-field>
                 <p></p>
 
                 <mat-form-field>
-                    <mat-select placeholder="Parent Field" [(ngModel)]="options.categoryField" required="true" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
+                    <mat-select placeholder="Parent Field" [(ngModel)]="options.categoryField" required="true"
+                                (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
                         <mat-option [value]="createEmptyField()">(None)</mat-option>
-                        <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
+                        <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}
+                        </mat-option>
                     </mat-select>
                 </mat-form-field>
                 <p></p>
 
                 <mat-form-field>
-                    <mat-select placeholder="Child Field" [(ngModel)]="options.typeField" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
+                    <mat-select placeholder="Child Field" [(ngModel)]="options.typeField" required="false"
+                                (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
                         <mat-option [value]="createEmptyField()">(None)</mat-option>
-                        <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
+                        <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}
+                        </mat-option>
                     </mat-select>
                 </mat-form-field>
                 <p></p>
 
                 <mat-form-field>
-                    <mat-select placeholder="Filter Field" [(ngModel)]="options.filterFields" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
+                    <mat-select placeholder="Filter Field" [(ngModel)]="options.filterFields" required="false"
+                                (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
                         <mat-option [value]="createEmptyField()">(None)</mat-option>
-                        <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
+                        <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}
+                        </mat-option>
                     </mat-select>
                 </mat-form-field>
                 <p></p>
 
                 <mat-form-field>
-                    <mat-select placeholder="ID Field" [(ngModel)]="options.idField" required="false" (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
+                    <mat-select placeholder="ID Field" [(ngModel)]="options.idField" required="false"
+                                (ngModelChange)="handleChangeData()" [disabled]="options.fields.length < 1">
                         <mat-option [value]="createEmptyField()">(None)</mat-option>
-                        <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}</mat-option>
+                        <mat-option *ngFor="let field of options.fields" [value]="field">{{ field.prettyName }}
+                        </mat-option>
                     </mat-select>
                 </mat-form-field>
                 <p></p>
@@ -95,7 +109,8 @@
                                 <p></p>-->
 
                 <span class="toggle-text">Sort:</span>
-                <mat-button-toggle-group class="neon-button-toggle-group-small" [(ngModel)]="options.ascending" (ngModelChange)="handleChangeData()">
+                <mat-button-toggle-group class="neon-button-toggle-group-small" [(ngModel)]="options.ascending"
+                                         (ngModelChange)="handleChangeData()">
                     <mat-button-toggle [value]="true">Ascending</mat-button-toggle>
                     <mat-button-toggle [value]="false">Descending</mat-button-toggle>
                 </mat-button-toggle-group>
@@ -113,13 +128,63 @@
     <div class="body-container">
         <div #taxonomyViewer class="taxonomy-viewer-container">
             <tree-root #treeRoot [nodes]="taxonomyGroups" [options]="testOptions">
-                <ng-template #treeNodeTemplate let-node="node"  let-index="index">
-                    <input
-                        (change)="checkRelatedNodes( node, $event)"
-                        type="checkbox"
-                        [indeterminate]="node.data.indeterminate"
-                        [checked]="node.data.checked">
-                        <span (click)="onEvent($event, node)">{{ node.data.name }} <span *ngIf="node.data.nodeCount > 0">({{ node.data.nodeCount }})</span></span>
+                <ng-template #treeNodeFullTemplate let-node let-index="index" let-templates="templates">
+                    <div
+                        [ngClass]="setClassForTreePosition(node, 'tree-node tree-node-level-')"
+                        [class]="node.getClass()"
+                        [class.tree-node-expanded]="node.isExpanded && node.hasChildren"
+                        [class.tree-node-collapsed]="node.isCollapsed && node.hasChildren"
+                        [class.tree-node-leaf]="node.isLeaf"
+                        [class.tree-node-active]="node.isActive"
+                        [class.tree-node-focused]="node.isFocused">
+
+
+                        <tree-node-drop-slot
+                            *ngIf="index === 0"
+                            [dropIndex]="node.index"
+                            [node]="node.parent">
+                        </tree-node-drop-slot>
+
+                        <div class="node-wrapper" [style.padding-left]="node.getNodePadding()">
+                            <tree-node-expander [node]="node"></tree-node-expander>
+                            <div class="node-content-wrapper"
+                                 (click)="node.mouseAction('click', $event)"
+                                 (dblclick)="node.mouseAction('dblClick', $event)"
+                                 [class.node-content-wrapper-active]="node.isActive"
+                                 [class.node-content-wrapper-focused]="node.isFocused">
+
+
+                                <div *ngIf="node.data.description != options.valueField.columnName">
+                                    <input
+                                        (change)="checkRelatedNodes( node, $event)"
+                                        type="checkbox"
+                                        [indeterminate]="node.data.indeterminate"
+                                        [checked]="node.data.checked">
+                                    <span (click)="onEvent($event, node)">{{ node.data.name }}<span
+                                        *ngIf="node.data.nodeCount > 0"> ({{ node.data.nodeCount }})</span></span>
+                                </div>
+                                <div *ngIf="node.data.description == options.valueField.columnName">
+                                <span>{{ node.data.name }}<span *ngIf="node.data.nodeCount > 0">({{ node.data.nodeCount }})</span>
+                                    <!--
+                                    {{index}} {{node.parent.data.children.length}}-->
+                                </span>
+                                </div>
+
+                                <!--                                           <tree-node-content
+                                    [node]="node"
+                                    [index]="index"
+                                    [template]="templates.treeNodeTemplate">
+
+
+                                </tree-node-content>-->
+                            </div>
+                        </div>
+
+                        <tree-node-children [node]="node" [templates]="templates">
+                        </tree-node-children>
+                        <tree-node-drop-slot [dropIndex]="node.index + 1" [node]="node.parent">
+                        </tree-node-drop-slot>
+                    </div>
                 </ng-template>
             </tree-root>
         </div>

--- a/src/app/components/taxonomy-viewer/taxonomy-viewer.component.scss
+++ b/src/app/components/taxonomy-viewer/taxonomy-viewer.component.scss
@@ -35,17 +35,7 @@
     font-size: 14px;
 }
 
-
-/deep/ tree-node > .tree-node > .tree-children{
-    border-right: solid 1px red !important;
-}
-
-.toggle-children {
-    z-index: 1;
-}
-
-
-/deep/ tree-node-children > div > tree-node-collection > div > tree-node > .lowest-node-level > tree-node-children > div{
+/deep/ tree-node-children > div > tree-node-collection > div > tree-node > .leaf-node-level > tree-node-children > div{
     border: 1px solid var(--color-text-header, grey);
     max-height: 200px;
     overflow-y: auto;

--- a/src/app/components/taxonomy-viewer/taxonomy-viewer.component.scss
+++ b/src/app/components/taxonomy-viewer/taxonomy-viewer.component.scss
@@ -35,9 +35,22 @@
     font-size: 14px;
 }
 
-.check-all-nodes{
-    padding: 4px;
 
+/deep/ tree-node > .tree-node > .tree-children{
+    border-right: solid 1px red !important;
+}
+
+.toggle-children {
+    z-index: 1;
+}
+
+
+/deep/ tree-node-children > div > tree-node-collection > div > tree-node > .lowest-node-level > tree-node-children > div{
+    border: 1px solid var(--color-text-header, grey);
+    max-height: 200px;
+    overflow-y: auto;
+    padding-left: 0px;
+    width: 92%;
 }
 
 

--- a/src/app/components/taxonomy-viewer/taxonomy-viewer.component.ts
+++ b/src/app/components/taxonomy-viewer/taxonomy-viewer.component.ts
@@ -359,7 +359,9 @@ export class TaxonomyViewerComponent extends BaseNeonComponent implements OnInit
             categories = neonUtilities.deepFind(d, this.options.categoryField.columnName);
 
             if (this.options.typeField.columnName) {
-                types = neonUtilities.deepFind(d, this.options.typeField.columnName);
+                types = neonUtilities.deepFind(d, this.options.typeField.columnName) instanceof Array ?
+                    neonUtilities.deepFind(d, this.options.typeField.columnName) :
+                    [neonUtilities.deepFind(d, this.options.typeField.columnName)];
             }
 
             //TODO: Not fully implemented because subTypes do not currently exist, but might need to be in the future THOR-908
@@ -413,7 +415,9 @@ export class TaxonomyViewerComponent extends BaseNeonComponent implements OnInit
                         if (subTypeNeeded) {
                             subTypeObject = {
                                 id: counter++, name: type, children: [], lineage: category,
-                                description: this.options.subTypeField.columnName, checked: true
+                                description: this.options.subTypeField.columnName ?
+                                    this.options.subTypeField.columnName : this.options.typeField.columnName,
+                                checked: true
                             };
 
                             if (valueObject) {
@@ -514,8 +518,8 @@ export class TaxonomyViewerComponent extends BaseNeonComponent implements OnInit
                 let id = neonUtilities.deepFind(d, this.options.idField.columnName);
                 let sourceIds = neonUtilities.deepFind(d, this.options.sourceIdField.columnName);
                 let description = neonUtilities.deepFind(d, group.description);
-                let nameExists = description instanceof Array ?
-                    description.find((s) => s.includes(group.name)) : description.includes(group.name);
+                let nameExists = description instanceof Array ? description.find((s) => s.includes(group.name)) :
+                    description instanceof String ? description.includes(group.name) : '';
 
                 if (!!nameExists && !group.nodeIds.includes(id)) {
                     group.nodeIds.push(id);

--- a/src/app/config/config.verdi-ta2-ta3.json
+++ b/src/app/config/config.verdi-ta2-ta3.json
@@ -3,7 +3,7 @@
         {
             "title": "VERDI",
             "name": "Seedling LDC TA2 Network",
-            "connectOnLoad": false,
+            "connectOnLoad": true,
             "icon": "assets/images/verdi-favicon.ico",
             "layout": "verdi-ta2-network",
             "datastore": "elasticsearch",
@@ -11,7 +11,7 @@
             "databases": [
                 {
                     "name": "verdi-rdf",
-                    "prettyName": "VERDI RDF",
+                    "prettyName": "Documents",
                     "tables": [
                         {
                             "name": "normal",
@@ -21,11 +21,11 @@
                 },
                 {
                     "name": "kb-simple",
-                    "prettyName": "VERDI SIMPLIFIED",
+                    "prettyName": "Network",
                     "tables": [
                         {
                             "name": "seedling",
-                            "prettyName": "Knowledge Base Simplified"
+                            "prettyName": "seedling"
                         }
                     ]
                 }
@@ -73,7 +73,7 @@
             "databases": [
                 {
                     "name": "verdi-rdf",
-                    "prettyName": "VERDI RDF",
+                    "prettyName": "Documents",
                     "tables": [
                         {
                             "name": "normal",
@@ -83,11 +83,11 @@
                 },
                 {
                     "name": "kb-events",
-                    "prettyName": "VERDI EVENTS",
+                    "prettyName": "Events",
                     "tables": [
                         {
                             "name": "seedling",
-                            "prettyName": "Knowledge Base Events"
+                            "prettyName": "seedling"
                         }
                     ]
                 }
@@ -119,7 +119,7 @@
             "databases": [
                 {
                     "name": "verdi-rdf",
-                    "prettyName": "VERDI RDF",
+                    "prettyName": "Documents",
                     "tables": [
                         {
                             "name": "normal",
@@ -129,11 +129,11 @@
                 },
                 {
                     "name": "kb-geo",
-                    "prettyName": "VERDI CLEAN GEOLOCATION",
+                    "prettyName": "Geolocation",
                     "tables": [
                         {
                             "name": "seedling",
-                            "prettyName": "Knowledge Base Geolocation"
+                            "prettyName": "seedling"
                         }
                     ]
                 }
@@ -157,98 +157,6 @@
         },
         {
             "title": "VERDI",
-            "name": "Seedling LDC TA2 Tabs",
-            "connectOnLoad": true,
-            "layout": "verdi-ta2-tabs",
-            "datastore": "elasticsearch",
-            "hostname": "localhost",
-            "databases": [
-                {
-                    "name": "verdi-rdf",
-                    "prettyName": "VERDI RDF",
-                    "tables": [
-                        {
-                            "name": "normal",
-                            "prettyName": "normal"
-                        }
-                    ]
-                },
-                {
-                    "name": "kb-simple",
-                    "prettyName": "VERDI SIMPLIFIED",
-                    "tables": [
-                        {
-                            "name": "seedling",
-                            "prettyName": "Knowledge Base Simplified"
-                        }
-                    ]
-                },
-                {
-                    "name": "kb-events",
-                    "prettyName": "VERDI EVENTS",
-                    "tables": [
-                        {
-                            "name": "seedling",
-                            "prettyName": "Knowledge Base Events"
-                        }
-                    ]
-                },
-                {
-                    "name": "kb-geo",
-                    "prettyName": "VERDI CLEAN GEOLOCATION",
-                    "tables": [
-                        {
-                            "name": "seedling",
-                            "prettyName": "Knowledge Base Geolocation"
-                        }
-                    ]
-                }
-            ],
-            "relations": [
-                {
-                    "members": [
-                        {
-                            "database": "verdi-rdf",
-                            "table": "normal",
-                            "field": "@id"
-                        },
-                        {
-                            "database": "kb-simple",
-                            "table": "seedling",
-                            "field": "docIds"
-                        },
-                        {
-                            "database": "kb-events",
-                            "table": "seedling",
-                            "field": "docIds"
-                        },
-                        {
-                            "database": "kb-geo",
-                            "table": "seedling",
-                            "field": "docIds"
-                        }
-                    ]
-                }
-            ],
-            "options": {
-                "checkForCoordinateValidation": "null_values",
-                "colorMaps": {
-                    "kb-simple": {
-                        "seedling": {
-                            "categories": {
-                                "ENTITY": "#ADD8E6",
-                                "EVENT": "#D98C8C",
-                                "RELATION": "#FFE4B5"
-                            },
-                            "types": {
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        {
-            "title": "VERDI",
             "name": "Seedling LDC TA3 Network",
             "connectOnLoad": false,
             "layout": "verdi-ta3-network",
@@ -257,25 +165,25 @@
             "databases": [
                 {
                     "name": "verdi-support",
-                    "prettyName": "VERDI",
+                    "prettyName": "Support",
                     "tables": [
                         {
                             "name": "hypothesis_info",
-                            "prettyName": "Hypothesis Info"
+                            "prettyName": "hypotheses"
                         },
                         {
                             "name": "parent_children",
-                            "prettyName": "Parent Children"
+                            "prettyName": "parent children documents"
                         }
                     ]
                 },
                 {
                     "name": "kb-simple",
-                    "prettyName": "VERDI SIMPLIFIED",
+                    "prettyName": "Network",
                     "tables": [
                         {
                             "name": "seedling",
-                            "prettyName": "Knowledge Base Simplified"
+                            "prettyName": "seedling"
                         }
                     ]
                 }
@@ -340,32 +248,32 @@
         {
             "title": "VERDI",
             "name": "Seedling LDC TA3 Events",
-            "connectOnLoad": false,
+            "connectOnLoad": true,
             "layout": "verdi-ta3-events",
             "datastore": "elasticsearch",
             "hostname": "localhost",
             "databases": [
                 {
                     "name": "verdi-support",
-                    "prettyName": "VERDI",
+                    "prettyName": "Support",
                     "tables": [
                         {
                             "name": "hypothesis_info",
-                            "prettyName": "Hypothesis Info"
+                            "prettyName": "hypotheses"
                         },
                         {
                             "name": "parent_children",
-                            "prettyName": "Parent Children"
+                            "prettyName": "parent children documents"
                         }
                     ]
                 },
                 {
                     "name": "kb-events",
-                    "prettyName": "VERDI EVENTS",
+                    "prettyName": "Events",
                     "tables": [
                         {
                             "name": "seedling",
-                            "prettyName": "Knowledge Base Events"
+                            "prettyName": "seedling"
                         }
                     ]
                 }
@@ -421,25 +329,25 @@
             "databases": [
                 {
                     "name": "verdi-support",
-                    "prettyName": "VERDI SUPPORT",
+                    "prettyName": "Support",
                     "tables": [
                         {
                             "name": "hypothesis_info",
-                            "prettyName": "Hypothesis Info"
+                            "prettyName": "hypotheses"
                         },
                         {
                             "name": "parent_children",
-                            "prettyName": "Parent Children"
+                            "prettyName": "parent children documents"
                         }
                     ]
                 },
                 {
                     "name": "kb-geo",
-                    "prettyName": "VERDI CLEAN GEOLOCATION",
+                    "prettyName": "Geolocation",
                     "tables": [
                         {
                             "name": "seedling",
-                            "prettyName": "Knowledge Base Geolocation"
+                            "prettyName": "seedling"
                         }
                     ]
                 }
@@ -487,6 +395,98 @@
         },
         {
             "title": "VERDI",
+            "name": "Seedling LDC TA2 Tabs",
+            "connectOnLoad": true,
+            "layout": "verdi-ta2-tabs",
+            "datastore": "elasticsearch",
+            "hostname": "localhost",
+            "databases": [
+                {
+                    "name": "verdi-rdf",
+                    "prettyName": "Documents",
+                    "tables": [
+                        {
+                            "name": "normal",
+                            "prettyName": "normal"
+                        }
+                    ]
+                },
+                {
+                    "name": "kb-simple",
+                    "prettyName": "Network",
+                    "tables": [
+                        {
+                            "name": "seedling",
+                            "prettyName": "seedling"
+                        }
+                    ]
+                },
+                {
+                    "name": "kb-events",
+                    "prettyName": "Events",
+                    "tables": [
+                        {
+                            "name": "seedling",
+                            "prettyName": "seedling"
+                        }
+                    ]
+                },
+                {
+                    "name": "kb-geo",
+                    "prettyName": "Geolocation",
+                    "tables": [
+                        {
+                            "name": "seedling",
+                            "prettyName": "seedling"
+                        }
+                    ]
+                }
+            ],
+            "relations": [
+                {
+                    "members": [
+                        {
+                            "database": "verdi-rdf",
+                            "table": "normal",
+                            "field": "@id"
+                        },
+                        {
+                            "database": "kb-simple",
+                            "table": "seedling",
+                            "field": "docIds"
+                        },
+                        {
+                            "database": "kb-events",
+                            "table": "seedling",
+                            "field": "docIds"
+                        },
+                        {
+                            "database": "kb-geo",
+                            "table": "seedling",
+                            "field": "docIds"
+                        }
+                    ]
+                }
+            ],
+            "options": {
+                "checkForCoordinateValidation": "null_values",
+                "colorMaps": {
+                    "kb-simple": {
+                        "seedling": {
+                            "categories": {
+                                "ENTITY": "#ADD8E6",
+                                "EVENT": "#D98C8C",
+                                "RELATION": "#FFE4B5"
+                            },
+                            "types": {
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "title": "VERDI",
             "name": "Seedling LDC TA3 Tabs",
             "connectOnLoad": true,
             "layout": "verdi-ta3-tabs",
@@ -495,45 +495,45 @@
             "databases": [
                 {
                     "name": "verdi-support",
-                    "prettyName": "VERDI SUPPORT",
+                    "prettyName": "Support",
                     "tables": [
                         {
                             "name": "hypothesis_info",
-                            "prettyName": "Hypothesis Info"
+                            "prettyName": "hypotheses"
                         },
                         {
                             "name": "parent_children",
-                            "prettyName": "Parent Children"
+                            "prettyName": "parent children documents"
                         }
                     ]
                 },
                 {
                     "name": "kb-simple",
-                    "prettyName": "VERDI SIMPLIFIED",
+                    "prettyName": "Network",
                     "tables": [
                         {
                             "name": "seedling",
-                            "prettyName": "Knowledge Base Simplified"
+                            "prettyName": "seedling"
                         }
                     ]
                 },
                 {
                     "name": "kb-events",
-                    "prettyName": "VERDI EVENTS",
+                    "prettyName": "Events",
                     "tables": [
                         {
                             "name": "seedling",
-                            "prettyName": "Knowledge Base Events"
+                            "prettyName": "seedling"
                         }
                     ]
                 },
                 {
                     "name": "kb-geo",
-                    "prettyName": "VERDI CLEAN GEOLOCATION",
+                    "prettyName": "Geolocation",
                     "tables": [
                         {
                             "name": "seedling",
-                            "prettyName": "Knowledge Base Geolocation"
+                            "prettyName": "seedling"
                         }
                     ]
                 }
@@ -630,6 +630,7 @@
                     "typeField": "types",
                     "subTypeField": "types",
                     "categoryField": "categories",
+                    "valueField": "name",
                     "sourceIdField": "docIds",
                     "filterFields": [
                         "categories",
@@ -702,6 +703,8 @@
                     "title": "Document Timeline",
                     "database": "verdi-rdf",
                     "table": "normal",
+                    "idField": "@id",
+                    "filterField": "@id",
                     "dateField": "date",
                     "granularity": "month",
                     "hideUnfiltered": false
@@ -802,11 +805,17 @@
                     "openOnMouseClick": true,
                     "hideUnfiltered": false,
                     "sortField": "docDate",
-                    "filterField": "kbid",
+                    "filterFields": [
+                        "kbid",
+                        "docIds"
+                    ],
                     "ascending": false,
                     "canvasSize": 180.00,
                     "viewType": "card",
-                    "truncateLabel": {"value":true, "length":35},
+                    "truncateLabel": {
+                        "value": true,
+                        "length": 35
+                    },
                     "limit": 12,
                     "typeMap": {
                         "jpg": "img",
@@ -832,6 +841,8 @@
                     "title": "Event Timeline",
                     "database": "kb-events",
                     "table": "seedling",
+                    "idField": "kbid",
+                    "filterField": "docIds",
                     "dateField": "docDate",
                     "granularity": "month",
                     "hideUnfiltered": false
@@ -924,18 +935,23 @@
                     "hideUnfiltered": false,
                     "showPointDataOnHover": true,
                     "name": "Documents",
-                    "layers": [{
-                        "title": "Map",
-                        "database": "kb-geo",
-                        "table": "seedling",
-                        "latitudeField": "geoLocation.lat",
-                        "longitudeField": "geoLocation.lon",
-                        "hoverPopupField": "name",
-                        "dateField": "docDate",
-                        "idField": "kbid",
-                        "filterFields": ["kbid", "docIds"],
-                        "colorField": "types"
-                    }]
+                    "layers": [
+                        {
+                            "title": "Map",
+                            "database": "kb-geo",
+                            "table": "seedling",
+                            "latitudeField": "geoLocation.lat",
+                            "longitudeField": "geoLocation.lon",
+                            "hoverPopupField": "name",
+                            "dateField": "docDate",
+                            "idField": "kbid",
+                            "filterFields": [
+                                "kbid",
+                                "docIds"
+                            ],
+                            "colorField": "types"
+                        }
+                    ]
                 },
                 "row": 2,
                 "col": 4
@@ -950,6 +966,8 @@
                     "title": "Map Timeline",
                     "database": "kb-geo",
                     "table": "seedling",
+                    "idField": "kbid",
+                    "filterField": "docIds",
                     "dateField": "docDate",
                     "granularity": "month",
                     "hideUnfiltered": false
@@ -998,383 +1016,6 @@
                 "col": 11
             }
         ],
-        "verdi-ta2-tabs": {
-            "Network Graph": [{
-                "type": "taxonomyViewer",
-                "sizex": 3,
-                "sizey": 16,
-                "bindings": {
-                    "id": "_id",
-                    "title": "Ontology",
-                    "database": "kb-simple",
-                    "table": "seedling",
-                    "typeField": "types",
-                    "subTypeField": "types",
-                    "categoryField": "categories",
-                    "sourceIdField": "docIds",
-                    "filterFields": [
-                        "categories",
-                        "types",
-                        "docIds"
-                    ],
-                    "ignoreSelf": true,
-                    "idField": "kbid",
-                    "linkField": "",
-                    "ascending": true
-                },
-                "row": 2,
-                "col": 1
-            },
-                {
-                    "type": "networkGraph",
-                    "sizex": 7,
-                    "sizey": 12,
-                    "bindings": {
-                        "title": "Network Graph",
-                        "database": "kb-simple",
-                        "table": "seedling",
-                        "unsharedFilterField": "",
-                        "unsharedFilterValue": "",
-                        "nodeField": "kbid",
-                        "nodeNameField": "name",
-                        "nodeShape": "box",
-                        "linkField": "edgeTarget",
-                        "linkNameField": "edgeLabel",
-                        "targetNameField": "edgeTargetName",
-                        "nodeColor": "",
-                        "linkColor": "#D1C2F0",
-                        "edgeColor": "#63B4CF",
-                        "xPositionField": "x",
-                        "yPositionField": "y",
-                        "xTargetPositionField": "edgeX",
-                        "yTargetPositionField": "edgeY",
-                        "typeField": "types",
-                        "isReified": false,
-                        "isDirected": true,
-                        "hideUnfiltered": false,
-                        "physics": false,
-                        "filterFields": [
-                            "categories",
-                            "types",
-                            "docIds"
-                        ],
-                        "idField": "kbid",
-                        "id": "_id",
-                        "filterable": true,
-                        "multiFilter": true,
-                        "multiFilterOperator": "or",
-                        "displayLegend": true,
-                        "nodeColorField": "categories",
-                        "targetColorField": "edgeCategories",
-                        "edgeColorField": "",
-                        "cleanLegendLabels": true,
-                        "legendFiltering": false
-                    },
-                    "row": 2,
-                    "col": 4
-                },
-                {
-                    "type": "timeline",
-                    "col": 4,
-                    "row": 16,
-                    "sizex": 7,
-                    "sizey": 4,
-                    "bindings": {
-                        "title": "Document Timeline",
-                        "database": "verdi-rdf",
-                        "table": "normal",
-                        "dateField": "date",
-                        "granularity": "month",
-                        "hideUnfiltered": false
-                    }
-                },
-                {
-                    "type": "thumbnailGrid",
-                    "sizex": 2,
-                    "sizey": 16,
-                    "bindings": {
-                        "id": "_id",
-                        "title": "Documents",
-                        "database": "verdi-rdf",
-                        "table": "normal",
-                        "idField": "@id",
-                        "flagSubLabel1": "@id",
-                        "flagSubLabel2": "date",
-                        "flagSubLabel3": "docType",
-                        "linkField": "url",
-                        "dateField": "date",
-                        "objectNameField": "",
-                        "objectIdField": "@id",
-                        "typeField": "docType",
-                        "predictedNameField": "",
-                        "percentField": "",
-                        "openOnMouseClick": true,
-                        "hideUnfiltered": false,
-                        "sortField": "@id",
-                        "filterField": "@id",
-                        "ignoreSelf": false,
-                        "ascending": true,
-                        "viewType": "details",
-                        "limit": 8,
-                        "typeMap": {
-                            "jpg": "img",
-                            "png": "img",
-                            "mp4": "vid",
-                            "pdf": "pdf",
-                            "ltf": "pdf",
-                            "gif": "img",
-                            "mp3": "aud",
-                            "svg": "img"
-                        }
-                    },
-                    "row": 2,
-                    "col": 11
-                }],
-            "Map": [{
-                "type": "taxonomyViewer",
-                "sizex": 3,
-                "sizey": 16,
-                "bindings": {
-                    "id": "_id",
-                    "title": "Ontology",
-                    "database": "kb-geo",
-                    "table": "seedling",
-                    "typeField": "types",
-                    "subTypeField": "types",
-                    "categoryField": "categories",
-                    "sourceIdField": "docIds",
-                    "filterFields": [
-                        "categories",
-                        "types",
-                        "docIds"
-                    ],
-                    "ignoreSelf": true,
-                    "idField": "kbid",
-                    "linkField": "",
-                    "ascending": true
-                },
-                "row": 2,
-                "col": 1
-            },
-                {
-                    "type": "map",
-                    "sizex": 7,
-                    "sizey": 12,
-                    "bindings": {
-                        "title": "Locations",
-                        "database": "kb-geo",
-                        "table": "seedling",
-                        "show": true,
-                        "type": "cluster",
-                        "limit": 5000,
-                        "mapType": "leaflet",
-                        "singleColor": true,
-                        "filterable": true,
-                        "hideUnfiltered": false,
-                        "showPointDataOnHover": true,
-                        "name": "Documents",
-                        "layers": [{
-                            "title": "Map",
-                            "database": "kb-geo",
-                            "table": "seedling",
-                            "latitudeField": "geoLocation.lat",
-                            "longitudeField": "geoLocation.lon",
-                            "hoverPopupField": "name",
-                            "dateField": "docDate",
-                            "idField": "kbid",
-                            "filterFields": ["kbid", "docIds"],
-                            "colorField": "types"
-                        }]
-                    },
-                    "row": 2,
-                    "col": 4
-                },
-                {
-                    "type": "timeline",
-                    "col": 4,
-                    "row": 16,
-                    "sizex": 7,
-                    "sizey": 4,
-                    "bindings": {
-                        "title": "Map Timeline",
-                        "database": "kb-geo",
-                        "table": "seedling",
-                        "dateField": "docDate",
-                        "granularity": "month",
-                        "hideUnfiltered": false
-                    }
-                },
-                {
-                    "type": "thumbnailGrid",
-                    "sizex": 2,
-                    "sizey": 16,
-                    "bindings": {
-                        "id": "_id",
-                        "title": "Documents",
-                        "database": "verdi-rdf",
-                        "table": "normal",
-                        "idField": "@id",
-                        "flagSubLabel1": "@id",
-                        "flagSubLabel2": "date",
-                        "flagSubLabel3": "docType",
-                        "linkField": "url",
-                        "dateField": "date",
-                        "objectNameField": "",
-                        "objectIdField": "@id",
-                        "typeField": "docType",
-                        "predictedNameField": "",
-                        "percentField": "",
-                        "openOnMouseClick": true,
-                        "hideUnfiltered": false,
-                        "sortField": "@id",
-                        "filterField": "@id",
-                        "ignoreSelf": false,
-                        "ascending": true,
-                        "viewType": "details",
-                        "limit": 8,
-                        "typeMap": {
-                            "jpg": "img",
-                            "png": "img",
-                            "mp4": "vid",
-                            "pdf": "pdf",
-                            "ltf": "pdf",
-                            "gif": "img",
-                            "mp3": "aud",
-                            "svg": "img"
-                        }
-                    },
-                    "row": 2,
-                    "col": 11
-                }],
-            "Events": [ {
-                "type": "taxonomyViewer",
-                "sizex": 3,
-                "sizey": 16,
-                "bindings": {
-                    "id": "_id",
-                    "title": "Ontology",
-                    "database": "kb-events",
-                    "table": "seedling",
-                    "typeField": "types",
-                    "subTypeField": "types",
-                    "categoryField": "categories",
-                    "sourceIdField": "docIds",
-                    "filterFields": [
-                        "categories",
-                        "types",
-                        "docIds"
-                    ],
-                    "ignoreSelf": true,
-                    "idField": "kbid",
-                    "linkField": "",
-                    "ascending": true
-                },
-                "row": 2,
-                "col": 1
-            },
-                {
-                    "type": "thumbnailGrid",
-                    "sizex": 7,
-                    "sizey": 12,
-                    "selected": true,
-                    "bindings": {
-                        "id": "_id",
-                        "title": "Events",
-                        "database": "kb-events",
-                        "table": "seedling",
-                        "idField": "kbid",
-                        "flagLabel": "name",
-                        "flagSubLabel1": "docDate",
-                        "flagSubLabel2": "types",
-                        "flagSubLabel3": "name",
-                        "linkField": "url",
-                        "dateField": "docDate",
-                        "objectNameField": "",
-                        "objectIdField": "kbid",
-                        "typeField": "docType",
-                        "predictedNameField": "",
-                        "percentField": "",
-                        "openOnMouseClick": true,
-                        "hideUnfiltered": false,
-                        "sortField": "docDate",
-                        "filterField": "kbid",
-                        "ascending": false,
-                        "canvasSize": 180.00,
-                        "viewType": "card",
-                        "truncateLabel": {"value":true, "length":35},
-                        "limit": 12,
-                        "typeMap": {
-                            "jpg": "img",
-                            "png": "img",
-                            "mp4": "vid",
-                            "pdf": "pdf",
-                            "ltf": "pdf",
-                            "gif": "img",
-                            "mp3": "aud",
-                            "svg": "img"
-                        }
-                    },
-                    "row": 2,
-                    "col": 4
-                },
-                {
-                    "type": "timeline",
-                    "col": 4,
-                    "row": 16,
-                    "sizex": 7,
-                    "sizey": 4,
-                    "bindings": {
-                        "title": "Event Timeline",
-                        "database": "kb-events",
-                        "table": "seedling",
-                        "dateField": "docDate",
-                        "granularity": "month",
-                        "hideUnfiltered": false
-                    }
-                },
-                {
-                    "type": "thumbnailGrid",
-                    "sizex": 2,
-                    "sizey": 16,
-                    "bindings": {
-                        "id": "_id",
-                        "title": "Documents",
-                        "database": "verdi-rdf",
-                        "table": "normal",
-                        "idField": "@id",
-                        "flagSubLabel1": "isPartOf",
-                        "flagSubLabel2": "date",
-                        "flagSubLabel3": "docType",
-                        "linkField": "url",
-                        "dateField": "date",
-                        "objectNameField": "",
-                        "objectIdField": "@id",
-                        "typeField": "docType",
-                        "predictedNameField": "",
-                        "percentField": "",
-                        "openOnMouseClick": true,
-                        "hideUnfiltered": false,
-                        "sortField": "@id",
-                        "filterField": "@id",
-                        "ignoreSelf": false,
-                        "ascending": true,
-                        "viewType": "details",
-                        "limit": 8,
-                        "typeMap": {
-                            "jpg": "img",
-                            "png": "img",
-                            "mp4": "vid",
-                            "pdf": "pdf",
-                            "ltf": "pdf",
-                            "gif": "img",
-                            "mp3": "aud",
-                            "svg": "img"
-                        }
-                    },
-                    "row": 2,
-                    "col": 11
-                }]
-        },
         "verdi-ta3-network": [
             {
                 "type": "queryBar",
@@ -1432,7 +1073,7 @@
                 "type": "networkGraph",
                 "sizex": 7,
                 "sizey": 12,
-                "bindings":{
+                "bindings": {
                     "title": "Network Graph",
                     "database": "kb-simple",
                     "table": "seedling",
@@ -1529,6 +1170,8 @@
                     "title": "Document Timeline",
                     "database": "verdi-support",
                     "table": "parent_children",
+                    "idField": "id",
+                    "filterField": "id",
                     "dateField": "download_date",
                     "granularity": "month",
                     "hideUnfiltered": true
@@ -1619,11 +1262,17 @@
                     "openOnMouseClick": true,
                     "hideUnfiltered": true,
                     "sortField": "docDate",
-                    "filterFields": ["kbid", "docIds"],
+                    "filterFields": [
+                        "kbid",
+                        "docIds"
+                    ],
                     "ascending": false,
                     "canvasSize": 180.00,
                     "viewType": "card",
-                    "truncateLabel": {"value":true, "length":35},
+                    "truncateLabel": {
+                        "value": true,
+                        "length": 35
+                    },
                     "limit": 12,
                     "typeMap": {
                         "jpg": "img",
@@ -1691,9 +1340,9 @@
                     "database": "kb-events",
                     "table": "seedling",
                     "dateField": "docDate",
-                    "filterFields": ["docIds"],
+                    "idField": "kbid",
+                    "filterField": "docIds",
                     "granularity": "month",
-                    "limit": 1000,
                     "hideUnfiltered": true
                 }
             }
@@ -1768,18 +1417,23 @@
                     "hideUnfiltered": true,
                     "showPointDataOnHover": true,
                     "name": "Documents",
-                    "layers": [{
-                        "title": "Map",
-                        "database": "kb-geo",
-                        "table": "seedling",
-                        "latitudeField": "geoLocation.lat",
-                        "longitudeField": "geoLocation.lon",
-                        "hoverPopupField": "name",
-                        "dateField": "docDate",
-                        "idField": "kbid",
-                        "filterFields": ["kbid", "docIds"],
-                        "colorField": "types"
-                    }]
+                    "layers": [
+                        {
+                            "title": "Map",
+                            "database": "kb-geo",
+                            "table": "seedling",
+                            "latitudeField": "geoLocation.lat",
+                            "longitudeField": "geoLocation.lon",
+                            "hoverPopupField": "name",
+                            "dateField": "docDate",
+                            "idField": "kbid",
+                            "filterFields": [
+                                "kbid",
+                                "docIds"
+                            ],
+                            "colorField": "types"
+                        }
+                    ]
                 },
                 "row": 2,
                 "col": 4
@@ -1835,42 +1489,445 @@
                     "title": "Map Timeline",
                     "database": "kb-geo",
                     "table": "seedling",
+                    "idField": "kbid",
+                    "filterField": "docIds",
                     "dateField": "docDate",
                     "granularity": "month",
                     "hideUnfiltered": true
                 }
             }
         ],
-        "verdi-ta3-tabs": {
-            "Network Graph": [{
-                "type": "queryBar",
-                "sizex": 12,
-                "sizey": 1,
-                "bindings": {
-                    "database": "verdi-support",
-                    "table": "hypothesis_info",
-                    "idField": "hypothesis_id",
-                    "filterField": "query",
-                    "placeHolder": "Query Hypotheses",
-                    "extendedFilter": true,
-                    "extensionFields": [
-                        {
-                            "database": "verdi-support",
-                            "table": "hypothesis_info",
-                            "idField": "hypothesis_id",
-                            "filterField": "query"
-                        },
-                        {
-                            "database": "kb-simple",
-                            "table": "seedling",
-                            "idField": "docIds",
-                            "filterField": "hypotheses"
-                        }
-                    ]
+        "verdi-ta2-tabs": {
+            "Network Graph": [
+                {
+                    "type": "taxonomyViewer",
+                    "sizex": 3,
+                    "sizey": 16,
+                    "bindings": {
+                        "id": "_id",
+                        "title": "Ontology",
+                        "database": "kb-simple",
+                        "table": "seedling",
+                        "typeField": "types",
+                        "subTypeField": "types",
+                        "categoryField": "categories",
+                        "sourceIdField": "docIds",
+                        "filterFields": [
+                            "categories",
+                            "types",
+                            "docIds"
+                        ],
+                        "ignoreSelf": true,
+                        "idField": "kbid",
+                        "linkField": "",
+                        "ascending": true
+                    },
+                    "row": 2,
+                    "col": 1
                 },
-                "row": 1,
-                "col": 1
-            },
+                {
+                    "type": "networkGraph",
+                    "sizex": 7,
+                    "sizey": 12,
+                    "bindings": {
+                        "title": "Network Graph",
+                        "database": "kb-simple",
+                        "table": "seedling",
+                        "unsharedFilterField": "",
+                        "unsharedFilterValue": "",
+                        "nodeField": "kbid",
+                        "nodeNameField": "name",
+                        "nodeShape": "box",
+                        "linkField": "edgeTarget",
+                        "linkNameField": "edgeLabel",
+                        "targetNameField": "edgeTargetName",
+                        "nodeColor": "",
+                        "linkColor": "#D1C2F0",
+                        "edgeColor": "#63B4CF",
+                        "xPositionField": "x",
+                        "yPositionField": "y",
+                        "xTargetPositionField": "edgeX",
+                        "yTargetPositionField": "edgeY",
+                        "typeField": "types",
+                        "isReified": false,
+                        "isDirected": true,
+                        "hideUnfiltered": false,
+                        "physics": false,
+                        "filterFields": [
+                            "categories",
+                            "types",
+                            "docIds"
+                        ],
+                        "idField": "kbid",
+                        "id": "_id",
+                        "filterable": true,
+                        "multiFilter": true,
+                        "multiFilterOperator": "or",
+                        "displayLegend": true,
+                        "nodeColorField": "categories",
+                        "targetColorField": "edgeCategories",
+                        "edgeColorField": "",
+                        "cleanLegendLabels": true,
+                        "legendFiltering": false
+                    },
+                    "row": 2,
+                    "col": 4
+                },
+                {
+                    "type": "timeline",
+                    "col": 4,
+                    "row": 16,
+                    "sizex": 7,
+                    "sizey": 4,
+                    "bindings": {
+                        "title": "Document Timeline",
+                        "database": "verdi-rdf",
+                        "table": "normal",
+                        "idField": "@id",
+                        "filterField": "@id",
+                        "dateField": "date",
+                        "granularity": "month",
+                        "hideUnfiltered": false
+                    }
+                },
+                {
+                    "type": "thumbnailGrid",
+                    "sizex": 2,
+                    "sizey": 16,
+                    "bindings": {
+                        "id": "_id",
+                        "title": "Documents",
+                        "database": "verdi-rdf",
+                        "table": "normal",
+                        "idField": "@id",
+                        "flagSubLabel1": "@id",
+                        "flagSubLabel2": "date",
+                        "flagSubLabel3": "docType",
+                        "linkField": "url",
+                        "dateField": "date",
+                        "objectNameField": "",
+                        "objectIdField": "@id",
+                        "typeField": "docType",
+                        "predictedNameField": "",
+                        "percentField": "",
+                        "openOnMouseClick": true,
+                        "hideUnfiltered": false,
+                        "sortField": "@id",
+                        "filterField": "@id",
+                        "ignoreSelf": false,
+                        "ascending": true,
+                        "viewType": "details",
+                        "limit": 8,
+                        "typeMap": {
+                            "jpg": "img",
+                            "png": "img",
+                            "mp4": "vid",
+                            "pdf": "pdf",
+                            "ltf": "pdf",
+                            "gif": "img",
+                            "mp3": "aud",
+                            "svg": "img"
+                        }
+                    },
+                    "row": 2,
+                    "col": 11
+                }
+            ],
+            "Map": [
+                {
+                    "type": "taxonomyViewer",
+                    "sizex": 3,
+                    "sizey": 16,
+                    "bindings": {
+                        "id": "_id",
+                        "title": "Ontology",
+                        "database": "kb-geo",
+                        "table": "seedling",
+                        "typeField": "types",
+                        "subTypeField": "types",
+                        "categoryField": "categories",
+                        "sourceIdField": "docIds",
+                        "filterFields": [
+                            "categories",
+                            "types",
+                            "docIds"
+                        ],
+                        "ignoreSelf": true,
+                        "idField": "kbid",
+                        "linkField": "",
+                        "ascending": true
+                    },
+                    "row": 2,
+                    "col": 1
+                },
+                {
+                    "type": "map",
+                    "sizex": 7,
+                    "sizey": 12,
+                    "bindings": {
+                        "title": "Locations",
+                        "database": "kb-geo",
+                        "table": "seedling",
+                        "show": true,
+                        "type": "cluster",
+                        "limit": 5000,
+                        "mapType": "leaflet",
+                        "singleColor": true,
+                        "filterable": true,
+                        "hideUnfiltered": false,
+                        "showPointDataOnHover": true,
+                        "name": "Documents",
+                        "layers": [
+                            {
+                                "title": "Map",
+                                "database": "kb-geo",
+                                "table": "seedling",
+                                "latitudeField": "geoLocation.lat",
+                                "longitudeField": "geoLocation.lon",
+                                "hoverPopupField": "name",
+                                "dateField": "docDate",
+                                "idField": "kbid",
+                                "filterFields": [
+                                    "kbid",
+                                    "docIds"
+                                ],
+                                "colorField": "types"
+                            }
+                        ]
+                    },
+                    "row": 2,
+                    "col": 4
+                },
+                {
+                    "type": "timeline",
+                    "col": 4,
+                    "row": 16,
+                    "sizex": 7,
+                    "sizey": 4,
+                    "bindings": {
+                        "title": "Map Timeline",
+                        "database": "kb-geo",
+                        "table": "seedling",
+                        "idField": "kbid",
+                        "filterField": "docIds",
+                        "dateField": "docDate",
+                        "granularity": "month",
+                        "hideUnfiltered": false
+                    }
+                },
+                {
+                    "type": "thumbnailGrid",
+                    "sizex": 2,
+                    "sizey": 16,
+                    "bindings": {
+                        "id": "_id",
+                        "title": "Documents",
+                        "database": "verdi-rdf",
+                        "table": "normal",
+                        "idField": "@id",
+                        "flagSubLabel1": "@id",
+                        "flagSubLabel2": "date",
+                        "flagSubLabel3": "docType",
+                        "linkField": "url",
+                        "dateField": "date",
+                        "objectNameField": "",
+                        "objectIdField": "@id",
+                        "typeField": "docType",
+                        "predictedNameField": "",
+                        "percentField": "",
+                        "openOnMouseClick": true,
+                        "hideUnfiltered": false,
+                        "sortField": "@id",
+                        "filterField": "@id",
+                        "ignoreSelf": false,
+                        "ascending": true,
+                        "viewType": "details",
+                        "limit": 8,
+                        "typeMap": {
+                            "jpg": "img",
+                            "png": "img",
+                            "mp4": "vid",
+                            "pdf": "pdf",
+                            "ltf": "pdf",
+                            "gif": "img",
+                            "mp3": "aud",
+                            "svg": "img"
+                        }
+                    },
+                    "row": 2,
+                    "col": 11
+                }
+            ],
+            "Events": [
+                {
+                    "type": "taxonomyViewer",
+                    "sizex": 3,
+                    "sizey": 16,
+                    "bindings": {
+                        "id": "_id",
+                        "title": "Ontology",
+                        "database": "kb-events",
+                        "table": "seedling",
+                        "typeField": "types",
+                        "subTypeField": "types",
+                        "categoryField": "categories",
+                        "sourceIdField": "docIds",
+                        "filterFields": [
+                            "categories",
+                            "types",
+                            "docIds"
+                        ],
+                        "ignoreSelf": true,
+                        "idField": "kbid",
+                        "linkField": "",
+                        "ascending": true
+                    },
+                    "row": 2,
+                    "col": 1
+                },
+                {
+                    "type": "thumbnailGrid",
+                    "sizex": 7,
+                    "sizey": 12,
+                    "selected": true,
+                    "bindings": {
+                        "id": "_id",
+                        "title": "Events",
+                        "database": "kb-events",
+                        "table": "seedling",
+                        "idField": "kbid",
+                        "flagLabel": "name",
+                        "flagSubLabel1": "docDate",
+                        "flagSubLabel2": "types",
+                        "flagSubLabel3": "name",
+                        "linkField": "url",
+                        "dateField": "docDate",
+                        "objectNameField": "",
+                        "objectIdField": "kbid",
+                        "typeField": "docType",
+                        "predictedNameField": "",
+                        "percentField": "",
+                        "openOnMouseClick": true,
+                        "hideUnfiltered": false,
+                        "sortField": "docDate",
+                        "filterFields": [
+                            "kbid",
+                            "docIds"
+                        ],
+                        "ascending": false,
+                        "canvasSize": 180.00,
+                        "viewType": "card",
+                        "truncateLabel": {
+                            "value": true,
+                            "length": 35
+                        },
+                        "limit": 12,
+                        "typeMap": {
+                            "jpg": "img",
+                            "png": "img",
+                            "mp4": "vid",
+                            "pdf": "pdf",
+                            "ltf": "pdf",
+                            "gif": "img",
+                            "mp3": "aud",
+                            "svg": "img"
+                        }
+                    },
+                    "row": 2,
+                    "col": 4
+                },
+                {
+                    "type": "timeline",
+                    "col": 4,
+                    "row": 16,
+                    "sizex": 7,
+                    "sizey": 4,
+                    "bindings": {
+                        "title": "Event Timeline",
+                        "database": "kb-events",
+                        "table": "seedling",
+                        "idField": "kbid",
+                        "filterField": "docIds",
+                        "dateField": "docDate",
+                        "granularity": "month",
+                        "hideUnfiltered": false
+                    }
+                },
+                {
+                    "type": "thumbnailGrid",
+                    "sizex": 2,
+                    "sizey": 16,
+                    "bindings": {
+                        "id": "_id",
+                        "title": "Documents",
+                        "database": "verdi-rdf",
+                        "table": "normal",
+                        "idField": "@id",
+                        "flagSubLabel1": "isPartOf",
+                        "flagSubLabel2": "date",
+                        "flagSubLabel3": "docType",
+                        "linkField": "url",
+                        "dateField": "date",
+                        "objectNameField": "",
+                        "objectIdField": "@id",
+                        "typeField": "docType",
+                        "predictedNameField": "",
+                        "percentField": "",
+                        "openOnMouseClick": true,
+                        "hideUnfiltered": false,
+                        "sortField": "@id",
+                        "filterField": "@id",
+                        "ignoreSelf": false,
+                        "ascending": true,
+                        "viewType": "details",
+                        "limit": 8,
+                        "typeMap": {
+                            "jpg": "img",
+                            "png": "img",
+                            "mp4": "vid",
+                            "pdf": "pdf",
+                            "ltf": "pdf",
+                            "gif": "img",
+                            "mp3": "aud",
+                            "svg": "img"
+                        }
+                    },
+                    "row": 2,
+                    "col": 11
+                }
+            ]
+        },
+        "verdi-ta3-tabs": {
+            "Network Graph": [
+                {
+                    "type": "queryBar",
+                    "sizex": 12,
+                    "sizey": 1,
+                    "bindings": {
+                        "database": "verdi-support",
+                        "table": "hypothesis_info",
+                        "idField": "hypothesis_id",
+                        "filterField": "query",
+                        "placeHolder": "Query Hypotheses",
+                        "extendedFilter": true,
+                        "extensionFields": [
+                            {
+                                "database": "verdi-support",
+                                "table": "hypothesis_info",
+                                "idField": "hypothesis_id",
+                                "filterField": "query"
+                            },
+                            {
+                                "database": "kb-simple",
+                                "table": "seedling",
+                                "idField": "docIds",
+                                "filterField": "hypotheses"
+                            }
+                        ]
+                    },
+                    "row": 1,
+                    "col": 1
+                },
                 {
                     "type": "newsFeed",
                     "sizex": 3,
@@ -1898,7 +1955,7 @@
                     "type": "networkGraph",
                     "sizex": 7,
                     "sizey": 12,
-                    "bindings":{
+                    "bindings": {
                         "title": "Network Graph",
                         "database": "kb-simple",
                         "table": "seedling",
@@ -1995,40 +2052,44 @@
                         "title": "Document Timeline",
                         "database": "verdi-support",
                         "table": "parent_children",
+                        "idField": "id",
+                        "filterField": "id",
                         "dateField": "download_date",
                         "granularity": "month",
                         "hideUnfiltered": true
                     }
-                }],
-            "Map": [{
-                "type": "queryBar",
-                "sizex": 12,
-                "sizey": 1,
-                "bindings": {
-                    "database": "verdi-support",
-                    "table": "hypothesis_info",
-                    "idField": "hypothesis_id",
-                    "filterField": "query",
-                    "placeHolder": "Query Hypotheses",
-                    "extendedFilter": true,
-                    "extensionFields": [
-                        {
-                            "database": "verdi-support",
-                            "table": "hypothesis_info",
-                            "idField": "hypothesis_id",
-                            "filterField": "query"
-                        },
-                        {
-                            "database": "kb-geo",
-                            "table": "seedling",
-                            "idField": "docIds",
-                            "filterField": "hypotheses"
-                        }
-                    ]
+                }
+            ],
+            "Map": [
+                {
+                    "type": "queryBar",
+                    "sizex": 12,
+                    "sizey": 1,
+                    "bindings": {
+                        "database": "verdi-support",
+                        "table": "hypothesis_info",
+                        "idField": "hypothesis_id",
+                        "filterField": "query",
+                        "placeHolder": "Query Hypotheses",
+                        "extendedFilter": true,
+                        "extensionFields": [
+                            {
+                                "database": "verdi-support",
+                                "table": "hypothesis_info",
+                                "idField": "hypothesis_id",
+                                "filterField": "query"
+                            },
+                            {
+                                "database": "kb-geo",
+                                "table": "seedling",
+                                "idField": "docIds",
+                                "filterField": "hypotheses"
+                            }
+                        ]
+                    },
+                    "row": 1,
+                    "col": 1
                 },
-                "row": 1,
-                "col": 1
-            },
                 {
                     "type": "newsFeed",
                     "sizex": 3,
@@ -2141,46 +2202,50 @@
                         "title": "Map Timeline",
                         "database": "kb-geo",
                         "table": "seedling",
+                        "idField": "kbid",
+                        "filterField": "docIds",
                         "dateField": "docDate",
                         "granularity": "month",
                         "hideUnfiltered": true
                     }
-                }],
-            "Events": [{
-                "type": "queryBar",
-                "sizex": 12,
-                "sizey": 1,
-                "bindings": {
-                    "database": "verdi-support",
-                    "table": "hypothesis_info",
-                    "idField": "hypothesis_id",
-                    "filterField": "query",
-                    "placeHolder": "Query Hypotheses",
-                    "extendedFilter": true,
-                    "extensionFields": [
-                        {
-                            "database": "verdi-support",
-                            "table": "hypothesis_info",
-                            "idField": "hypothesis_id",
-                            "filterField": "query"
-                        },
-                        {
-                            "database": "kb-events",
-                            "table": "seedling",
-                            "idField": "kbid",
-                            "filterField": "hypotheses"
-                        },
-                        {
-                            "database": "kb-events",
-                            "table": "seedling",
-                            "idField": "docIds",
-                            "filterField": "hypotheses"
-                        }
-                    ]
+                }
+            ],
+            "Events": [
+                {
+                    "type": "queryBar",
+                    "sizex": 12,
+                    "sizey": 1,
+                    "bindings": {
+                        "database": "verdi-support",
+                        "table": "hypothesis_info",
+                        "idField": "hypothesis_id",
+                        "filterField": "query",
+                        "placeHolder": "Query Hypotheses",
+                        "extendedFilter": true,
+                        "extensionFields": [
+                            {
+                                "database": "verdi-support",
+                                "table": "hypothesis_info",
+                                "idField": "hypothesis_id",
+                                "filterField": "query"
+                            },
+                            {
+                                "database": "kb-events",
+                                "table": "seedling",
+                                "idField": "kbid",
+                                "filterField": "hypotheses"
+                            },
+                            {
+                                "database": "kb-events",
+                                "table": "seedling",
+                                "idField": "docIds",
+                                "filterField": "hypotheses"
+                            }
+                        ]
+                    },
+                    "row": 1,
+                    "col": 1
                 },
-                "row": 1,
-                "col": 1
-            },
                 {
                     "type": "newsFeed",
                     "sizex": 3,
@@ -2229,11 +2294,17 @@
                         "openOnMouseClick": true,
                         "hideUnfiltered": true,
                         "sortField": "docDate",
-                        "filterFields": ["kbid", "docIds"],
+                        "filterFields": [
+                            "kbid",
+                            "docIds"
+                        ],
                         "ascending": false,
                         "canvasSize": 180.00,
                         "viewType": "card",
-                        "truncateLabel": {"value":true, "length":35},
+                        "truncateLabel": {
+                            "value": true,
+                            "length": 35
+                        },
                         "limit": 12,
                         "typeMap": {
                             "jpg": "img",
@@ -2301,12 +2372,14 @@
                         "database": "kb-events",
                         "table": "seedling",
                         "dateField": "docDate",
-                        "filterFields": ["docIds"],
+                        "idField": "kbid",
+                        "filterField": "docIds",
                         "granularity": "month",
                         "limit": 1000,
                         "hideUnfiltered": true
                     }
-                }]
+                }
+            ]
         }
     }
 }

--- a/src/app/config/config.verdi-ta2-ta3.json
+++ b/src/app/config/config.verdi-ta2-ta3.json
@@ -248,7 +248,7 @@
         {
             "title": "VERDI",
             "name": "Seedling LDC TA3 Events",
-            "connectOnLoad": true,
+            "connectOnLoad": false,
             "layout": "verdi-ta3-events",
             "datastore": "elasticsearch",
             "hostname": "localhost",
@@ -396,7 +396,7 @@
         {
             "title": "VERDI",
             "name": "Seedling LDC TA2 Tabs",
-            "connectOnLoad": true,
+            "connectOnLoad": false,
             "layout": "verdi-ta2-tabs",
             "datastore": "elasticsearch",
             "hostname": "localhost",
@@ -488,7 +488,7 @@
         {
             "title": "VERDI",
             "name": "Seedling LDC TA3 Tabs",
-            "connectOnLoad": true,
+            "connectOnLoad": false,
             "layout": "verdi-ta3-tabs",
             "datastore": "elasticsearch",
             "hostname": "localhost",
@@ -629,8 +629,8 @@
                     "table": "seedling",
                     "typeField": "types",
                     "subTypeField": "types",
-                    "categoryField": "categories",
                     "valueField": "name",
+                    "categoryField": "categories",
                     "sourceIdField": "docIds",
                     "filterFields": [
                         "categories",
@@ -765,6 +765,7 @@
                     "table": "seedling",
                     "typeField": "types",
                     "subTypeField": "types",
+                    "valueField": "name",
                     "categoryField": "categories",
                     "sourceIdField": "docIds",
                     "filterFields": [
@@ -903,6 +904,7 @@
                     "table": "seedling",
                     "typeField": "types",
                     "subTypeField": "types",
+                    "valueField": "name",
                     "categoryField": "categories",
                     "sourceIdField": "docIds",
                     "filterFields": [
@@ -1510,6 +1512,7 @@
                         "table": "seedling",
                         "typeField": "types",
                         "subTypeField": "types",
+                        "valueField": "name",
                         "categoryField": "categories",
                         "sourceIdField": "docIds",
                         "filterFields": [
@@ -1645,6 +1648,7 @@
                         "table": "seedling",
                         "typeField": "types",
                         "subTypeField": "types",
+                        "valueField": "name",
                         "categoryField": "categories",
                         "sourceIdField": "docIds",
                         "filterFields": [
@@ -1770,6 +1774,7 @@
                         "table": "seedling",
                         "typeField": "types",
                         "subTypeField": "types",
+                        "valueField": "name",
                         "categoryField": "categories",
                         "sourceIdField": "docIds",
                         "filterFields": [


### PR DESCRIPTION
I added leaf nodes at the lowest level of the taxonomy to represent the name values in the AIDA seedling data. The leaf nodes do not have checkboxes or filtering capability like the other nodes in the taxonomy. They simply exist as a reference for the user. The leaf node level is styled as a scrolling div for separation, neatness, and legibility. The values can be hidden or shown using the settings menu in the taxonomy widget.