### PR TITLE
THOR-942 Filter Refactor (Query Bar and Taxonomy)

### DIFF
--- a/src/app/components/query-bar/query-bar.component.html
+++ b/src/app/components/query-bar/query-bar.component.html
@@ -10,7 +10,7 @@
                 <span [matTooltip]="option">{{ option }}</span>
             </mat-option>
         </mat-autocomplete>
-        <button mat-button *ngIf="queryBar.value" mat-icon-button aria-label="Clear" (click)="queryBar.value = ''; removeFilter()">
+        <button mat-button *ngIf="queryBar.value" mat-icon-button aria-label="Clear" (click)="queryBar.value = ''; removeFilters()">
             <mat-icon>close</mat-icon>
         </button>
     </mat-form-field>

--- a/src/app/components/query-bar/query-bar.component.ts
+++ b/src/app/components/query-bar/query-bar.component.ts
@@ -13,18 +13,18 @@
  * limitations under the License.
  *
  */
-import { BehaviorSubject, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Injector, ViewChild } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { map, startWith } from 'rxjs/operators';
 
-import { AbstractSearchService, FilterClause, QueryPayload } from '../../services/abstract.search.service';
+import { AbstractSearchService, CompoundFilterType, FilterClause, QueryPayload } from '../../services/abstract.search.service';
 import { AbstractWidgetService } from '../../services/abstract.widget.service';
 import { DatasetService } from '../../services/dataset.service';
