### PR TITLE
THOR-948 Fix so that an empty filter is no longer required

### DIFF
--- a/src/app/components/data-table/data-table.component.spec.ts
+++ b/src/app/components/data-table/data-table.component.spec.ts
@@ -37,7 +37,6 @@ import { SearchServiceMock } from '../../../testUtils/MockServices/SearchService
 import { By } from '@angular/platform-browser';
 import * as neon from 'neon-framework';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
-import { WhereWrapper } from '../../services/search.service';
 
 describe('Component: DataTable', () => {
     let component: DataTableComponent,
@@ -670,7 +669,10 @@ describe('Component: DataTable', () => {
 
         expect(component.finalizeVisualizationQuery(component.options, {}, [])).toEqual({
             fields: ['*'],
-            filter: new WhereWrapper(neon.query.or())
+            filter: {
+                filters: [],
+                type: 'and'
+            }
         });
     });
 

--- a/src/app/components/data-table/data-table.component.spec.ts
+++ b/src/app/components/data-table/data-table.component.spec.ts
@@ -669,10 +669,7 @@ describe('Component: DataTable', () => {
 
         expect(component.finalizeVisualizationQuery(component.options, {}, [])).toEqual({
             fields: ['*'],
-            filter: {
-                filters: [],
-                type: 'and'
-            }
+            filter: null
         });
     });
 

--- a/src/app/components/data-table/data-table.component.ts
+++ b/src/app/components/data-table/data-table.component.ts
@@ -45,7 +45,6 @@ import {
 } from '../../widget-option';
 import * as neon from 'neon-framework';
 import { MatDialog } from '@angular/material';
-import { WhereWrapper } from '../../services/search.service';
 
 @Component({
     selector: 'app-data-table',
@@ -512,11 +511,7 @@ export class DataTableComponent extends BaseNeonComponent implements OnInit, OnD
         // Override the default query fields because we want to find all fields.
         this.searchService.updateFieldsToMatchAll(query);
 
-        if (filters.length) {
-            this.searchService.updateFilter(query, this.searchService.buildCompoundFilterClause(filters));
-        } else {
-            this.searchService.updateFilter(query, new WhereWrapper(neon.query.or()));
-        }
+        this.searchService.updateFilter(query, this.searchService.buildCompoundFilterClause(filters));
 
         if (options.sortField.columnName) {
             this.searchService.updateSort(query, options.sortField.columnName,

--- a/src/app/components/news-feed/news-feed.component.spec.ts
+++ b/src/app/components/news-feed/news-feed.component.spec.ts
@@ -33,7 +33,6 @@ import { DatasetServiceMock } from '../../../testUtils/MockServices/DatasetServi
 import { FilterServiceMock } from '../../../testUtils/MockServices/FilterServiceMock';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';
 import { TransformedVisualizationData } from '../base-neon-component/base-neon.component';
-import { WhereWrapper } from '../../services/search.service';
 
 describe('Component: NewsFeed', () => {
     let component: NewsFeedComponent;
@@ -383,7 +382,10 @@ describe('Component: NewsFeed', () => {
 
         expect(component.finalizeVisualizationQuery(component.options, {}, [])).toEqual({
             fields: ['*'],
-            filter: new WhereWrapper(neon.query.or())
+            filter: {
+                filters: [],
+                type: 'and'
+            }
         });
     }));
 

--- a/src/app/components/news-feed/news-feed.component.spec.ts
+++ b/src/app/components/news-feed/news-feed.component.spec.ts
@@ -382,10 +382,7 @@ describe('Component: NewsFeed', () => {
 
         expect(component.finalizeVisualizationQuery(component.options, {}, [])).toEqual({
             fields: ['*'],
-            filter: {
-                filters: [],
-                type: 'and'
-            }
+            filter: null
         });
     }));
 

--- a/src/app/components/news-feed/news-feed.component.ts
+++ b/src/app/components/news-feed/news-feed.component.ts
@@ -45,7 +45,6 @@ import {
 import * as neon from 'neon-framework';
 import * as _ from 'lodash';
 import { MatDialog } from '@angular/material';
-import { WhereWrapper } from '../../services/search.service';
 
 /**
  * A visualization that displays binary and text files triggered through a select_id event.
@@ -186,11 +185,7 @@ export class NewsFeedComponent extends BaseNeonComponent implements OnInit, OnDe
 
         this.searchService.updateFieldsToMatchAll(query);
 
-        if (filters.length) {
-            this.searchService.updateFilter(query, this.searchService.buildCompoundFilterClause(filters));
-        } else {
-            this.searchService.updateFilter(query, new WhereWrapper(neon.query.or()));
-        }
+        this.searchService.updateFilter(query, this.searchService.buildCompoundFilterClause(filters));
 
         if (this.options.sortField.columnName) {
             this.searchService.updateSort(query, options.sortField.columnName,

--- a/src/app/components/thumbnail-grid/thumbnail-grid.component.spec.ts
+++ b/src/app/components/thumbnail-grid/thumbnail-grid.component.spec.ts
@@ -726,10 +726,7 @@ describe('Component: ThumbnailGrid', () => {
 
         expect(component.finalizeVisualizationQuery(component.options, {}, [])).toEqual({
             fields: ['*'],
-            filter: {
-                filters: [],
-                type: 'and'
-            }
+            filter: null
         });
     });
 

--- a/src/app/components/thumbnail-grid/thumbnail-grid.component.spec.ts
+++ b/src/app/components/thumbnail-grid/thumbnail-grid.component.spec.ts
@@ -40,7 +40,6 @@ import { DetailsThumbnailSubComponent } from './subcomponent.details-view';
 import { TitleThumbnailSubComponent } from './subcomponent.title-view';
 import { CardThumbnailSubComponent } from './subcomponent.card-view';
 import { TransformedVisualizationData } from '../base-neon-component/base-neon.component';
-import { WhereWrapper } from '../../services/search.service';
 
 let validateSelect = (element: any, name: string, required: boolean = false, disabled: boolean = false) => {
     expect(element.componentInstance.disabled).toEqual(disabled);
@@ -727,7 +726,10 @@ describe('Component: ThumbnailGrid', () => {
 
         expect(component.finalizeVisualizationQuery(component.options, {}, [])).toEqual({
             fields: ['*'],
-            filter: new WhereWrapper(neon.query.or())
+            filter: {
+                filters: [],
+                type: 'and'
+            }
         });
     });
 

--- a/src/app/components/thumbnail-grid/thumbnail-grid.component.ts
+++ b/src/app/components/thumbnail-grid/thumbnail-grid.component.ts
@@ -45,7 +45,6 @@ import {
 } from '../../widget-option';
 import * as neon from 'neon-framework';
 import { MatDialog } from '@angular/material';
-import { WhereWrapper } from '../../services/search.service';
 
 export const ViewType = {
     CARD: 'card',
@@ -247,11 +246,7 @@ export class ThumbnailGridComponent extends BaseNeonComponent implements OnInit,
 
         this.searchService.updateFieldsToMatchAll(query);
 
-        if (filters.length) {
-            this.searchService.updateFilter(query, this.searchService.buildCompoundFilterClause(filters));
-        } else {
-            this.searchService.updateFilter(query, new WhereWrapper(neon.query.or()));
-        }
+        this.searchService.updateFilter(query, this.searchService.buildCompoundFilterClause(filters));
 
         if (options.sortField.columnName) {
             this.searchService.updateSort(query, options.sortField.columnName,

--- a/src/app/services/search.service.spec.ts
+++ b/src/app/services/search.service.spec.ts
@@ -232,6 +232,9 @@ describe('Service: Search', () => {
     it('updateFilter does update given query payload', inject([SearchService], (service: SearchService) => {
         let input: neon.query.Query = new neon.query.Query();
 
+        service.updateFilter(new QueryWrapper(input), null);
+        expect(input).toEqual(new neon.query.Query());
+
         service.updateFilter(new QueryWrapper(input), new WhereWrapper(neon.query.where('field1', '=', 'value1')));
         expect(input).toEqual(new neon.query.Query().where(neon.query.where('field1', '=', 'value1')));
 

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -186,7 +186,9 @@ export class SearchService extends AbstractSearchService {
         let wherePredicate: neon.query.WherePredicate = (queryPayload as QueryWrapper).query['filter'].whereClause;
         /* tslint:enable:no-string-literal */
 
-        this.transformWherePredicateValues(wherePredicate, keysToValuesToLabels);
+        if (wherePredicate) {
+            this.transformWherePredicateValues(wherePredicate, keysToValuesToLabels);
+        }
 
         return queryPayload;
     }
@@ -282,7 +284,9 @@ export class SearchService extends AbstractSearchService {
      * @override
      */
     public updateFilter(queryPayload: QueryWrapper, filterClause: WhereWrapper): AbstractSearchService {
-        (queryPayload as QueryWrapper).query.where((filterClause as WhereWrapper).where);
+        if (filterClause) {
+            (queryPayload as QueryWrapper).query.where((filterClause as WhereWrapper).where);
+        }
         return this;
     }
 

--- a/src/testUtils/MockServices/SearchServiceMock.ts
+++ b/src/testUtils/MockServices/SearchServiceMock.ts
@@ -31,10 +31,10 @@ import { RequestWrapper } from '../../app/connection';
 export class SearchServiceMock extends AbstractSearchService {
 
     public buildCompoundFilterClause(filterClauses: FilterClause[], type: CompoundFilterType = CompoundFilterType.AND): FilterClause {
-        return filterClauses.length === 1 ? filterClauses[0] : {
+        return filterClauses.length ? (filterClauses.length === 1 ? filterClauses[0] : {
             filters: filterClauses,
             type: '' + type
-        };
+        }) : null;
     }
 
     public buildDateQueryGroup(groupField: string, interval: TimeInterval): QueryGroup {
@@ -97,6 +97,10 @@ export class SearchServiceMock extends AbstractSearchService {
     }
 
     private transformFilterClauseValuesHelper(filter: any, keysToValuesToLabels: { [key: string]: { [value: string]: string } }): void {
+        if (!filter) {
+            return;
+        }
+
         if (!filter.type) {
             let keys = Object.keys(keysToValuesToLabels);
             let key = filter.lhs;


### PR DESCRIPTION
@arciisine I believe this fixes the issue we discussed yesterday with the dashboard generating an error if no filter is defined.  I was able to reproduce the issue (by removing the empty filters you had added) and eliminated the error with this change.  Please confirm whether this works for you too.