### PR TITLE
THOR-942 Filter Refactor (Filter Builder)

### DIFF
--- a/src/app/components/filter-builder/filter-builder.component.html
+++ b/src/app/components/filter-builder/filter-builder.component.html
@@ -1,71 +1,71 @@
 <div class="header-filter-options">
     <div layout-align="space-between center">
-        <button mat-icon-button aria-label="Add" matTooltip="Add New Clause" matTooltipPosition="below" (click)="addBlankFilterClause()">
+        <button mat-icon-button aria-label="Add" matTooltip="Add Filter Clause" matTooltipPosition="below"
+                (click)="addBlankFilterClause()">
             <mat-icon>add_circle</mat-icon>
         </button>
 
-        <button mat-icon-button aria-label="Reset" matTooltip="Reset Filter Builder" matTooltipPosition="below"
-                (click)="resetFilterBuilder()">
-            <mat-icon>delete_sweep</mat-icon>
+        <button mat-icon-button area-label="Save" matTooltip="Save Custom Filter" tooltip-position="below"
+                [disabled]="!validateFilters(filterClauses)" (click)="saveFilter()">
+            <mat-icon>save</mat-icon>
         </button>
 
-        <mat-button-toggle-group #operatorToggle="matButtonToggleGroup" [(ngModel)]="options.requireAll" (change)="updateFilters()"
+        <mat-button-toggle-group #operatorToggle="matButtonToggleGroup" [(ngModel)]="requireAll"
                 class="neon-button-toggle-group-small">
             <mat-button-toggle [value]="true">AND</mat-button-toggle>
             <mat-button-toggle [value]="false">OR</mat-button-toggle>
         </mat-button-toggle-group>
+
+        <button mat-icon-button aria-label="Clear" matTooltip="Clear Custom Filter" matTooltipPosition="below"
+                (click)="clearEveryFilterClause()">
+            <mat-icon>delete_sweep</mat-icon>
+        </button>
     </div>
 </div>
 
-<div class="clause-container" *ngFor="let clause of clauses">
+<div class="clause-container" *ngFor="let filterClause of filterClauses">
     <div class="clause-form-container">
         <mat-form-field class="neon-form-field-flex-5 neon-form-field">
-            <mat-select placeholder="Database" [(ngModel)]="clause.changeDatabase"
-                        required="true" (ngModelChange)="handleChangeDatabaseOfClause(clause)"
-                        [disabled]="clause.databases.length < 2">
-                <mat-option *ngFor="let database of clause.databases" [value]="database">{{ database.prettyName }}</mat-option>
+            <mat-select placeholder="Database" [(ngModel)]="filterClause.changeDatabase"
+                        required="true" (ngModelChange)="handleChangeDatabaseOfClause(filterClause)"
+                        [disabled]="filterClause.databases.length < 2">
+                <mat-option *ngFor="let database of filterClause.databases" [value]="database">{{ database.prettyName }}</mat-option>
             </mat-select>
         </mat-form-field>
 
         <mat-form-field class="neon-form-field-flex-5 neon-form-field">
-            <mat-select placeholder="Table" [(ngModel)]="clause.changeTable"
-                        required="true" (ngModelChange)="handleChangeTableOfClause(clause)"
-                        [disabled]="clause.tables.length < 2">
-                <mat-option *ngFor="let table of clause.tables" [value]="table">{{ table.prettyName }}</mat-option>
+            <mat-select placeholder="Table" [(ngModel)]="filterClause.changeTable"
+                        required="true" (ngModelChange)="handleChangeTableOfClause(filterClause)"
+                        [disabled]="filterClause.tables.length < 2">
+                <mat-option *ngFor="let table of filterClause.tables" [value]="table">{{ table.prettyName }}</mat-option>
             </mat-select>
         </mat-form-field>
 
         <mat-form-field class="neon-form-field-flex-5 neon-form-field">
-            <mat-select placeholder="Field" [(ngModel)]="clause.changeField"
-                        required="true" (ngModelChange)="handleChangeFieldOfClause(clause)"
-                        [disabled]="clause.fields.length == 0">
-                <mat-option *ngFor="let field of clause.fields" [value]="field">{{ field.prettyName }}</mat-option>
+            <mat-select placeholder="Field" [(ngModel)]="filterClause.changeField"
+                        required="true" (ngModelChange)="handleChangeFieldOfClause(filterClause)"
+                        [disabled]="filterClause.fields.length == 0">
+                <mat-option *ngFor="let field of filterClause.fields" [value]="field">{{ field.prettyName }}</mat-option>
             </mat-select>
         </mat-form-field>
 
         <mat-form-field class="neon-form-field-flex-5 neon-form-field">
-            <mat-select placeholder="Operator" [(ngModel)]="clause.operator"
-                        required="true" (ngModelChange)="handleChangeDataOfClause(clause)"
+            <mat-select placeholder="Operator" [(ngModel)]="filterClause.operator"
+                        required="true" (ngModelChange)="handleChangeDataOfClause(filterClause)"
                         [disabled]="operators.length == 0">
                 <mat-option *ngFor="let operator of operators" [value]="operator">{{ operator.prettyName }}</mat-option>
             </mat-select>
         </mat-form-field>
 
         <mat-form-field class="neon-form-field-flex-5 neon-form-field">
-            <input matInput placeholder="Value" [(ngModel)]="clause.value" (input)="handleChangeDataOfClause(clause)"
-                    (keyup.enter)="toggleClause(clause)">
+            <input matInput placeholder="Value" [(ngModel)]="filterClause.value" (input)="handleChangeDataOfClause(filterClause)"
+                    (keyup.enter)="saveFilter(filterClause)">
         </mat-form-field>
     </div>
 
     <div class="clause-button-container">
-        <button mat-icon-button class="neon-icon-button clause-button" [class.active]="clause.active"
-                [matTooltip]="'Filter is ' + (clause.active ? 'On' : 'Off') + ' (Click to Toggle)'" tooltip-position="below"
-                [disabled]="!validateClause(clause)" (click)="toggleClause(clause)">
-            <mat-icon class="neon-icon">check_circle</mat-icon>
-        </button>
-
-        <button mat-icon-button class="neon-icon-button clause-button" (click)="removeClause(clause)"
-                matTooltip="Remove Filter" matTooltipPosition="below">
+        <button mat-icon-button class="neon-icon-button clause-button" (click)="removeClause(filterClause)"
+                matTooltip="Remove Filter Clause" matTooltipPosition="below">
             <mat-icon class="neon-icon">delete</mat-icon>
         </button>
     </div>

--- a/src/app/components/filter-builder/filter-builder.component.html
+++ b/src/app/components/filter-builder/filter-builder.component.html
@@ -10,10 +10,16 @@
             <mat-icon>save</mat-icon>
         </button>
 