-import { FilterService } from '../../services/filter.service';
+import { CompoundFilterDesign, FilterBehavior, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
 
 import { BaseNeonComponent, TransformedVisualizationData } from '../base-neon-component/base-neon.component';
-import { FieldMetaData, SimpleFilter } from '../../dataset';
+import { DatabaseMetaData, FieldMetaData, TableMetaData } from '../../dataset';
 import { neonUtilities } from '../../neon-namespaces';
 import {
     OptionChoices,
@@ -54,11 +54,7 @@ export class QueryBarComponent  extends BaseNeonComponent {
     autoComplete: boolean = true;
     queryValues: string[] = [];
     queryArray: any[];
-    filterIds: string[] = [];
-    currentFilter: string = '';
 
-    public simpleFilter = new BehaviorSubject<SimpleFilter>(undefined);
-    public filterId = new BehaviorSubject<string>(undefined);
     public queryOptions: Observable<void | string[]>;
 
     private filterFormControl: FormControl;
@@ -98,6 +94,43 @@ export class QueryBarComponent  extends BaseNeonComponent {
         ];
     }
 
+    private createFilterDesignOnExtensionField(
+        databaseName: string,
+        tableName: string,
+        fieldName: string,
+        value?: any
+    ): FilterDesign {
+        let database: DatabaseMetaData = this.datasetService.getDatabaseWithName(databaseName);
+        let table: TableMetaData = this.datasetService.getTableWithName(databaseName, tableName);
+        let field: FieldMetaData = this.datasetService.getFieldWithName(databaseName, tableName, fieldName);
+        return (database && database.name && table && table.name && field && field.columnName) ? {
+            datastore: '',
+            database: database,
+            table: table,
+            field: field,
+            operator: '=',
+            value: value
+        } as SimpleFilterDesign : null;
+    }
+
+    private createFilterDesignOnList(filters: FilterDesign[]): FilterDesign {
+        return {
+            type: CompoundFilterType.OR,
+            filters: filters
+        } as CompoundFilterDesign;
+    }
+
+    private createFilterDesignOnText(value?: any): FilterDesign {
+        return {
+            datastore: '',
+            database: this.options.database,
+            table: this.options.table,
+            field: this.options.filterField,
+            operator: '=',
+            value: value
+        } as SimpleFilterDesign;
+    }
+
     /**
      * Creates and returns an array of non-field options for the visualization.
      *
@@ -112,6 +145,45 @@ export class QueryBarComponent  extends BaseNeonComponent {
             new WidgetFreeTextOption('id', 'ID', ''),
             new WidgetFreeTextOption('placeHolder', 'Place Holder', 'Query')
         ];
+    }
+
+    /**
+     * Returns each type of filter made by this visualization as an object containing 1) a filter design with undefined values and 2) a
+     * callback to redraw the filter.  This visualization will automatically update with compatible filters that were set externally.
+     *
+     * @return {FilterBehavior[]}
+     * @override
+     */
+    protected designEachFilterWithNoValues(): FilterBehavior[] {
+        let behaviors: FilterBehavior[] = [];
+
+        if (this.options.filterField.columnName) {
+            behaviors.push({
+                // Match a single EQUALS filter on the filter field.
+                filterDesign: this.createFilterDesignOnText(),
+                redrawCallback: this.updateQueryBarText.bind(this)
+            });
+        }
+
+        if (this.options.extendedFilter) {
+            this.options.extensionFields.forEach((extensionField) => {
+                behaviors.push({
+                    // Match a single EQUALS filter on the extension database/table/field.
+                    filterDesign: this.createFilterDesignOnExtensionField(extensionField.database, extensionField.table,
+                        extensionField.idField),
+                    redrawCallback: () => { /* Do nothing */ }
+                });
+
+                behaviors.push({
+                    // Match a compound OR filter with one or more EQUALS filters on the extension database/table/field.
+                    filterDesign: this.createFilterDesignOnList([this.createFilterDesignOnExtensionField(extensionField.database,
+                        extensionField.table, extensionField.idField)]),
+                    redrawCallback: () => { /* Do nothing */ }
+                });
+            });
+        }
+
+        return behaviors;
     }
 
     /**
@@ -240,80 +312,46 @@ export class QueryBarComponent  extends BaseNeonComponent {
     }
 
     /**
-     * Returns the list filters for the visualization to ignore.
-     *
-     * @return {array|null}
-     * @override
-     */
-    getFiltersToIgnore() {
-        // Ignore all the filters for the database and the table so it always shows the selected items.
-        let neonFilters = this.filterService.getFiltersForFields(this.options.database.name, this.options.table.name);
-
-        let ignoredFilterIds = neonFilters.filter((neonFilter) => {
-            return !neonFilter.filter.whereClause.whereClauses;
-        }).map((neonFilter) => {
-            return neonFilter.id;
-        });
-
-        return ignoredFilterIds.length ? ignoredFilterIds : null;
-    }
-
-    /**
-     * Returns the text for the given filter object.
-     *
-     * @arg {object} filter
-     * @return {string}
-     * @override
-     */
-    getFilterText(filter: any): string {
-        return filter.prettyField + ' = ' + filter.value;
-    }
-
-    /**
-     * Returns the list of filter objects.
-     *
-     * @return {array}
-     * @override
-     */
-    getCloseableFilters(): any[] {
-        return [];
-    }
-
-    /**
      * Creates a standard filter for the visualization.
      *
      * @arg {string} text
      */
     createFilter(text: string) {
-        if (text && text.length === 0) {
-            this.removeFilter();
-            return;
-        }
+        let removeTextFilter = true;
+        let removeFilterList: FilterDesign[] = [];
 
-        //filters query text
-        if (text && text !== this.currentFilter) {
-            let values = this.queryArray.filter((value) =>
-                value[this.options.filterField.columnName].toLowerCase() === text.toLowerCase()),
-                clause: WherePredicate;
+        if (text) {
+            let values: any[] = this.queryArray.filter((value) =>
+                value[this.options.filterField.columnName].toLowerCase() === text.toLowerCase());
 
             if (values.length) {
-                clause = neon.query.where(this.options.filterField.columnName, '=', text);
+                let filters: FilterDesign[] = [this.createFilterDesignOnText(text)];
 
-                if (this.currentFilter && this.filterIds) {
-                    this.removeAllFilters(this.options, this.filterService.getFilters(), false, false);
-                }
+                removeTextFilter = false;
 
-                this.addFilter(text, clause, this.options.filterField.columnName);
-                this.currentFilter = text;
                 //gathers ids from the filtered query text in order to extend filtering to the other components
                 if (this.options.extendedFilter) {
-                    for (let ef of this.options.extensionFields) {
-                        this.extensionFilter(text, ef, values);
-                    }
+                    this.options.extensionFields.forEach((extensionField) => {
+                        let extendFilters: FilterDesign[] = this.extensionFilter(text, extensionField, values);
+                        if (extendFilters.length) {
+                            filters = filters.concat(extendFilters);
+                        } else {
+                            removeFilterList.push(this.createFilterDesignOnExtensionField(extensionField.database, extensionField.table,
+                                extensionField.idField));
+                        }
+                    });
                 }
-            } else {
-                this.removeAllFilters(this.options, this.filterService.getFilters(), false, false);
+
+                this.exchangeFilters(filters);
             }
+        }
+
+        if (removeTextFilter) {
+            removeFilterList.push(this.createFilterDesignOnText());
+        }
+
+        if (removeFilterList.length) {
+            this.deleteFilters(removeFilterList);
         }
     }
 
@@ -323,10 +361,13 @@ export class QueryBarComponent  extends BaseNeonComponent {
      * @arg {string} text
      * @arg {any} fields
      * @arg {any} array
+     * @return {FilterDesign[]}
      *
      * @private
      */
-    private extensionFilter(text: string, fields: any, array: any[]) {
+    private extensionFilter(text: string, fields: any, array: any[]): FilterDesign[] {
+        let filters: FilterDesign[] = [];
+
         if (fields.database !== this.options.database.name && fields.table !== this.options.table.name) {
             let query = new neon.query.Query().selectFrom(fields.database, fields.table),
                 queryFields = [fields.idField, fields.filterField],
@@ -357,50 +398,14 @@ export class QueryBarComponent  extends BaseNeonComponent {
                 }
 
                 tempArray = tempArray.filter((value, index, items) => items.indexOf(value) === index);
-                this.extensionAddFilter(text, fields, tempArray);
+                filters.push(this.extensionAddFilter(text, fields, tempArray));
             });
         }
 
-        this.extensionAddFilter(text, fields, array);
-    }
+        filters.push(this.extensionAddFilter(text, fields, array));
 
-    /**
-     * Adds or replaces a filter for the visualization
-     *
-     * @arg {string} text
-     * @arg {WherePredicate} clause
-     * @arg {string} field
-     * @arg {string} database?
-     * @arg {string} table?
-     */
-    addFilter(text: string, clause: WherePredicate, field: string, database?: string, table?: string) {
-        let db = database ? database : this.options.database.name,
-            tb = table ? table : this.options.table.name,
-            filterName = ` ${this.options.title} - ${db} - ${tb} - ${field}`,
-            filterId = this.filterId.getValue(),
-            noOp = () => { /*no op*/ };
-
-        if (filterId) {
-            this.filterService.replaceFilter(
-                this.messenger, filterId, this.id,
-                db, tb, clause,
-                filterName,
-                (id) => {
-                    this.filterIds.push(id);
-                }, noOp
-            );
-        } else {
-            this.filterService.addFilter(
-                this.messenger, this.id,
-                db, tb, clause,
-                filterName,
-                (id) => {
-                    this.filterIds.push(id);
-                    this.filterId.next(typeof id === 'string' ? id : null);
-                },
-                noOp
-            );
-        }
+        // Remove null objects.
+        return filters.filter((filter) => !!filter);
     }
 
     /**
@@ -409,53 +414,36 @@ export class QueryBarComponent  extends BaseNeonComponent {
      * @arg {string} text
      * @arg {any} fields
      * @arg {any} array
+     * @return {FilterDesign}
      *
      * @private
      */
-    private extensionAddFilter(text: string, fields: any, array: any[]) {
-        let whereClauses = [],
-            clause: WherePredicate;
-        for (let item of array) {
-            if ((typeof item === 'object')) {
-                if (item.hasOwnProperty(fields.idField)) {
-                    whereClauses.push(neon.query.where(fields.idField, '=', item[fields.idField]));
-                }
-            } else {
-                whereClauses.push(neon.query.where(fields.idField, '=', item));
-            }
-        }
+    private extensionAddFilter(text: string, fields: any, array: any[]): FilterDesign {
+        let filters: FilterDesign[] = array.map((element) => {
+            let value: any = ((typeof element === 'object' && element.hasOwnProperty(fields.idField)) ? element[fields.idField] : element);
+            return this.createFilterDesignOnExtensionField(fields.database, fields.table, fields.idField, value);
+        }).filter((filterDesign) => !!filterDesign);
 
-        if (whereClauses.length) {
-            clause = neon.query.or.apply(neon.query, whereClauses);
-            this.filterId.next(this.id);
-            this.addFilter(text, clause, fields.idField, fields.database, fields.table);
-        }
+        return filters.length ? this.createFilterDesignOnList(filters) : null;
     }
 
-    /**
-     * Called when a filter has been removed
-     *
-     */
-    removeFilter() {
-        if (this.filterIds) {
-            // Must always requery and refresh the visualization once all the filters are removed.
-            this.removeAllFilters(this.options, this.filterService.getFilters(), true, true);
-            this.filterIds = [];
-            this.currentFilter = '';
-        }
-    }
+    public removeFilters() {
+        let removeFilterList: FilterDesign[] = [this.createFilterDesignOnText()];
 
-    /**
-     * Sets filters for the visualization.
-     *
-     * @override
-     */
-    setupFilters() {
-        //
+        this.options.extensionFields.forEach((extensionField) => {
+            removeFilterList.push(this.createFilterDesignOnExtensionField(extensionField.database, extensionField.table,
+                extensionField.idField));
+        });
+
+        this.deleteFilters(removeFilterList);
     }
 
     protected clearVisualizationData(options: any): void {
         // TODO THOR-985 Temporary function.
         this.transformVisualizationQueryResults(options, []);
+    }
+
+    private updateQueryBarText(filters: FilterDesign[]) {
+        // TODO AIDA-754
     }
 }


### PR DESCRIPTION
WHAT DOES THOR-942 WANT TO FIX
- Each filterable visualization component creates and maintains a list of its own filter objects (with unique and inconsistent structure) and overrides many superclass functions (getCloseableFilters, getFiltersToIgnore, getFilterText, removeFilters, setupFilters, etc.) to manage its filters.
- The visualization components depend on the neon.query library, making it impossible to use them independently of the Neon Middleware.
- Filters are no longer saved in the server (due to a previous ticket) and thus we can remove the complex callback chains from the  functions that add/delete filters.
- A lot of code to create, add, or toggle filters in the visualization components is duplicated across the codebase.
- The setupFilters function, intended to allow filters on the same field to be shared across visualizations, is clumsy, confusing, and usually implemented incorrectly (or not implemented at all).
- The visualization components show little grey boxes when filtered, and we don't want to show the boxes anymore.

HOW DOES THOR-942 FIX IT
- Created a set of interfaces in the FilterService to represent filters across the application.  We're using interfaces because they are equivalent to JSON objects and are thus compatible with future non-Typescript Web Components.  The FilterDesign interfaces are converted to Filter classes that are used internally within the FilterService.
- Replaced the many abstract filter functions in BaseNeonComponent with a single function:  designEachFilterWithNoValues.  This function allows the visualization to inform the BaseNeonComponent as to the types of filters that are compatible with it as well as a callback function to redraw its filters whenever updated.  Filters are now automatically shared across visualizations by using the output from designEachFilterWithNoValues (no need to implement setupFilters in each visualization!).
- Replaced the addFilter, removeFilter, and replaceFilter functions with deleteFilters, exchangeFilters, and toggleFilters that take FilterDesigns (JSON objects) rather that neon.query objects.
- Replaced the unique filters from the individual visualization components with a cachedFilters property in the BaseNeonComponent that copies filters from the FilterService rather than using separate (unique, inconsistent) filter objects.
- The FilterService now saves each filter not by visualization but by unique database/table/field/operator (FilterDataSource).  This way a filter can easily be shared across visualizations based on its FilterDataSource.  Filters themselves are now tied to the whole application rather than a single visualization.
- Removed the little grey boxes from the visualizations.

WHAT IS IN THIS PR
- Updates to the Query Bar and Taxonomy Viewer Components to make them work with the new FilterService and BaseNeonComponent changes.
- I made a big change in how the Taxonomy specifically creates filters:  rather than adding or removing filters on individual unchecked/checked nodes and their children/parents, it now completely replaces its previous filters with new filters representing ALL unchecked nodes (and their children/parents) whenever a node is unchecked/checked.  I think I tested this new behavior pretty well, but, Stacey, I want to get your feedback to make sure I haven't made any mistakes!

To test this commit, please use branch THOR-942-services because that has the complete, functional set of changes.