-        <mat-button-toggle-group #operatorToggle="matButtonToggleGroup" [(ngModel)]="requireAll"
-                class="neon-button-toggle-group-small">
-            <mat-button-toggle [value]="true">AND</mat-button-toggle>
-            <mat-button-toggle [value]="false">OR</mat-button-toggle>
+        <mat-button-toggle-group #operatorToggle="matButtonToggleGroup" [(ngModel)]="filterIsOptional"
+                class="neon-button-toggle-group-small" title="Required or Optional Filter">
+            <mat-button-toggle [value]="false">REQ</mat-button-toggle>
+            <mat-button-toggle [value]="true">OPT</mat-button-toggle>
+        </mat-button-toggle-group>
+
+        <mat-button-toggle-group #operatorToggle="matButtonToggleGroup" [(ngModel)]="compoundTypeIsOr"
+                class="neon-button-toggle-group-small" title="Compound Filter Type" [disabled]="filterClauses.length < 2">
+            <mat-button-toggle [value]="false">AND</mat-button-toggle>
+            <mat-button-toggle [value]="true">OR</mat-button-toggle>
         </mat-button-toggle-group>
 
         <button mat-icon-button aria-label="Clear" matTooltip="Clear Custom Filter" matTooltipPosition="below"

--- a/src/app/components/filter-builder/filter-builder.component.spec.ts
+++ b/src/app/components/filter-builder/filter-builder.component.spec.ts
@@ -33,7 +33,6 @@ import { DatasetServiceMock } from '../../../testUtils/MockServices/DatasetServi
 import { FilterServiceMock } from '../../../testUtils/MockServices/FilterServiceMock';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';
-import * as neon from 'neon-framework';
 
 describe('Component: Filter Builder', () => {
     let testConfig: NeonGTDConfig = new NeonGTDConfig();
@@ -64,336 +63,95 @@ describe('Component: Filter Builder', () => {
         fixture.detectChanges();
     });
 
-    it('class options properties are set to expected defaults', () => {
-        expect(component.options.clauseConfig).toEqual([]);
-        expect(component.options.requireAll).toEqual(false);
-    });
-
     it('class properties are set to expected defaults', () => {
-        expect(component.clauses.length).toEqual(1);
-        expect(component.clauses[0].databases).toEqual(DatasetServiceMock.DATABASES);
-        expect(component.clauses[0].database).toEqual(DatasetServiceMock.DATABASES[0]);
-        expect(component.clauses[0].tables).toEqual(DatasetServiceMock.TABLES);
-        expect(component.clauses[0].table).toEqual(DatasetServiceMock.TABLES[0]);
-        expect(component.clauses[0].fields).toEqual(DatasetServiceMock.FIELDS);
-        expect(component.clauses[0].field).toEqual(new FieldMetaData());
-        expect(component.clauses[0].operator.value).toEqual('contains');
-        expect(component.clauses[0].value).toEqual('');
-        expect(component.clauses[0].active).toEqual(false);
-        expect(component.clauses[0]._id).toBeDefined();
-        expect(component.clauses[0].changeDatabase).toEqual(DatasetServiceMock.DATABASES[0]);
-        expect(component.clauses[0].changeTable).toEqual(DatasetServiceMock.TABLES[0]);
-        expect(component.clauses[0].changeField).toEqual(new FieldMetaData());
+        expect(component.filterClauses.length).toEqual(1);
+        expect(component.filterClauses[0].databases).toEqual(DatasetServiceMock.DATABASES);
+        expect(component.filterClauses[0].database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect(component.filterClauses[0].tables).toEqual(DatasetServiceMock.TABLES);
+        expect(component.filterClauses[0].table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect(component.filterClauses[0].fields).toEqual(DatasetServiceMock.FIELDS);
+        expect(component.filterClauses[0].field).toEqual(new FieldMetaData());
+        expect(component.filterClauses[0].operator.value).toEqual('contains');
+        expect(component.filterClauses[0].value).toEqual('');
+        expect(component.filterClauses[0]._id).toBeDefined();
+        expect(component.filterClauses[0].changeDatabase).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect(component.filterClauses[0].changeTable).toEqual(DatasetServiceMock.TABLES[0]);
+        expect(component.filterClauses[0].changeField).toEqual(new FieldMetaData());
 
-        let databaseTableFieldKeys = Array.from(component.databaseTableFieldKeysToFilterIds.keys());
-        expect(databaseTableFieldKeys.length > 0).toEqual(true);
-
-        databaseTableFieldKeys.forEach((key) => {
-            expect(component.databaseTableFieldKeysToFilterIds.get(key)).toEqual('');
-        });
+        expect(component.requireAll).toEqual(false);
     });
 
-    it('addBlankFilterClause does work as expected', () => {
+    it('does show expected HTML elements', () => {
+        // TODO THOR-701
+    });
+
+    it('addBlankFilterClause does add a new blank filter clause to the internal list', () => {
         component.addBlankFilterClause();
 
-        expect(component.clauses.length).toEqual(2);
-        expect(component.clauses[1].databases).toEqual(DatasetServiceMock.DATABASES);
-        expect(component.clauses[1].database).toEqual(DatasetServiceMock.DATABASES[0]);
-        expect(component.clauses[1].tables).toEqual(DatasetServiceMock.TABLES);
-        expect(component.clauses[1].table).toEqual(DatasetServiceMock.TABLES[0]);
-        expect(component.clauses[1].fields).toEqual(DatasetServiceMock.FIELDS);
-        expect(component.clauses[1].field).toEqual(new FieldMetaData());
-        expect(component.clauses[1].operator.value).toEqual('contains');
-        expect(component.clauses[1].value).toEqual('');
-        expect(component.clauses[1].active).toEqual(false);
-        expect(component.clauses[1]._id).toBeDefined();
-        expect(component.clauses[1].changeDatabase).toEqual(DatasetServiceMock.DATABASES[0]);
-        expect(component.clauses[1].changeTable).toEqual(DatasetServiceMock.TABLES[0]);
-        expect(component.clauses[1].changeField).toEqual(new FieldMetaData());
+        expect(component.filterClauses.length).toEqual(2);
+        expect(component.filterClauses[1].databases).toEqual(DatasetServiceMock.DATABASES);
+        expect(component.filterClauses[1].database).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect(component.filterClauses[1].tables).toEqual(DatasetServiceMock.TABLES);
+        expect(component.filterClauses[1].table).toEqual(DatasetServiceMock.TABLES[0]);
+        expect(component.filterClauses[1].fields).toEqual(DatasetServiceMock.FIELDS);
+        expect(component.filterClauses[1].field).toEqual(new FieldMetaData());
+        expect(component.filterClauses[1].operator.value).toEqual('contains');
+        expect(component.filterClauses[1].value).toEqual('');
+        expect(component.filterClauses[1]._id).toBeDefined();
+        expect(component.filterClauses[1].changeDatabase).toEqual(DatasetServiceMock.DATABASES[0]);
+        expect(component.filterClauses[1].changeTable).toEqual(DatasetServiceMock.TABLES[0]);
+        expect(component.filterClauses[1].changeField).toEqual(new FieldMetaData());
     });
 
-    it('addOrReplaceFilter does nothing if given filter does not have clauses', () => {
-        // TODO
+    it('clearEveryFilterClause does remove all the filter clauses from the internal list', () => {
+        // TODO THOR-701
     });
 
-    it('addOrReplaceFilter does add given filter', () => {
-        // TODO
+    it('handleChangeDatabaseOfClause does update database/tables/fields', () => {
+        // TODO THOR-701
     });
 
-    it('addOrReplaceFilter does replace given filter if filterId is defined', () => {
-        // TODO
+    it('handleChangeDataOfClause does work as expected', () => {
+        // TODO THOR-701
     });
 
-    it('addOrReplaceFilter does work with multiple filter clauses', () => {
-        // TODO
+    it('handleChangeFieldOfClause does update field', () => {
+        // TODO THOR-701
     });
 
-    it('createFilterNameObject does return expected object', () => {
-        expect(component.createFilterNameObject()).toEqual({
-            visName: 'Filter Builder',
-            text: '0 Filters'
-        });
-
-        component.clauses[0].active = true;
-        component.clauses[0].field = DatasetServiceMock.TEXT_FIELD;
-        component.clauses[0].value = 'My Test Text';
-
-        expect(component.createFilterNameObject()).toEqual({
-            visName: 'Filter Builder',
-            text: 'Test Text Field contains My Test Text'
-        });
-
-        component.addBlankFilterClause();
-        component.clauses[1].active = true;
-        component.clauses[1].field = DatasetServiceMock.TEXT_FIELD;
-        component.clauses[1].value = 'My Test Text';
-
-        expect(component.createFilterNameObject()).toEqual({
-            visName: 'Filter Builder',
-            text: '2 Filters'
-        });
+    it('handleChangeTableOfClause does update table/fields', () => {
+        // TODO THOR-701
     });
 
-    it('createNeonFilter with single matching filter clause does return expected neon filter object', () => {
-        // TODO
+    it('removeClause does remove the given filter clause from the internal list of filter clauses', () => {
+        // TODO THOR-701
     });
 
-    it('createNeonFilter with multiple matching filter clauses does return expected neon filter object', () => {
-        // TODO
+    it('saveFilter does not add a new filter to the filter service if any of the filter clauses are not valid', () => {
+        // TODO THOR-701
     });
 
-    it('createNeonFilter with multiple filter clauses (some matching, some not) does return expected neon filter object', () => {
-        // TODO
+    it('saveFilter does add a new simple filter to the filter service and clear the internal list of filter clauses', () => {
+        // TODO THOR-701
     });
 
-    it('createNeonFilter does validate clauses', () => {
-        // TODO
+    it('saveFilter does add a new compound OR filter to the filter service', () => {
+        // TODO THOR-701
     });
 
-    it('createNeonFilter does work as expected with numbers', () => {
-        // TODO
+    it('saveFilter does add a new compound AND filter to the filter service', () => {
+        // TODO THOR-701
     });
 
-    it('createNeonFilter does work as expected with requireAll=true', () => {
-        // TODO
+    it('saveFilter does parse number strings of non-CONTAINS filters', () => {
+        // TODO THOR-701
     });
 
-    it('finalizeVisualizationQuery does return null always', () => {
-        expect(component.finalizeVisualizationQuery(component.options, {}, [])).toEqual(null);
+    it('saveFilter does not parse number strings of CONTAINS and NOT CONTAINS filters', () => {
+        // TODO THOR-701
     });
 
-    it('getCloseableFilters does return empty array always', () => {
-        expect(component.getCloseableFilters()).toEqual([]);
-    });
-
-    it('getDatabaseTableFieldKey does return expected string', () => {
-        expect(component.getDatabaseTableFieldKey('a', 'b', 'c')).toEqual('a-b-c');
-    });
-
-    it('getFiltersToIgnore does return null always', () => {
-        expect(component.getFiltersToIgnore()).toEqual(null);
-    });
-
-    it('getFilterText does return expected string', () => {
-        expect(component.getFilterText(null)).toEqual('0 Filters');
-
-        component.clauses[0].active = true;
-        component.clauses[0].field = DatasetServiceMock.TEXT_FIELD;
-        component.clauses[0].value = 'My Test Text';
-
-        expect(component.getFilterText(null)).toEqual('Test Text Field contains My Test Text');
-
-        component.addBlankFilterClause();
-        component.clauses[1].active = true;
-        component.clauses[1].field = DatasetServiceMock.TEXT_FIELD;
-        component.clauses[1].value = 'My Test Text';
-
-        expect(component.getFilterText(null)).toEqual('2 Filters');
-    });
-
-    it('getElementRefs returns empty object', () => {
-        let refs = component.getElementRefs();
-        expect(refs).toEqual({});
-    });
-
-    it('handleChangeDatabaseOfClause does deactivate clause, update database/tables/fields, and call updateFiltersOfKey', () => {
-        // TODO
-    });
-
-    it('handleChangeDataOfClause does deactivate clause and call updateFiltersOfKey', () => {
-        // TODO
-    });
-
-    it('handleChangeFieldOfClause does deactivate clause, update field, and call updateFiltersOfKey', () => {
-        // TODO
-    });
-
-    it('handleChangeTableOfClause does deactivate clause, update table/fields, and call updateFiltersOfKey', () => {
-        // TODO
-    });
-
-    it('validateVisualizationQuery does return false always', () => {
-        expect(component.validateVisualizationQuery(component.options)).toEqual(false);
-    });
-
-    it('transformVisualizationQueryResults does nothing', () => {
-        // TODO
-    });
-
-    it('initializeProperties does initialize clauses from clauseConfig', () => {
-        component.clauses = [];
-        component.options.clauseConfig = [{
-            database: 'testDatabase2',
-            table: 'testTable2',
-            field: 'testTextField',
-            operator: '=',
-            value: 'My Test Text',
-            id: 'testFilterId'
-        }];
-
-        component.initializeProperties();
-
-        expect(component.clauses.length).toEqual(1);
-        expect(component.clauses[0].database).toEqual(DatasetServiceMock.DATABASES[1]);
-        expect(component.clauses[0].table).toEqual(DatasetServiceMock.TABLES[1]);
-        expect(component.clauses[0].field).toEqual(DatasetServiceMock.TEXT_FIELD);
-        expect(component.clauses[0].operator.value).toEqual('=');
-        expect(component.clauses[0].value).toEqual('My Test Text');
-        expect(component.clauses[0].active).toEqual(true);
-        expect(component.databaseTableFieldKeysToFilterIds.get('testDatabase2-testTable2-testTextField')).toEqual('testFilterId');
-    });
-
-    it('refreshVisualization does nothing', () => {
-        // TODO
-    });
-
-    it('removeClause does remove the given filter clause from clauses and neon', () => {
-        // TODO
-    });
-
-    it('removeClause does replace the neon filter if needed', () => {
-        // TODO
-    });
-
-    it('removeFilter does nothing', () => {
-        // TODO
-    });
-
-    it('removeFilterById does call removeFilters', () => {
-        // TODO
-    });
-
-    it('resetFilterBuilder does remove all clauses and neon filters', () => {
-        // TODO
-    });
-
-    it('setupFilters does nothing', () => {
-        // TODO
-    });
-
-    it('toggleClause does validate and activate given inactive clause', () => {
-        // TODO
-    });
-
-    it('toggleClause does deactivate given active clause', () => {
-        // TODO
-    });
-
-    it('updateFilters does call updateFiltersOfKey on every key', () => {
-        // TODO
-    });
-
-    it('updateFiltersOfKey does call addOrReplaceFilter if clauses of given key exist', () => {
-        // TODO
-    });
-
-    it('updateFiltersOfKey does call removeFilterById if clauses of given key do not exist', () => {
-        // TODO
-    });
-
-    it('validateClause does return expected boolean', () => {
-        // TODO
-    });
-});
-
-describe('Component: Filter Builder with config', () => {
-    let testConfig: NeonGTDConfig = new NeonGTDConfig();
-    let component: FilterBuilderComponent;
-    let fixture: ComponentFixture<FilterBuilderComponent>;
-
-    initializeTestBed('Filter Builder', {
-        declarations: [
-            FilterBuilderComponent
-        ],
-        providers: [
-            { provide: DatasetService, useClass: DatasetServiceMock },
-            { provide: FilterService, useClass: FilterServiceMock },
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector,
-            {
-                provide: 'clauseConfig',
-                useValue: [{
-                    database: 'testDatabase2',
-                    table: 'testTable2',
-                    field: 'testTextField',
-                    operator: '=',
-                    value: 'testTextValue',
-                    id: 'testFilterId'
-                }]
-            },
-            { provide: 'requireAll', useValue: true },
-            { provide: 'config', useValue: testConfig }
-        ],
-        imports: [
-            AppMaterialModule,
-            FormsModule,
-            BrowserAnimationsModule
-        ]
-    });
-
-    beforeEach(() => {
-        fixture = TestBed.createComponent(FilterBuilderComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-    });
-
-    it('class options properties are set from config to expected values', () => {
-        expect(component.options.clauseConfig).toEqual([{
-            database: 'testDatabase2',
-            table: 'testTable2',
-            field: 'testTextField',
-            operator: '=',
-            value: 'testTextValue',
-            id: 'testFilterId'
-        }]);
-        expect(component.options.requireAll).toEqual(true);
-    });
-
-    it('clauses and databaseTableFieldKeysToFilterIds are set from config to expected values', () => {
-        expect(component.clauses.length).toEqual(1);
-        expect(component.clauses[0].databases).toEqual(DatasetServiceMock.DATABASES);
-        expect(component.clauses[0].database).toEqual(DatasetServiceMock.DATABASES[1]);
-        expect(component.clauses[0].tables).toEqual(DatasetServiceMock.TABLES);
-        expect(component.clauses[0].table).toEqual(DatasetServiceMock.TABLES[1]);
-        expect(component.clauses[0].fields).toEqual(DatasetServiceMock.FIELDS);
-        expect(component.clauses[0].field).toEqual(DatasetServiceMock.TEXT_FIELD);
-        expect(component.clauses[0].operator.value).toEqual('=');
-        expect(component.clauses[0].value).toEqual('testTextValue');
-        expect(component.clauses[0].active).toEqual(true);
-        expect(component.clauses[0]._id).toBeDefined();
-        expect(component.clauses[0].changeDatabase).toEqual(DatasetServiceMock.DATABASES[1]);
-        expect(component.clauses[0].changeTable).toEqual(DatasetServiceMock.TABLES[1]);
-        expect(component.clauses[0].changeField).toEqual(DatasetServiceMock.TEXT_FIELD);
-
-        expect(component.databaseTableFieldKeysToFilterIds.get('testDatabase2-testTable2-testTextField')).toEqual('testFilterId');
-
-        let databaseTableFieldKeys = Array.from(component.databaseTableFieldKeysToFilterIds.keys());
-        expect(databaseTableFieldKeys.length > 0).toEqual(true);
-
-        databaseTableFieldKeys.forEach((key) => {
-            if (key !== 'testDatabase2-testTable2-testTextField') {
-                expect(component.databaseTableFieldKeysToFilterIds.get(key)).toEqual('');
-            }
-        });
+    it('validateFilter does return expected boolean', () => {
+        // TODO THOR-701
     });
 });

--- a/src/app/components/filter-builder/filter-builder.component.spec.ts
+++ b/src/app/components/filter-builder/filter-builder.component.spec.ts
@@ -78,7 +78,8 @@ describe('Component: Filter Builder', () => {
         expect(component.filterClauses[0].changeTable).toEqual(DatasetServiceMock.TABLES[0]);
         expect(component.filterClauses[0].changeField).toEqual(new FieldMetaData());
 
-        expect(component.requireAll).toEqual(false);
+        expect(component.compoundTypeIsOr).toEqual(false);
+        expect(component.filterIsOptional).toEqual(false);
     });
 
     it('does show expected HTML elements', () => {

--- a/src/app/components/filter-builder/filter-builder.component.ts
+++ b/src/app/components/filter-builder/filter-builder.component.ts
@@ -62,7 +62,9 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
         { value: '>=', prettyName: '>=' },
         { value: '<=', prettyName: '<=' }
     ];
-    public requireAll: boolean = false;
+
+    public compoundTypeIsOr: boolean = false;
+    public filterIsOptional: boolean = false;
 
     constructor(
         datasetService: DatasetService,
@@ -262,12 +264,12 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
      * Saves a new custom filter using every filter clause in the global list.
      */
     public saveFilter(): void {
-        if (!this.validateFilters(this.filterClauses)) {
+        if (!this.filterClauses.length || !this.validateFilters(this.filterClauses)) {
             return;
         }
 
         // Turn the filter clauses into filter designs.
-        let filterDesigns: FilterDesign[] = this.filterClauses.map((filterClause) => {
+        let filterDesigns: SimpleFilterDesign[] = this.filterClauses.map((filterClause) => {
             let operator: string = filterClause.operator.value;
             let value: any = filterClause.value;
             if (filterClause.operator.value !== 'contains' && filterClause.operator.value !== 'not contains') {
@@ -278,6 +280,7 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
                 }
             }
             return {
+                optional: this.filterIsOptional,
                 datastore: '',
                 database: filterClause.database,
                 table: filterClause.table,
@@ -289,7 +292,8 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
 
         // Create a compound filter from multiple filters if needed.
         let filterDesign: FilterDesign = !filterDesigns.length ? null : (filterDesigns.length === 1 ? filterDesigns[0] : {
-            type: this.requireAll ? CompoundFilterType.AND : CompoundFilterType.OR,
+            type: this.compoundTypeIsOr ? CompoundFilterType.OR : CompoundFilterType.AND,
+            optional: this.filterIsOptional,
             inflexible: true,
             filters: filterDesigns
         } as CompoundFilterDesign);

--- a/src/app/components/filter-builder/filter-builder.component.ts
+++ b/src/app/components/filter-builder/filter-builder.component.ts
@@ -23,9 +23,9 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 
-import { AbstractSearchService, FilterClause, QueryPayload } from '../../services/abstract.search.service';
+import { AbstractSearchService, CompoundFilterType, FilterClause, QueryPayload } from '../../services/abstract.search.service';
 import { DatasetService } from '../../services/dataset.service';
-import { FilterService } from '../../services/filter.service';
+import { CompoundFilterDesign, FilterBehavior, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
 
 import { BaseNeonComponent, TransformedVisualizationData } from '../base-neon-component/base-neon.component';
 import { FieldMetaData, TableMetaData, DatabaseMetaData } from '../../dataset';
@@ -38,8 +38,9 @@ import {
     WidgetOptionCollection,
     WidgetSelectOption
 } from '../../widget-option';
-import * as neon from 'neon-framework';
+
 import { neonEvents } from '../../../app/neon-namespaces';
+import * as uuidv4 from 'uuid/v4';
 import { MatDialog } from '@angular/material';
 
 @Component({
@@ -50,8 +51,7 @@ import { MatDialog } from '@angular/material';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FilterBuilderComponent extends BaseNeonComponent implements OnInit, OnDestroy {
-    public clauses: FilterClauseMetaData[] = [];
-    public databaseTableFieldKeysToFilterIds: Map<string, string> = new Map<string, string>();
+    public filterClauses: FilterClauseMetaData[] = [];
     public operators: OperatorMetaData[] = [
         { value: 'contains', prettyName: 'contains' },
         { value: 'not contains', prettyName: 'not contains' },
@@ -62,6 +62,7 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
         { value: '>=', prettyName: '>=' },
         { value: '<=', prettyName: '<=' }
     ];
+    public requireAll: boolean = false;
 
     constructor(
         datasetService: DatasetService,
@@ -81,91 +82,47 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
             dialog
         );
 
-        this.messenger.subscribe(neonEvents.DASHBOARD_CLEAR, this.clearFilterBuilder.bind(this));
+        this.messenger.subscribe(neonEvents.DASHBOARD_CLEAR, this.clearEveryFilterClause.bind(this));
+
+        this.addBlankFilterClause();
     }
 
     /**
      * Adds a blank filter clause to the global list.
      */
-    addBlankFilterClause() {
-        let clause: FilterClauseMetaData = new FilterClauseMetaData(() => []);
-        clause.updateDatabases(this.datasetService);
-        clause.field = this.createEmptyField();
-        clause.operator = this.operators[0];
-        clause.value = '';
-        clause.active = false;
-        clause.changeDatabase = clause.database;
-        clause.changeTable = clause.table;
-        clause.changeField = clause.field;
-        if (clause.database && clause.table) {
-            this.clauses.push(clause);
+    public addBlankFilterClause(): void {
+        let filterClause: FilterClauseMetaData = new FilterClauseMetaData(() => []);
+        filterClause.updateDatabases(this.datasetService);
+        filterClause.field = this.createEmptyField();
+        filterClause.operator = this.operators[0];
+        filterClause.value = '';
+        filterClause.changeDatabase = filterClause.database;
+        filterClause.changeTable = filterClause.table;
+        filterClause.changeField = filterClause.field;
+        if (filterClause.database && filterClause.table) {
+            this.filterClauses.push(filterClause);
         }
     }
 
     /**
-     * Adds the given filter to this visualization or replaces the existing filter in this visualization.
+     * Clears every filter clause from the global list.
      */
-    addOrReplaceFilter(executeQueryChainOnsuccess: boolean, filter: CustomFilter) {
-        if (!filter.clauses || !filter.clauses.length) {
-            return;
-        }
-        let onSuccess = (neonFilterId) => {
-            this.databaseTableFieldKeysToFilterIds.set(filter.databaseTableFieldKey, neonFilterId);
-        };
-        let onError = (err) => {
-            console.error(err);
-        };
-        let databaseName = filter.clauses[0].database.name;
-        let tableName = filter.clauses[0].table.name;
-        let fieldName = filter.clauses[0].field.columnName;
-
-        if (filter.filterId) {
-            this.filterService.replaceFilter(
-                this.messenger,
-                filter.filterId,
-                this.id,
-                databaseName,
-                tableName,
-                this.createNeonFilter(databaseName, tableName, fieldName),
-                this.createFilterNameObject(),
-                onSuccess.bind(this),
-                onError.bind(this));
-        } else {
-            this.filterService.addFilter(
-                this.messenger,
-                this.id,
-                databaseName,
-                tableName,
-                this.createNeonFilter(databaseName, tableName, fieldName),
-                this.createFilterNameObject(),
-                onSuccess.bind(this),
-                onError.bind(this)
-            );
-        }
+    public clearEveryFilterClause(): void {
+        this.filterClauses = [];
+        this.addBlankFilterClause();
     }
 
-    clearFilterBuilder() {
-        this.clauses.forEach((clause) => {
-            this.removeClause(clause);
-        });
-        this.changeDetection.detectChanges();
-    }
-
-    createClauseBindings(): any[] {
-        return this.clauses.filter((clause) => {
-            return clause.active;
-        }).map((clause) => {
-            let filterId = this.databaseTableFieldKeysToFilterIds.get(this.getDatabaseTableFieldKey(clause.database.name,
-                clause.table.name, clause.field.columnName));
-            return {
-                database: clause.database.name,
-                table: clause.table.name,
-                field: clause.field.columnName,
-                operator: clause.operator.value,
-                value: clause.value,
-                id: filterId
-            };
-        });
+    /**
+     * Returns each type of filter made by this visualization as an object containing 1) a filter design with undefined values and 2) a
+     * callback to redraw the filter.  This visualization will automatically update with compatible filters that were set externally.
+     *
+     * @return {FilterBehavior[]}
+     * @override
+     */
+    protected designEachFilterWithNoValues(): FilterBehavior[] {
+        // TODO THOR-994 The Filter Builder is no longer a Widget.
+        // TODO THOR-996 The Filter Builder does not update with filters that are set externally, but should it (combined w/ Filter Tray)?
+        return [] as FilterBehavior[];
     }
 
     /**
@@ -175,55 +132,8 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
      * @override
      */
     createFieldOptions(): (WidgetFieldOption | WidgetFieldArrayOption)[] {
+        // TODO THOR-994 The Filter Builder is no longer a Widget.
         return [];
-    }
-
-    /**
-     * Creates and returns the filter name object for the visualization.
-     *
-     * @return {any}
-     */
-    createFilterNameObject(): any {
-        return {
-            visName: this.options.title,
-            text: this.getFilterText(null)
-        };
-    }
-
-    /**
-     * Creates and returns a neon filter object for the given database, table, and field names.
-     *
-     * @arg {string} database
-     * @arg {string} table
-     * @arg {string} field
-     * @return neon.query.WherePredicate
-     */
-    createNeonFilter(database: string, table: string, field: string): neon.query.WherePredicate {
-        let databaseTableFieldKey = this.getDatabaseTableFieldKey(database, table, field);
-        let activeMatchingClauses = this.clauses.filter((clause) => {
-            let clauseDatabaseTableFieldKey = this.getDatabaseTableFieldKey(clause.database.name, clause.table.name,
-                clause.field.columnName);
-            return databaseTableFieldKey === clauseDatabaseTableFieldKey && this.validateClause(clause) && clause.active;
-        });
-
-        let filterClauses = activeMatchingClauses.map((clause) => {
-            let operator = clause.operator.value;
-            let value: any = clause.value;
-            if (operator !== 'contains' && operator !== 'not contains') {
-                value = parseFloat(clause.value);
-                if (isNaN(value) || value.toString() !== clause.value) { // The second check catches values larger than Number.MAX_SAFE_INT
-                    value = clause.value;
-                }
-            }
-            return neon.query.where(clause.field.columnName, operator, value);
-        });
-        if (filterClauses.length === 1) {
-            return filterClauses[0];
-        }
-        if (this.options.requireAll) {
-            return neon.query.and.apply(neon.query, filterClauses);
-        }
-        return neon.query.or.apply(neon.query, filterClauses);
     }
 
     /**
@@ -233,12 +143,8 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
      * @override
      */
     createNonFieldOptions(): WidgetOption[] {
-        let clauseConfigOption = new WidgetNonPrimitiveOption('clauseConfig', 'Clause Config', []);
-        clauseConfigOption.getValueToSaveInBindings = this.createClauseBindings.bind(this);
-        return [
-            new WidgetSelectOption('requireAll', 'Filter Operator', false, OptionChoices.OrFalseAndTrue),
-            clauseConfigOption
-        ];
+        // TODO THOR-994 The Filter Builder is no longer a Widget.
+        return [];
     }
 
     /**
@@ -251,30 +157,8 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
      * @override
      */
     finalizeVisualizationQuery(options: any, query: QueryPayload, sharedFilters: FilterClause[]): QueryPayload {
-        // Does not run a visualization query.
+        // TODO THOR-994 The Filter Builder does not run a visualization query.
         return null;
-    }
-
-    /**
-     * Returns the filter list for the visualization.
-     *
-     * @return {any[]}
-     * @override
-     */
-    getCloseableFilters(): any[] {
-        return [];
-    }
-
-    /**
-     * Returns the key for the given database/table/field names.
-     *
-     * @arg {string} database
-     * @arg {string} table
-     * @arg {string} field
-     * @return {string}
-     */
-    getDatabaseTableFieldKey(database, table, field): string {
-        return database + '-' + table + '-' + field;
     }
 
     /**
@@ -284,32 +168,8 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
      * @override
      */
     getElementRefs(): any {
+        // TODO THOR-994 The Filter Builder is no longer a Widget.
         return {};
-    }
-
-    /**
-     * Returns the list of filter IDs for the visualization to ignore (or null to ignore no filters).
-     *
-     * @return {string[]}
-     * @override
-     */
-    getFiltersToIgnore(): string[] {
-        return null;
-    }
-
-    /**
-     * Returns the filter text for the visualization.
-     *
-     * @arg {any} filter
-     * @return {string}
-     * @override
-     */
-    getFilterText(filter: any): string {
-        let activeClauses = this.clauses.filter((clause) => {
-            return this.validateClause(clause) && clause.active;
-        });
-        return activeClauses.length === 1 ? (activeClauses[0].field.prettyName + ' ' + activeClauses[0].operator.prettyName + ' ' +
-            activeClauses[0].value) : (activeClauses.length + ' Filters');
     }
 
     /**
@@ -319,6 +179,7 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
      * @override
      */
     getVisualizationDefaultLimit(): number {
+        // TODO THOR-994 The Filter Builder is no longer a Widget.
         return 0;
     }
 
@@ -329,130 +190,47 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
      * @override
      */
     getVisualizationDefaultTitle(): string {
+        // TODO THOR-994 The Filter Builder is no longer a Widget.
         return 'Filter Builder';
     }
 
     /**
-     * Updates the active status, tables, fields, and value in the given clause and the filters.
+     * Updates the database, tables, and fields in the given clause.
      *
-     * @arg {FilterClauseMetaData} clause
+     * @arg {FilterClauseMetaData} filterClause
      */
-    handleChangeDatabaseOfClause(clause: FilterClauseMetaData) {
-        let databaseTableFieldKey = this.getDatabaseTableFieldKey(clause.database.name, clause.table.name,
-            clause.field.columnName);
-
-        clause.active = false;
-        clause.database = clause.changeDatabase;
-        clause.updateTables(this.datasetService);
-        clause.changeTable = clause.table;
-
-        if (this.databaseTableFieldKeysToFilterIds.get(databaseTableFieldKey)) {
-            this.updateFiltersOfKey(databaseTableFieldKey);
-        }
+    public handleChangeDatabaseOfClause(filterClause: FilterClauseMetaData): void {
+        filterClause.database = filterClause.changeDatabase;
+        filterClause.updateTables(this.datasetService);
+        filterClause.changeTable = filterClause.table;
     }
 
     /**
-     * Updates the active status of the given clause.
+     * Updates the given clause.
      *
-     * @arg {FilterClauseMetaData} clause
+     * @arg {FilterClauseMetaData} filterClause
      */
-    handleChangeDataOfClause(clause: FilterClauseMetaData) {
-        if (clause.active) {
-            clause.active = false;
-            let databaseTableFieldKey = this.getDatabaseTableFieldKey(clause.database.name, clause.table.name,
-                clause.field.columnName);
-            this.updateFiltersOfKey(databaseTableFieldKey);
-        }
+    public handleChangeDataOfClause(filterClause: FilterClauseMetaData): void {
+        // Do nothing.
     }
 
     /**
-     * Updates the active status and value in the given clause and the filters.
+     * Updates the field in the given clause.
      *
-     * @arg {FilterClauseMetaData} clause
+     * @arg {FilterClauseMetaData} filterClause
      */
-    handleChangeFieldOfClause(clause: FilterClauseMetaData) {
-        let databaseTableFieldKey = this.getDatabaseTableFieldKey(clause.database.name, clause.table.name,
-            clause.field.columnName);
-
-        clause.active = false;
-        clause.field = clause.changeField;
-
-        if (this.databaseTableFieldKeysToFilterIds.get(databaseTableFieldKey)) {
-            this.updateFiltersOfKey(databaseTableFieldKey);
-        }
+    public handleChangeFieldOfClause(filterClause: FilterClauseMetaData): void {
+        filterClause.field = filterClause.changeField;
     }
 
     /**
-     * Updates the active status, fields, and value in the given clause and the filters.
+     * Updates the table and fields in the given clause.
      *
-     * @arg {FilterClauseMetaData} clause
+     * @arg {FilterClauseMetaData} filterClause
      */
-    handleChangeTableOfClause(clause: FilterClauseMetaData) {
-        let databaseTableFieldKey = this.getDatabaseTableFieldKey(clause.database.name, clause.table.name,
-            clause.field.columnName);
-
-        clause.active = false;
-        clause.table = clause.changeTable;
-        clause.updateFields(this.datasetService);
-
-        if (this.databaseTableFieldKeysToFilterIds.get(databaseTableFieldKey)) {
-            this.updateFiltersOfKey(databaseTableFieldKey);
-        }
-    }
-
-    /**
-     * Initializes any visualization properties when the widget is created.
-     *
-     * @override
-     */
-    initializeProperties() {
-        // Backwards compatibility (initialFilters deprecated due to its redundancy with clauseConfig).
-        this.options.clauseConfig = this.options.clauseConfig || this.injector.get('initialFilters', []);
-
-        this.options.databases.forEach((database) => {
-            database.tables.forEach((table) => {
-                table.fields.forEach((field) => {
-                    let databaseTableFieldKey = this.getDatabaseTableFieldKey(database.name, table.name, field.columnName);
-                    this.databaseTableFieldKeysToFilterIds.set(databaseTableFieldKey, '');
-                });
-            });
-        });
-
-        this.options.clauseConfig.forEach((clauseConfig) => {
-            let clause: FilterClauseMetaData = new FilterClauseMetaData(() => []);
-            clause.updateDatabases(this.datasetService);
-            clause.database = clause.databases.find((database) => {
-                return database.name === clauseConfig.database;
-            });
-            clause.updateTables(this.datasetService);
-            clause.table = clause.tables.find((table) => {
-                return table.name === clauseConfig.table;
-            });
-            clause.updateFields(this.datasetService);
-            clause.field = clause.fields.find((field) => {
-                return field.columnName === clauseConfig.field;
-            });
-            clause.operator = this.operators.find((operator) => {
-                return operator.value === clauseConfig.operator;
-            });
-            clause.value = clauseConfig.value;
-            clause.active = true;
-            clause.changeDatabase = clause.database;
-            clause.changeTable = clause.table;
-            clause.changeField = clause.field;
-            if (clause.database && clause.table) {
-                let filterId = clauseConfig.id || this.filterService.createFilterId(clauseConfig.database, clauseConfig.table);
-                this.clauses.push(clause);
-                this.databaseTableFieldKeysToFilterIds.set(this.getDatabaseTableFieldKey(clause.database.name,
-                    clause.table.name, clause.field.columnName), filterId);
-            }
-        });
-
-        if (!this.clauses.length) {
-            this.addBlankFilterClause();
-        } else {
-            this.updateFilters();
-        }
+    public handleChangeTableOfClause(filterClause: FilterClauseMetaData): void {
+        filterClause.table = filterClause.changeTable;
+        filterClause.updateFields(this.datasetService);
     }
 
     /**
@@ -461,96 +239,67 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
      * @override
      */
     refreshVisualization() {
+        // TODO THOR-994 The Filter Builder is no longer a Widget.
         // Do nothing.
     }
 
     /**
      * Removes the given filter clause from neon and this visualization.
      *
-     * @arg {FilterClauseMetaData} clause
+     * @arg {FilterClauseMetaData} filterClause
      */
-    removeClause(clause: FilterClauseMetaData) {
-        this.clauses = this.clauses.filter((clauseFromList) => {
-            return clause._id !== clauseFromList._id;
+    public removeClause(filterClause: FilterClauseMetaData): void {
+        this.filterClauses = this.filterClauses.filter((filterClauseFromGlobalList) => {
+            return filterClause._id !== filterClauseFromGlobalList._id;
         });
 
-        let databaseTableFieldKey = this.getDatabaseTableFieldKey(clause.database.name, clause.table.name,
-            clause.field.columnName);
-
-        if (this.databaseTableFieldKeysToFilterIds.get(databaseTableFieldKey)) {
-            let shouldReplace = this.clauses.some((clauseFromList) => {
-                return databaseTableFieldKey === this.getDatabaseTableFieldKey(clauseFromList.database.name,
-                    clauseFromList.table.name, clauseFromList.field.columnName);
-            });
-
-            if (shouldReplace) {
-                this.filterService.replaceFilter(
-                    this.messenger,
-                    this.databaseTableFieldKeysToFilterIds.get(databaseTableFieldKey),
-                    this.id,
-                    clause.database.name,
-                    clause.table.name,
-                    this.createNeonFilter(clause.database.name, clause.table.name, clause.field.columnName),
-                    this.createFilterNameObject()
-                );
-            } else {
-                this.removeFilterById(databaseTableFieldKey);
-            }
-        }
-
-        if (!this.clauses.length) {
+        if (!this.filterClauses.length) {
             this.addBlankFilterClause();
         }
     }
 
     /**
-     * Removes the given visualization filter object from this visualization.
-     *
-     * @override
+     * Saves a new custom filter using every filter clause in the global list.
      */
-    removeFilter(filter: any) {
-        // Do nothing.  Handle filters internally.
-    }
+    public saveFilter(): void {
+        if (!this.validateFilters(this.filterClauses)) {
+            return;
+        }
 
-    /**
-     * Removes the filters with the given key.
-     *
-     * @arg {string} databaseTableFieldKey
-     */
-    removeFilterById(databaseTableFieldKey: string) {
-        this.filterService.removeFilters(
-            this.messenger,
-            [this.databaseTableFieldKeysToFilterIds.get(databaseTableFieldKey)],
-            () => {
-                this.databaseTableFieldKeysToFilterIds.set(databaseTableFieldKey, '');
+        // Turn the filter clauses into filter designs.
+        let filterDesigns: FilterDesign[] = this.filterClauses.map((filterClause) => {
+            let operator: string = filterClause.operator.value;
+            let value: any = filterClause.value;
+            if (filterClause.operator.value !== 'contains' && filterClause.operator.value !== 'not contains') {
+                value = parseFloat(filterClause.value);
+                // The second check catches values larger than Number.MAX_SAFE_INT
+                if (isNaN(value) || value.toString() !== filterClause.value) {
+                    value = filterClause.value;
+                }
             }
-        );
-    }
-
-    /**
-     * Resets the filter builder by removing all filters.
-     */
-    resetFilterBuilder() {
-        let callback = () => {
-            this.clauses = [];
-            this.addBlankFilterClause();
-        };
-        let filterIds = [];
-        this.databaseTableFieldKeysToFilterIds.forEach((filterId, databaseTableFieldKey) => {
-            if (filterId) {
-                filterIds.push(filterId);
-            }
+            return {
+                datastore: '',
+                database: filterClause.database,
+                table: filterClause.table,
+                field: filterClause.field,
+                operator: filterClause.operator.value,
+                value: value
+            } as SimpleFilterDesign;
         });
-        this.filterService.removeFilters(this.messenger, filterIds, callback.bind(this));
-    }
 
-    /**
-     * Updates the filters for the visualization on initialization or whenever filters are changed externally.
-     *
-     * @override
-     */
-    setupFilters() {
-        // Do nothing.
+        // Create a compound filter from multiple filters if needed.
+        let filterDesign: FilterDesign = !filterDesigns.length ? null : (filterDesigns.length === 1 ? filterDesigns[0] : {
+            type: this.requireAll ? CompoundFilterType.AND : CompoundFilterType.OR,
+            inflexible: true,
+            filters: filterDesigns
+        } as CompoundFilterDesign);
+
+        if (filterDesign) {
+            this.filterService.toggleFilters('CustomFilter', [filterDesign], this.datasetService.findRelationDataList(),
+                this.searchService);
+
+            this.clearEveryFilterClause();
+        }
     }
 
     /**
@@ -562,62 +311,30 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
      * @override
      */
     transformVisualizationQueryResults(options: any, results: any[]): TransformedVisualizationData {
-        // Does not run a visualization query.
+        // TODO THOR-994 The Filter Builder does not run a visualization query.
         return null;
     }
 
     /**
-     * Toggles the active status of the given filter clause.
+     * Returns whether the given filter clauses is valid.
      *
-     * @arg {FilterClauseMetaData} clause
+     * @arg {FilterClauseMetaData} filterClause
+     * @return {boolean}
+     * @private
      */
-    toggleClause(clause: FilterClauseMetaData) {
-        if (clause.active) {
-            clause.active = false;
-            let databaseTableFieldKey = this.getDatabaseTableFieldKey(clause.database.name, clause.table.name,
-                clause.field.columnName);
-            this.updateFiltersOfKey(databaseTableFieldKey);
-        } else if (this.validateClause(clause)) {
-            clause.active = true;
-            let databaseTableFieldKey = this.getDatabaseTableFieldKey(clause.database.name, clause.table.name,
-                clause.field.columnName);
-            this.updateFiltersOfKey(databaseTableFieldKey);
-        }
+    private validateFilter(filterClause: FilterClauseMetaData): boolean {
+        return !!(filterClause.database && filterClause.database.name && filterClause.table && filterClause.table.name &&
+            filterClause.field && filterClause.field.columnName);
     }
 
     /**
-     * Updates all filters.
-     */
-    updateFilters() {
-        this.databaseTableFieldKeysToFilterIds.forEach((filterId, databaseTableFieldKey) => {
-            this.updateFiltersOfKey(databaseTableFieldKey);
-        });
-    }
-
-    /**
-     * Updates all filters with the given key, either adding/replacing them or removing them as needed.
-     */
-    updateFiltersOfKey(databaseTableFieldKey: string) {
-        let filterId = this.databaseTableFieldKeysToFilterIds.get(databaseTableFieldKey);
-        let activeMatchingClauses = this.clauses.filter((clause) => {
-            let clauseDatabaseTableFieldKey = this.getDatabaseTableFieldKey(clause.database.name, clause.table.name,
-                clause.field.columnName);
-            return databaseTableFieldKey === clauseDatabaseTableFieldKey && this.validateClause(clause) && clause.active;
-        });
-        if (activeMatchingClauses.length) {
-            this.addOrReplaceFilter(false, new CustomFilter(activeMatchingClauses, databaseTableFieldKey, filterId));
-        } else {
-            this.removeFilterById(databaseTableFieldKey);
-        }
-    }
-
-    /**
-     * Returns the validity of the given clause.
+     * Returns whether all of the given filter clauses are valid.
      *
-     * @arg {FilterClauseMetaData} clause
+     * @arg {FilterClauseMetaData[]} filterClauses
+     * @return {boolean}
      */
-    validateClause(clause: FilterClauseMetaData) {
-        return clause.database && clause.table && clause.field && clause.field.columnName;
+    public validateFilters(filterClauses: FilterClauseMetaData[]): boolean {
+        return filterClauses.every((filterClause) => this.validateFilter(filterClause));
     }
 
     /**
@@ -628,7 +345,7 @@ export class FilterBuilderComponent extends BaseNeonComponent implements OnInit,
      * @override
      */
     validateVisualizationQuery(options: any): boolean {
-        // Does not run a visualization query.
+        // TODO THOR-994 The Filter Builder does not run a visualization query.
         return false;
     }
 }
@@ -639,23 +356,10 @@ class OperatorMetaData {
 }
 
 class FilterClauseMetaData extends WidgetOptionCollection {
-    active: boolean;
     changeDatabase: DatabaseMetaData;
     changeTable: TableMetaData;
     changeField: FieldMetaData;
     field: FieldMetaData;
     operator: OperatorMetaData;
     value: string;
-}
-
-class CustomFilter {
-    clauses: FilterClauseMetaData[];
-    databaseTableFieldKey: string;
-    filterId: string;
-
-    constructor(clauses: FilterClauseMetaData[], databaseTableFieldKey: string, filterId: string) {
-        this.clauses = clauses;
-        this.databaseTableFieldKey = databaseTableFieldKey;
-        this.filterId = filterId;
-    }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -183,6 +183,14 @@ body {
     font-weight: 500 !important;
 
     .mat-button-toggle {
+        &.mat-button-toggle-checked {
+            background-color: var(--color-background-contrast, lightgrey) !important;
+        }
+
+        &.mat-button-toggle-disabled {
+            opacity: 0.5;
+        }
+
         &:first-child {
             border-radius: 10px 0 0 10px !important;
         }
@@ -191,7 +199,7 @@ body {
             border-radius: 0 10px 10px 0 !important;
         }
 
-        &:hover:not(.mat-button-toggle-checked) {
+        &:hover:not(.mat-button-toggle-checked):not(.mat-button-toggle-disabled) {
             background-color: var(--color-accent, lightgrey) !important;
         }
     }


### PR DESCRIPTION
WHAT DOES THOR-942 WANT TO FIX
- Each filterable visualization component creates and maintains a list of its own filter objects (with unique and inconsistent structure) and overrides many superclass functions (getCloseableFilters, getFiltersToIgnore, getFilterText, removeFilters, setupFilters, etc.) to manage its filters.
- The visualization components depend on the neon.query library, making it impossible to use them independently of the Neon Middleware.
- Filters are no longer saved in the server (due to a previous ticket) and thus we can remove the complex callback chains from the  functions that add/delete filters.
- A lot of code to create, add, or toggle filters in the visualization components is duplicated across the codebase.
- The setupFilters function, intended to allow filters on the same field to be shared across visualizations, is clumsy, confusing, and usually implemented incorrectly (or not implemented at all).
- The visualization components show little grey boxes when filtered, and we don't want to show the boxes anymore.

HOW DOES THOR-942 FIX IT
- Created a set of interfaces in the FilterService to represent filters across the application.  We're using interfaces because they are equivalent to JSON objects and are thus compatible with future non-Typescript Web Components.  The FilterDesign interfaces are converted to Filter classes that are used internally within the FilterService.
- Replaced the many abstract filter functions in BaseNeonComponent with a single function:  designEachFilterWithNoValues.  This function allows the visualization to inform the BaseNeonComponent as to the types of filters that are compatible with it as well as a callback function to redraw its filters whenever updated.  Filters are now automatically shared across visualizations by using the output from designEachFilterWithNoValues (no need to implement setupFilters in each visualization!).
- Replaced the addFilter, removeFilter, and replaceFilter functions with deleteFilters, exchangeFilters, and toggleFilters that take FilterDesigns (JSON objects) rather that neon.query objects.
- Replaced the unique filters from the individual visualization components with a cachedFilters property in the BaseNeonComponent that copies filters from the FilterService rather than using separate (unique, inconsistent) filter objects.
- The FilterService now saves each filter not by visualization but by unique database/table/field/operator (FilterDataSource).  This way a filter can easily be shared across visualizations based on its FilterDataSource.  Filters themselves are now tied to the whole application rather than a single visualization.
- Removed the little grey boxes from the visualizations.

WHAT IS IN THIS PR
- Updates to the Aggregation Component to make it work with the new FilterService and BaseNeonComponent changes.
- I had to change the core behavior of the Filter Builder to make it work in the refactor.  Since individual components no longer have ownership of their own filters, it doesn't make sense for the Filter Builder to hold onto or show only the filters it created.  Therefore the workflow for the Filter Builder (for now) is as follows:  the user designs a filter using the dropdowns and input fields as normal; adding clauses to the filter builder transforms the design into a compound AND/OR filter; clicking "Save Filter" adds a single filter, created using all valid clauses, to the dashboard, and resets the Filter Builder; existing filters can be deleted using the Active Filters tab, like filters from visualizations.  I'm going to review this new workflow with Sophie next week so we can plan for our next steps.

To test this commit, please use branch THOR-942-services because that has the complete, functional set of changes.