### PR TITLE
THOR-1308 Created Dataset

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,12 +18,12 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CommonModule } from '@angular/common';
 
 import { AbstractSearchService } from './services/abstract.search.service';
-import { AbstractWidgetService } from './services/abstract.widget.service';
+import { AbstractColorThemeService } from './services/abstract.color-theme.service';
 import { DashboardService } from './services/dashboard.service';
 import { FilterService } from './services/filter.service';
 import { PropertyService } from './services/property.service';
 import { SearchService } from './services/search.service';
-import { WidgetService } from './services/widget.service';
+import { ColorThemeService } from './services/color-theme.service';
 
 import { AppComponent } from './app.component';
 
@@ -57,8 +57,8 @@ import { DynamicDialogComponent } from './components/dynamic-dialog/dynamic-dial
             useClass: SearchService
         },
         {
-            provide: AbstractWidgetService,
-            useClass: WidgetService
+            provide: AbstractColorThemeService,
+            useClass: ColorThemeService
         }
     ],
     entryComponents: [AppComponent, DynamicDialogComponent],

--- a/src/app/components/add-visualization/add-visualization.component.spec.ts
+++ b/src/app/components/add-visualization/add-visualization.component.spec.ts
@@ -13,64 +13,27 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import {
-    ChangeDetectionStrategy,
-    Component,
-    ViewEncapsulation
-} from '@angular/core';
-import { MatSnackBar, MatGridListModule, MatDividerModule } from '@angular/material';
+import { MatGridListModule, MatDividerModule } from '@angular/material';
 import { } from 'jasmine-core';
 
 import { AddVisualizationComponent } from './add-visualization.component';
 import { AddVisualizationModule } from './add-visualization.module';
 
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterService } from '../../services/filter.service';
-import { WidgetService } from '../../services/widget.service';
 
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 
-// Must define the test component.
-@Component({
-    selector: 'app-test-add-visualization',
-    templateUrl: 'add-visualization.component.html',
-    styleUrls: ['add-visualization.component.scss'],
-    encapsulation: ViewEncapsulation.Emulated,
-    changeDetection: ChangeDetectionStrategy.OnPush
-})
-
-class TestAddVisualizationComponent extends AddVisualizationComponent {
-    constructor(
-        widgetService: AbstractWidgetService,
-        snackBar: MatSnackBar
-    ) {
-        super(
-            snackBar,
-            widgetService
-        );
-    }
-
-    // TODO Add any needed custom functions here.
-}
-
 describe('Component: AddVisualization', () => {
-    let component: TestAddVisualizationComponent;
-    let fixture: ComponentFixture<TestAddVisualizationComponent>;
+    let component: AddVisualizationComponent;
+    let fixture: ComponentFixture<AddVisualizationComponent>;
     let spyOnInit;
 
     initializeTestBed('Add Visualization', {
-        declarations: [
-            TestAddVisualizationComponent
-        ],
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
-            {
-                provide: AbstractWidgetService,
-                useClass: WidgetService
-            }
+            FilterService
         ],
         imports: [
             MatDividerModule,
@@ -80,7 +43,7 @@ describe('Component: AddVisualization', () => {
     });
 
     beforeEach(() => {
-        fixture = TestBed.createComponent(TestAddVisualizationComponent);
+        fixture = TestBed.createComponent(AddVisualizationComponent);
         component = fixture.componentInstance;
         spyOnInit = spyOn(component, 'ngOnInit');
         fixture.detectChanges();

--- a/src/app/components/add-visualization/add-visualization.component.ts
+++ b/src/app/components/add-visualization/add-visualization.component.ts
@@ -15,8 +15,6 @@
 import { Component, OnInit } from '@angular/core';
 import { MatSnackBar } from '@angular/material';
 
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
-
 import { NeonGridItem } from '../../models/neon-grid-item';
 import { neonEvents, neonVisualizations } from '../../models/neon-namespaces';
 
@@ -38,10 +36,7 @@ export class AddVisualizationComponent implements OnInit {
 
     public messenger: eventing.Messenger;
 
-    constructor(
-        public snackBar: MatSnackBar,
-        protected widgetService: AbstractWidgetService
-    ) {
+    constructor(public snackBar: MatSnackBar) {
         this.messenger = new eventing.Messenger();
     }
 

--- a/src/app/components/aggregation/aggregation.component.spec.ts
+++ b/src/app/components/aggregation/aggregation.component.spec.ts
@@ -33,7 +33,7 @@ import { WidgetService } from '../../services/widget.service';
 import { Color } from '../../models/color';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';
-import { NeonFieldMetaData } from '../../models/types';
+import { NeonFieldMetaData } from '../../models/dataset';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 
 describe('Component: Aggregation', () => {

--- a/src/app/components/aggregation/aggregation.component.spec.ts
+++ b/src/app/components/aggregation/aggregation.component.spec.ts
@@ -24,11 +24,11 @@ import { ChartJsLineSubcomponent } from './subcomponent.chartjs.line';
 import { ChartJsScatterSubcomponent } from './subcomponent.chartjs.scatter';
 
 import { AbstractSearchService, CompoundFilterType } from '../../services/abstract.search.service';
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
+import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
 import { AggregationType } from '../../models/widget-option';
 import { DashboardService } from '../../services/dashboard.service';
 import { CompoundFilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
-import { WidgetService } from '../../services/widget.service';
+import { ColorThemeService } from '../../services/color-theme.service';
 
 import { Color } from '../../models/color';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
@@ -45,7 +45,7 @@ describe('Component: Aggregation', () => {
 
     initializeTestBed('Aggregation', {
         providers: [
-            { provide: AbstractWidgetService, useClass: WidgetService },
+            { provide: AbstractColorThemeService, useClass: ColorThemeService },
             { provide: DashboardService, useClass: DashboardServiceMock },
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
@@ -3960,7 +3960,7 @@ describe('Component: Aggregation with config', () => {
 
     initializeTestBed('Aggregation', {
         providers: [
-            { provide: AbstractWidgetService, useClass: WidgetService },
+            { provide: AbstractColorThemeService, useClass: ColorThemeService },
             { provide: DashboardService, useClass: DashboardServiceMock },
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
@@ -4061,7 +4061,7 @@ describe('Component: Aggregation with XY config', () => {
 
     initializeTestBed('Aggregation', {
         providers: [
-            { provide: AbstractWidgetService, useClass: WidgetService },
+            { provide: AbstractColorThemeService, useClass: ColorThemeService },
             { provide: DashboardService, useClass: DashboardServiceMock },
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
@@ -4162,7 +4162,7 @@ describe('Component: Aggregation with date config', () => {
 
     initializeTestBed('Aggregation', {
         providers: [
-            { provide: AbstractWidgetService, useClass: WidgetService },
+            { provide: AbstractColorThemeService, useClass: ColorThemeService },
             { provide: DashboardService, useClass: DashboardServiceMock },
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },

--- a/src/app/components/aggregation/aggregation.component.ts
+++ b/src/app/components/aggregation/aggregation.component.ts
@@ -36,7 +36,7 @@ import {
     SortOrder,
     TimeInterval
 } from '../../services/abstract.search.service';
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
+import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import {
     CompoundFilterDesign,
@@ -188,7 +188,7 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
         injector: Injector,
         ref: ChangeDetectorRef,
         dialog: MatDialog,
-        protected widgetService: AbstractWidgetService,
+        protected colorThemeService: AbstractColorThemeService,
         public visualization: ElementRef
     ) {
         super(
@@ -797,14 +797,14 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
         let yList = [];
         let groupsToColors = new Map<string, Color>();
         if (!options.groupField.columnName) {
-            groupsToColors.set(this.DEFAULT_GROUP, this.widgetService.getColor(options.database.name, options.table.name, '',
+            groupsToColors.set(this.DEFAULT_GROUP, this.colorThemeService.getColor(options.database.name, options.table.name, '',
                 this.DEFAULT_GROUP));
         }
 
         let findGroupColor = (group: string): Color => {
             let color = groupsToColors.get(group);
             if (!color) {
-                color = this.widgetService.getColor(options.database.name, options.table.name, options.groupField.columnName, group);
+                color = this.colorThemeService.getColor(options.database.name, options.table.name, options.groupField.columnName, group);
                 groupsToColors.set(group, color);
             }
             return color;
@@ -1264,7 +1264,7 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
 
         this.updateOnResize();
 
-        this.colorKeys = [this.widgetService.getColorKey(this.options.database.name, this.options.table.name,
+        this.colorKeys = [this.colorThemeService.getColorKey(this.options.database.name, this.options.table.name,
             this.options.groupField.columnName || '')];
     }
 

--- a/src/app/components/aggregation/aggregation.component.ts
+++ b/src/app/components/aggregation/aggregation.component.ts
@@ -306,14 +306,15 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
                     groups.push(this.searchService.buildDateQueryGroup(options.xField.columnName, TimeInterval.YEAR));
                 // Falls through
             }
-            this.searchService.updateAggregation(query, AggregationType.MIN, '_date', options.xField.columnName).updateSort(query, '_date');
+            this.searchService.updateAggregation(query, AggregationType.MIN, this.searchService.getAggregationName('date'),
+                options.xField.columnName).updateSort(query, this.searchService.getAggregationName('date'));
             countField = '_' + options.granularity;
         } else if (!options.sortByAggregation) {
             groups.push(this.searchService.buildQueryGroup(options.xField.columnName));
             this.searchService.updateSort(query, options.xField.columnName);
         } else {
             groups.push(this.searchService.buildQueryGroup(options.xField.columnName));
-            this.searchService.updateSort(query, '_aggregation', SortOrder.DESCENDING);
+            this.searchService.updateSort(query, this.searchService.getAggregationName(), SortOrder.DESCENDING);
         }
 
         if (this.optionsTypeIsXY(options)) {
@@ -327,7 +328,7 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
         }
 
         if (!this.optionsTypeIsXY(options)) {
-            this.searchService.updateAggregation(query, options.aggregation, '_aggregation',
+            this.searchService.updateAggregation(query, options.aggregation, this.searchService.getAggregationName(),
                 (options.aggregation === AggregationType.COUNT ? countField : options.aggregationField.columnName));
         }
 
@@ -815,7 +816,7 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
                 color: findGroupColor(group),
                 group: group,
                 x: item[options.xField.columnName],
-                y: isXY ? item[options.yField.columnName] : (Math.round((item._aggregation) * 10000) / 10000)
+                y: isXY ? item[options.yField.columnName] : (Math.round(item[this.searchService.getAggregationName()] * 10000) / 10000)
             };
         };
 
@@ -823,7 +824,7 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
         let shownResults = [];
 
         if (!isXY) {
-            queryResults = queryResults.filter((item) => item._aggregation !== 'NaN');
+            queryResults = queryResults.filter((item) => item[this.searchService.getAggregationName()] !== 'NaN');
         }
 
         if (options.xField.type === 'date' && queryResults.length) {
@@ -845,9 +846,10 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
                     break;
             }
 
-            let beginDate = options.savePrevious && this.xList.length ? this.xList[0] : queryResults[0]._date;
+            let beginDate = options.savePrevious && this.xList.length ? this.xList[0] :
+                queryResults[0][this.searchService.getAggregationName('date')];
             let endDate = options.savePrevious && this.xList.length ? this.xList[this.xList.length - 1] :
-                queryResults[queryResults.length - 1]._date;
+                queryResults[queryResults.length - 1][this.searchService.getAggregationName('date')];
             this.dateBucketizer.setStartDate(new Date(beginDate));
             this.dateBucketizer.setEndDate(new Date(endDate));
 
@@ -868,7 +870,7 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
                     transformations = new Array(xDomainLength).fill(undefined).map(() => []);
                     groupToTransformations.set(transformation.group, transformations);
                 }
-                let index = this.dateBucketizer.getBucketIndex(new Date(item._date));
+                let index = this.dateBucketizer.getBucketIndex(new Date(item[this.searchService.getAggregationName('date')]));
                 // Fix the X so it is a readable date string.
                 transformation.x = moment(this.dateBucketizer.getDateForBucket(index)).toISOString();
                 transformations[index].push(transformation);

--- a/src/app/components/annotation-viewer/annotation-viewer.component.spec.ts
+++ b/src/app/components/annotation-viewer/annotation-viewer.component.spec.ts
@@ -20,10 +20,10 @@ import { } from 'jasmine-core';
 import { AnnotationViewerComponent } from './annotation-viewer.component';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
+import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterService } from '../../services/filter.service';
-import { WidgetService } from '../../services/widget.service';
+import { ColorThemeService } from '../../services/color-theme.service';
 
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';
@@ -38,7 +38,7 @@ describe('Component: AnnotationViewer', () => {
 
     initializeTestBed('Annotation Viewer', {
         providers: [
-            { provide: AbstractWidgetService, useClass: WidgetService },
+            { provide: AbstractColorThemeService, useClass: ColorThemeService },
             { provide: DashboardService, useClass: DashboardServiceMock },
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },

--- a/src/app/components/annotation-viewer/annotation-viewer.component.spec.ts
+++ b/src/app/components/annotation-viewer/annotation-viewer.component.spec.ts
@@ -27,7 +27,7 @@ import { WidgetService } from '../../services/widget.service';
 
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';
-import { NeonFieldMetaData } from '../../models/types';
+import { NeonFieldMetaData } from '../../models/dataset';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 
 import { AnnotationViewerModule } from './annotation-viewer.module';

--- a/src/app/components/annotation-viewer/annotation-viewer.component.ts
+++ b/src/app/components/annotation-viewer/annotation-viewer.component.ts
@@ -25,7 +25,7 @@ import {
 } from '@angular/core';
 
 import { AbstractSearchService, FilterClause, QueryPayload } from '../../services/abstract.search.service';
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
+import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterBehavior, FilterDesign, FilterService } from '../../services/filter.service';
 
@@ -107,7 +107,7 @@ export class AnnotationViewerComponent extends BaseNeonComponent implements OnIn
     public offset = 0;
 
     constructor(
-        protected widgetService: AbstractWidgetService,
+        protected colorThemeService: AbstractColorThemeService,
         dashboardService: DashboardService,
         filterService: FilterService,
         searchService: AbstractSearchService,
@@ -429,7 +429,7 @@ export class AnnotationViewerComponent extends BaseNeonComponent implements OnIn
                     let currentPart = new Part();
                     let currentText = document.annotationTextList[index];
                     let currentType = document.annotationTypeList[index];
-                    let highlightColor = this.widgetService.getColor(this.options.database.name, this.options.table.name, currentType,
+                    let highlightColor = this.colorThemeService.getColor(this.options.database.name, this.options.table.name, currentType,
                         currentType).getComputedCssTransparencyHigh(this.visualization);
 
                     currentPart.highlightColor = highlightColor;
@@ -444,7 +444,7 @@ export class AnnotationViewerComponent extends BaseNeonComponent implements OnIn
                         this.seenTypes.push(type);
                     }
                 }
-                this.colorKeys = this.seenTypes.map((type) => this.widgetService.getColorKey(this.options.database.name,
+                this.colorKeys = this.seenTypes.map((type) => this.colorThemeService.getColorKey(this.options.database.name,
                     this.options.table.name, type));
             }
 
@@ -646,7 +646,7 @@ export class AnnotationViewerComponent extends BaseNeonComponent implements OnIn
                 if (disabledValues.includes(part.type)) {
                     part.highlightColor = 'rgb(255,255,255)';
                 } else if (part.highlightColor && part.highlightColor.includes('rgb(255,255,255')) {
-                    part.highlightColor = this.widgetService.getColor(this.options.database.name, this.options.table.name, part.type,
+                    part.highlightColor = this.colorThemeService.getColor(this.options.database.name, this.options.table.name, part.type,
                         part.type).getComputedCssTransparencyHigh(this.visualization);
                 }
             }

--- a/src/app/components/annotation-viewer/annotation-viewer.component.ts
+++ b/src/app/components/annotation-viewer/annotation-viewer.component.ts
@@ -30,7 +30,7 @@ import { DashboardService } from '../../services/dashboard.service';
 import { FilterBehavior, FilterDesign, FilterService } from '../../services/filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
-import { NeonFieldMetaData } from '../../models/types';
+import { NeonFieldMetaData } from '../../models/dataset';
 import { neonUtilities } from '../../models/neon-namespaces';
 import {
     OptionChoices,

--- a/src/app/components/base-neon-component/base-neon.component.spec.ts
+++ b/src/app/components/base-neon-component/base-neon.component.spec.ts
@@ -890,7 +890,7 @@ describe('BaseNeonComponent', () => {
     it('getButtonText with multiple layers does return expected string', () => {
         expect(component.getButtonText()).toEqual('');
 
-        let layerA: any = new WidgetOptionCollection(() => [], component['dataset'], 'Test Layer', 100, undefined, {});
+        let layerA: any = new WidgetOptionCollection(() => [], component['dataset'], 'Test Layer', 100);
         layerA.title = 'Layer A';
         component.options.layers.push(layerA);
 
@@ -903,7 +903,7 @@ describe('BaseNeonComponent', () => {
         component['layerIdToElementCount'].set(layerA._id, 2);
         expect(component.getButtonText()).toEqual('2 Results');
 
-        let layerB: any = new WidgetOptionCollection(() => [], component['dataset'], 'Test Layer', 100, undefined, {});
+        let layerB: any = new WidgetOptionCollection(() => [], component['dataset'], 'Test Layer', 100);
         layerB.title = 'Layer B';
         component.options.layers.push(layerB);
 
@@ -1359,7 +1359,7 @@ describe('BaseNeonComponent', () => {
     });
 
     it('handleTransformVisualizationQueryResults does call success callback function', (done) => {
-        let expectedOptions = new WidgetOptionCollection(() => [], component['dataset'], 'Test Layer', 100, undefined, {});
+        let expectedOptions = new WidgetOptionCollection(() => [], component['dataset'], 'Test Layer', 100);
         let expectedResults = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         /* eslint-disable-next-line @typescript-eslint/unbound-method */
         component.transformVisualizationQueryResults = (options, results) => {
@@ -1381,7 +1381,7 @@ describe('BaseNeonComponent', () => {
 
     it('handleTransformVisualizationQueryResults does call failure callback function', (done) => {
         let expectedError = new Error('Test Error');
-        let expectedOptions = new WidgetOptionCollection(() => [], component['dataset'], 'Test Layer', 100, undefined, {});
+        let expectedOptions = new WidgetOptionCollection(() => [], component['dataset'], 'Test Layer', 100);
         let expectedResults = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         /* eslint-disable-next-line @typescript-eslint/unbound-method */
         component.transformVisualizationQueryResults = (__options, __results) => {

--- a/src/app/components/base-neon-component/base-neon.component.spec.ts
+++ b/src/app/components/base-neon-component/base-neon.component.spec.ts
@@ -31,7 +31,8 @@ import { DashboardService } from '../../services/dashboard.service';
 import { FilterBehavior, FilterService } from '../../services/filter.service';
 
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { NeonFieldMetaData, NeonConfig } from '../../models/types';
+import { NeonConfig } from '../../models/types';
+import { NeonFieldMetaData } from '../../models/dataset';
 import {
     AggregationType,
     OptionChoices,
@@ -889,7 +890,7 @@ describe('BaseNeonComponent', () => {
     it('getButtonText with multiple layers does return expected string', () => {
         expect(component.getButtonText()).toEqual('');
 
-        let layerA: any = new WidgetOptionCollection(() => [], component['dashboardState'], 'Test Layer', 100, undefined, {});
+        let layerA: any = new WidgetOptionCollection(() => [], component['dataset'], 'Test Layer', 100, undefined, {});
         layerA.title = 'Layer A';
         component.options.layers.push(layerA);
 
@@ -902,7 +903,7 @@ describe('BaseNeonComponent', () => {
         component['layerIdToElementCount'].set(layerA._id, 2);
         expect(component.getButtonText()).toEqual('2 Results');
 
-        let layerB: any = new WidgetOptionCollection(() => [], component['dashboardState'], 'Test Layer', 100, undefined, {});
+        let layerB: any = new WidgetOptionCollection(() => [], component['dataset'], 'Test Layer', 100, undefined, {});
         layerB.title = 'Layer B';
         component.options.layers.push(layerB);
 
@@ -1358,7 +1359,7 @@ describe('BaseNeonComponent', () => {
     });
 
     it('handleTransformVisualizationQueryResults does call success callback function', (done) => {
-        let expectedOptions = new WidgetOptionCollection(() => [], component['dashboardState'], 'Test Layer', 100, undefined, {});
+        let expectedOptions = new WidgetOptionCollection(() => [], component['dataset'], 'Test Layer', 100, undefined, {});
         let expectedResults = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         /* eslint-disable-next-line @typescript-eslint/unbound-method */
         component.transformVisualizationQueryResults = (options, results) => {
@@ -1380,7 +1381,7 @@ describe('BaseNeonComponent', () => {
 
     it('handleTransformVisualizationQueryResults does call failure callback function', (done) => {
         let expectedError = new Error('Test Error');
-        let expectedOptions = new WidgetOptionCollection(() => [], component['dashboardState'], 'Test Layer', 100, undefined, {});
+        let expectedOptions = new WidgetOptionCollection(() => [], component['dataset'], 'Test Layer', 100, undefined, {});
         let expectedResults = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         /* eslint-disable-next-line @typescript-eslint/unbound-method */
         component.transformVisualizationQueryResults = (__options, __results) => {

--- a/src/app/components/base-neon-component/base-neon.component.ts
+++ b/src/app/components/base-neon-component/base-neon.component.ts
@@ -523,10 +523,11 @@ export abstract class BaseNeonComponent implements AfterViewInit, OnInit, OnDest
      * @abstract
      */
     private handleSuccessfulTotalCountQuery(options: WidgetOptionCollection, response: any, callback: () => void): void {
-        if (!response || !response.data || !response.data.length || response.data[0]._count === undefined) {
+        if (!response || !response.data || !response.data.length ||
+            response.data[0][this.searchService.getAggregationName('count')] === undefined) {
             this.layerIdToElementCount.set(options._id, 0);
         } else {
-            this.layerIdToElementCount.set(options._id, response.data[0]._count);
+            this.layerIdToElementCount.set(options._id, response.data[0][this.searchService.getAggregationName('count')]);
         }
         this.lastPage = ((this.page * this.options.limit) >= this.layerIdToElementCount.get(options._id));
         // Decrease loadingCount because of the visualization query.
@@ -581,7 +582,8 @@ export abstract class BaseNeonComponent implements AfterViewInit, OnInit, OnDest
                 if (countQuery) {
                     // Add a count aggregation on '*' to get the total hit count.
                     // Do not add a limit or an offset!
-                    this.searchService.updateAggregation(countQuery, AggregationType.COUNT, '_count', '*');
+                    this.searchService.updateAggregation(countQuery, AggregationType.COUNT,
+                        this.searchService.getAggregationName('count'), '*');
                     this.executeQuery(options, countQuery, 'total count query', this.handleSuccessfulTotalCountQuery.bind(this));
                     // Ignore our own callback since the visualization will be refreshed within handleSuccessfulTotalCountQuery.
                 } else {

--- a/src/app/components/base-neon-component/base-neon.component.ts
+++ b/src/app/components/base-neon-component/base-neon.component.ts
@@ -33,13 +33,25 @@ import {
     OptionType,
     WidgetOption
 } from '../../models/widget-option';
-import { RootWidgetOptionCollection, WidgetOptionCollection, ConfigurableWidget } from '../../models/widget-option-collection';
+import {
+    ConfigurableWidget,
+    OptionConfig,
+    RootWidgetOptionCollection,
+    WidgetOptionCollection
+} from '../../models/widget-option-collection';
 
 import { eventing } from 'neon-framework';
 import { MatDialogRef, MatDialog } from '@angular/material';
 import { DynamicDialogComponent } from '../dynamic-dialog/dynamic-dialog.component';
 import { RequestWrapper } from '../../services/connection.service';
 import { DashboardState } from '../../models/dashboard-state';
+
+export class InjectorOptionConfig extends OptionConfig {
+    public get(bindingKey: string, defaultValue: any): any {
+        // Assume config is an Angular Injector
+        return this.config.get(bindingKey, defaultValue);
+    }
+}
 
 /**
  * @class BaseNeonComponent
@@ -1004,7 +1016,7 @@ export abstract class BaseNeonComponent implements AfterViewInit, OnInit, OnDest
      */
     private createWidgetOptions(injector: Injector, visualizationTitle: string, defaultLimit: number): any {
         let options = new RootWidgetOptionCollection(this.createOptions.bind(this), this.createOptionsForLayer.bind(this),
-            this.dataset, visualizationTitle, defaultLimit, this.shouldCreateDefaultLayer(), injector);
+            this.dataset, visualizationTitle, defaultLimit, this.shouldCreateDefaultLayer(), new InjectorOptionConfig(injector));
 
         this.layerIdToQueryIdToQueryObject.set(options._id, new Map<string, RequestWrapper>());
 

--- a/src/app/components/base-neon-component/base-neon.component.ts
+++ b/src/app/components/base-neon-component/base-neon.component.ts
@@ -657,6 +657,7 @@ export abstract class BaseNeonComponent implements AfterViewInit, OnInit, OnDest
             this.layerIdToQueryIdToQueryObject.get(options._id).get(queryId).abort();
         }
 
+        // TODO THOR-1062 Allow multiple datastores
         this.layerIdToQueryIdToQueryObject.get(options._id).set(queryId, this.searchService.runSearch(
             this.dataset.datastores[0].type, this.dataset.datastores[0].host, query
         ));
@@ -689,6 +690,7 @@ export abstract class BaseNeonComponent implements AfterViewInit, OnInit, OnDest
      * @return {boolean}
      */
     private cannotExecuteQuery(options: WidgetOptionCollection): boolean {
+        // TODO THOR-1062 Allow multiple datastores
         return (!this.searchService.canRunSearch(this.dataset.datastores[0].type, this.dataset.datastores[0].host) ||
             (this.options.hideUnfiltered && !this.getGlobalFilterClauses(options).length));
     }
@@ -962,6 +964,7 @@ export abstract class BaseNeonComponent implements AfterViewInit, OnInit, OnDest
      * @arg {any} options A WidgetOptionCollection object.
      */
     private getLabelOptions(options: WidgetOptionCollection) {
+        // TODO THOR-1062 Allow multiple datastores
         let datastore = this.dataset.datastores[0];
         let matchingDatabase = datastore.databases[options.database.name];
         let matchingTable = matchingDatabase.tables[options.table.name];

--- a/src/app/components/config-editor/config-editor.component.ts
+++ b/src/app/components/config-editor/config-editor.component.ts
@@ -17,8 +17,6 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { MatSnackBar } from '@angular/material';
 import { NeonConfig } from '../../models/types';
 
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
-
 import * as yaml from 'js-yaml';
 import { ConfigService } from '../../services/config.service';
 import { Subject } from 'rxjs';
@@ -41,7 +39,6 @@ export class ConfigEditorComponent implements OnInit, OnDestroy {
     constructor(
         private configService: ConfigService,
         public snackBar: MatSnackBar,
-        protected widgetService: AbstractWidgetService
     ) {
         this.snackBar = snackBar;
     }

--- a/src/app/components/current-filters/current-filters.component.spec.ts
+++ b/src/app/components/current-filters/current-filters.component.spec.ts
@@ -44,7 +44,6 @@ describe('Component: CurrentFiltersComponent', () => {
                 name: 'table',
                 prettyName: 'Table',
                 fields: [],
-                mappings: {},
                 labelOptions: {}
             },
             {

--- a/src/app/components/custom-connection/custom-connection-data.ts
+++ b/src/app/components/custom-connection/custom-connection-data.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { NeonDatabaseMetaData } from '../../models/types';
+import { NeonDatabaseMetaData } from '../../models/dataset';
 
 export class CustomConnectionData {
     public datasetName: string = '';

--- a/src/app/components/custom-connection/custom-connection.component.ts
+++ b/src/app/components/custom-connection/custom-connection.component.ts
@@ -21,7 +21,7 @@ import { CustomConnectionStep } from './custom-connection-step';
 import { CustomConnectionData } from './custom-connection-data';
 
 import { eventing } from 'neon-framework';
-import { NeonDatastoreConfig, NeonDatabaseMetaData } from '../../models/types';
+import { NeonDatastoreConfig, NeonDatabaseMetaData } from '../../models/dataset';
 
 @Component({
     selector: 'app-custom-connection',

--- a/src/app/components/custom-connection/simple-setup.component.ts
+++ b/src/app/components/custom-connection/simple-setup.component.ts
@@ -17,7 +17,7 @@ import { Component } from '@angular/core';
 import { DashboardService } from '../../services/dashboard.service';
 
 import { CustomConnectionStep } from './custom-connection-step';
-import { NeonDatabaseMetaData, NeonTableMetaData, NeonFieldMetaData } from '../../models/types';
+import { NeonDatabaseMetaData, NeonTableMetaData, NeonFieldMetaData } from '../../models/dataset';
 import { ConnectionService, Connection } from '../../services/connection.service';
 
 // TODO It's likely worth removing the extends here. I don't do it now just in case we do want to add steps as we iterate.

--- a/src/app/components/data-message/data-message.component.ts
+++ b/src/app/components/data-message/data-message.component.ts
@@ -21,8 +21,6 @@ import {
 } from '@angular/core';
 import { MatSnackBar } from '@angular/material';
 
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
-
 @Component({
     selector: 'app-data-message',
     templateUrl: 'data-message.component.html',
@@ -34,7 +32,6 @@ export class DataMessageComponent implements OnInit {
     constructor(
         private changeDetection: ChangeDetectorRef,
         public snackBar: MatSnackBar,
-        protected widgetService: AbstractWidgetService
     ) {
     }
 

--- a/src/app/components/data-table/data-table.component.spec.ts
+++ b/src/app/components/data-table/data-table.component.spec.ts
@@ -22,7 +22,7 @@ import { DataTableComponent } from './data-table.component';
 import { AbstractSearchService, CompoundFilterType } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterService } from '../../services/filter.service';
-import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/types';
+import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';

--- a/src/app/components/data-table/data-table.component.ts
+++ b/src/app/components/data-table/data-table.component.ts
@@ -30,7 +30,7 @@ import { DashboardService } from '../../services/dashboard.service';
 import { CompoundFilterDesign, FilterBehavior, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
-import { NeonFieldMetaData } from '../../models/types';
+import { NeonFieldMetaData } from '../../models/dataset';
 import { neonUtilities } from '../../models/neon-namespaces';
 import {
     OptionChoices,

--- a/src/app/components/document-viewer/document-viewer.component.spec.ts
+++ b/src/app/components/document-viewer/document-viewer.component.spec.ts
@@ -20,10 +20,8 @@ import { Injector } from '@angular/core';
 import { DocumentViewerComponent } from './document-viewer.component';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterService } from '../../services/filter.service';
-import { WidgetService } from '../../services/widget.service';
 
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';
@@ -44,7 +42,6 @@ describe('Component: DocumentViewer', () => {
             },
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
-            { provide: AbstractWidgetService, useClass: WidgetService },
             Injector
         ],
         imports: [
@@ -884,7 +881,6 @@ describe('Component: Document Viewer with Config', () => {
             { provide: DashboardService, useClass: DashboardServiceMock },
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
-            { provide: AbstractWidgetService, useClass: WidgetService },
             Injector,
             { provide: 'title', useValue: 'Document Viewer Title' },
             { provide: 'tableKey', useValue: 'table_key_1' },

--- a/src/app/components/document-viewer/document-viewer.component.spec.ts
+++ b/src/app/components/document-viewer/document-viewer.component.spec.ts
@@ -14,7 +14,7 @@
  */
 import { By } from '@angular/platform-browser';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/types';
+import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
 import { Injector } from '@angular/core';
 
 import { DocumentViewerComponent } from './document-viewer.component';

--- a/src/app/components/document-viewer/document-viewer.component.ts
+++ b/src/app/components/document-viewer/document-viewer.component.ts
@@ -26,7 +26,6 @@ import {
 } from '@angular/core';
 
 import { AbstractSearchService, FilterClause, QueryPayload, SortOrder } from '../../services/abstract.search.service';
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterBehavior, FilterService } from '../../services/filter.service';
 
@@ -66,7 +65,6 @@ export class DocumentViewerComponent extends BaseNeonComponent implements OnInit
         filterService: FilterService,
         searchService: AbstractSearchService,
         injector: Injector,
-        protected widgetService: AbstractWidgetService,
         public viewContainerRef: ViewContainerRef,
         ref: ChangeDetectorRef,
         public dialog: MatDialog,

--- a/src/app/components/filter-builder/filter-builder.component.spec.ts
+++ b/src/app/components/filter-builder/filter-builder.component.spec.ts
@@ -15,7 +15,7 @@
 import { } from 'jasmine-core';
 
 import { FilterBuilderComponent } from './filter-builder.component';
-import { NeonFieldMetaData } from '../../models/types';
+import { NeonFieldMetaData } from '../../models/dataset';
 
 import { FilterService } from '../../services/filter.service';
 

--- a/src/app/components/filter-builder/filter-builder.component.ts
+++ b/src/app/components/filter-builder/filter-builder.component.ts
@@ -23,7 +23,7 @@ import { CompoundFilterDesign, FilterDesign, FilterService, SimpleFilterDesign }
 import { DashboardService } from '../../services/dashboard.service';
 
 import { DashboardState } from '../../models/dashboard-state';
-import { NeonFieldMetaData, NeonTableMetaData, NeonDatabaseMetaData } from '../../models/types';
+import { NeonFieldMetaData, NeonTableMetaData, NeonDatabaseMetaData } from '../../models/dataset';
 import { OptionCollection } from '../../models/widget-option-collection';
 
 @Component({
@@ -71,7 +71,7 @@ export class FilterBuilderComponent {
      */
     public addBlankFilterClause(): void {
         let filterClause: FilterClauseMetaData = new FilterClauseMetaData();
-        filterClause.updateDatabases(this.dashboardState);
+        filterClause.updateDatabases(this.dashboardState.asDataset());
         filterClause.field = NeonFieldMetaData.get();
         filterClause.operator = this.operators[0];
         filterClause.value = '';
@@ -105,7 +105,7 @@ export class FilterBuilderComponent {
      */
     public handleChangeDatabaseOfClause(filterClause: FilterClauseMetaData): void {
         filterClause.database = filterClause.changeDatabase;
-        filterClause.updateTables(this.dashboardState);
+        filterClause.updateTables(this.dashboardState.asDataset());
         filterClause.changeTable = filterClause.table;
     }
 
@@ -134,7 +134,7 @@ export class FilterBuilderComponent {
      */
     public handleChangeTableOfClause(filterClause: FilterClauseMetaData): void {
         filterClause.table = filterClause.changeTable;
-        filterClause.updateFields(this.dashboardState);
+        filterClause.updateFields();
     }
 
     /**

--- a/src/app/components/filter-builder/filter-builder.component.ts
+++ b/src/app/components/filter-builder/filter-builder.component.ts
@@ -57,13 +57,15 @@ export class FilterBuilderComponent {
         public filterService: FilterService,
         public searchService: AbstractSearchService
     ) {
+        this.dashboardState = dashboardService.state;
+
         this.dashboardService.stateSource.subscribe(() => {
             this.clearEveryFilterClause();
         });
 
-        this.dashboardState = dashboardService.state;
-
-        this.addBlankFilterClause();
+        if (!this.filterClauses.length) {
+            this.addBlankFilterClause();
+        }
     }
 
     /**

--- a/src/app/components/filter-builder/filter-builder.component.ts
+++ b/src/app/components/filter-builder/filter-builder.component.ts
@@ -22,8 +22,7 @@ import { AbstractSearchService, CompoundFilterType } from '../../services/abstra
 import { CompoundFilterDesign, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
 import { DashboardService } from '../../services/dashboard.service';
 
-import { DashboardState } from '../../models/dashboard-state';
-import { NeonFieldMetaData, NeonTableMetaData, NeonDatabaseMetaData } from '../../models/dataset';
+import { Dataset, NeonFieldMetaData, NeonTableMetaData, NeonDatabaseMetaData } from '../../models/dataset';
 import { OptionCollection } from '../../models/widget-option-collection';
 
 @Component({
@@ -50,16 +49,17 @@ export class FilterBuilderComponent {
     public compoundTypeIsOr: boolean = false;
     public parentFilterIsOr: boolean = false;
 
-    readonly dashboardState: DashboardState;
+    private _dataset: Dataset;
 
     constructor(
         public dashboardService: DashboardService,
         public filterService: FilterService,
         public searchService: AbstractSearchService
     ) {
-        this.dashboardState = dashboardService.state;
+        this._dataset = dashboardService.state.asDataset();
 
         this.dashboardService.stateSource.subscribe(() => {
+            this._dataset = this.dashboardService.state.asDataset();
             this.clearEveryFilterClause();
         });
 
@@ -73,7 +73,7 @@ export class FilterBuilderComponent {
      */
     public addBlankFilterClause(): void {
         let filterClause: FilterClauseMetaData = new FilterClauseMetaData();
-        filterClause.updateDatabases(this.dashboardState.asDataset());
+        filterClause.updateDatabases(this._dataset);
         filterClause.field = NeonFieldMetaData.get();
         filterClause.operator = this.operators[0];
         filterClause.value = '';
@@ -107,7 +107,7 @@ export class FilterBuilderComponent {
      */
     public handleChangeDatabaseOfClause(filterClause: FilterClauseMetaData): void {
         filterClause.database = filterClause.changeDatabase;
-        filterClause.updateTables(this.dashboardState.asDataset());
+        filterClause.updateTables(this._dataset);
         filterClause.changeTable = filterClause.table;
     }
 
@@ -189,9 +189,7 @@ export class FilterBuilderComponent {
         } as CompoundFilterDesign);
 
         if (filterDesign) {
-            this.filterService.toggleFilters('CustomFilter', [filterDesign], this.dashboardState.findRelationDataList(),
-                this.searchService);
-
+            this.filterService.toggleFilters('CustomFilter', [filterDesign], this._dataset.relations, this.searchService);
             this.clearEveryFilterClause();
         }
     }

--- a/src/app/components/gear/gear.component.spec.ts
+++ b/src/app/components/gear/gear.component.spec.ts
@@ -19,9 +19,7 @@ import { } from 'jasmine-core';
 import { GearComponent } from '../gear/gear.component';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { WidgetService } from '../../services/widget.service';
 
 import { NeonFieldMetaData } from '../../models/dataset';
 
@@ -100,7 +98,6 @@ describe('Component: Gear Component', () => {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
             { provide: AbstractSearchService, useClass: SearchServiceMock },
-            { provide: AbstractWidgetService, useClass: WidgetService },
             Injector
         ],
         imports: [

--- a/src/app/components/gear/gear.component.spec.ts
+++ b/src/app/components/gear/gear.component.spec.ts
@@ -54,7 +54,7 @@ class MockConfigurable implements ConfigurableWidget {
     calledExportData = 0;
 
     constructor(dashboardState: DashboardState) {
-        this.options = new RootWidgetOptionCollection(() => [], () => [], dashboardState.asDataset(), 'Test Layer', 100, false, null, {});
+        this.options = new RootWidgetOptionCollection(() => [], () => [], dashboardState.asDataset(), 'Test Layer', 100, false);
     }
 
     changeData(__options?: WidgetOptionCollection, __databaseOrTableChange?: boolean): void {
@@ -151,7 +151,7 @@ describe('Component: Gear Component', () => {
     });
 
     it('getLayerList does return expected list', () => {
-        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'].asDataset(), 'Test Layer', 100, null, {});
+        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'].asDataset(), 'Test Layer', 100);
         expect(component.getLayerList(layer)).toEqual(['limit']);
 
         layer.append(new WidgetFieldOption('field', '', true));
@@ -171,11 +171,11 @@ describe('Component: Gear Component', () => {
         };
 
         component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
-            'Test Layer', 100, false, null, {});
+            'Test Layer', 100, false);
         component['originalOptions'].append(new WidgetFreeTextOption('testOption', '', ''), '');
 
         component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
-            'Test Layer', 100, false, null, {});
+            'Test Layer', 100, false);
         component.modifiedOptions.append(new WidgetFreeTextOption('testOption', '', ''), 'testText');
 
         expect(component['originalOptions'].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
@@ -211,11 +211,11 @@ describe('Component: Gear Component', () => {
         };
 
         component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
-            'Test Layer', 100, false, null, {});
+            'Test Layer', 100, false);
         component['originalOptions'].append(new WidgetFieldOption('testField', '', true), NeonFieldMetaData.get());
 
         component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
-            'Test Layer', 100, false, null, {});
+            'Test Layer', 100, false);
         component.modifiedOptions.append(new WidgetFieldOption('testField', '', true), DashboardServiceMock.FIELD_MAP.NAME);
 
         expect(component['originalOptions'].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
@@ -251,10 +251,10 @@ describe('Component: Gear Component', () => {
         };
 
         component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
-            'Test Layer', 100, false, null, {});
+            'Test Layer', 100, false);
 
         component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
-            'Test Layer', 100, false, null, {});
+            'Test Layer', 100, false);
         component.modifiedOptions.database = DashboardServiceMock.DATABASES.testDatabase2;
 
         expect(component['originalOptions'].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
@@ -287,10 +287,10 @@ describe('Component: Gear Component', () => {
         };
 
         component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
-            'Test Layer', 100, false, null, {});
+            'Test Layer', 100, false);
 
         component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
-            'Test Layer', 100, false, null, {});
+            'Test Layer', 100, false);
         component.modifiedOptions.table = DashboardServiceMock.TABLES.testTable2;
 
         expect(component['originalOptions'].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
@@ -323,12 +323,12 @@ describe('Component: Gear Component', () => {
         };
 
         component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
-            'Test Layer', 100, false, null, {});
+            'Test Layer', 100, false);
 
         component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
-            'Test Layer', 100, false, null, {});
+            'Test Layer', 100, false);
 
-        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'].asDataset(), 'Test Layer', 100, null, {});
+        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'].asDataset(), 'Test Layer', 100);
         component.modifiedOptions.layers.push(layer);
 
         expect(component['originalOptions'].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
@@ -368,12 +368,12 @@ describe('Component: Gear Component', () => {
         };
 
         component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
-            'Test Layer', 100, false, null, {});
+            'Test Layer', 100, false);
 
         component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
-            'Test Layer', 100, false, null, {});
+            'Test Layer', 100, false);
 
-        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'].asDataset(), 'Test Layer', 100, null, {});
+        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'].asDataset(), 'Test Layer', 100);
         layer.append(new WidgetFreeTextOption('testNestedOption', '', ''), '');
         component['originalOptions'].layers.push(layer);
         component.modifiedOptions.layers.push(layer.copy());
@@ -420,13 +420,13 @@ describe('Component: Gear Component', () => {
         };
 
         component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
-            'Test Layer', 100, false, null, {});
+            'Test Layer', 100, false);
 
-        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'].asDataset(), 'Test Layer', 100, null, {});
+        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'].asDataset(), 'Test Layer', 100);
         component['originalOptions'].layers.push(layer);
 
         component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
-            'Test Layer', 100, false, null, {});
+            'Test Layer', 100, false);
 
         expect(component['originalOptions'].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
         expect(component['originalOptions'].table).toEqual(DashboardServiceMock.TABLES.testTable1);
@@ -464,18 +464,18 @@ describe('Component: Gear Component', () => {
         };
 
         component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
-            'Test Layer', 100, false, null, {});
+            'Test Layer', 100, false);
         component['originalOptions'].append(new WidgetFreeTextOption('testOption', '', ''), '');
         component['originalOptions'].append(new WidgetFieldOption('testField', '', true), NeonFieldMetaData.get());
 
         component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
-            'Test Layer', 100, false, null, {});
+            'Test Layer', 100, false);
         component.modifiedOptions.database = DashboardServiceMock.DATABASES.testDatabase2;
         component.modifiedOptions.table = DashboardServiceMock.TABLES.testTable2;
         component.modifiedOptions.append(new WidgetFreeTextOption('testOption', '', ''), 'testText');
         component.modifiedOptions.append(new WidgetFieldOption('testField', '', true), DashboardServiceMock.FIELD_MAP.NAME);
 
-        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'].asDataset(), 'Test Layer', 100, null, {});
+        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'].asDataset(), 'Test Layer', 100);
         layer.append(new WidgetFreeTextOption('testNestedOption', '', ''), '');
         component['originalOptions'].layers.push(layer);
         component.modifiedOptions.layers.push(layer.copy());
@@ -620,11 +620,11 @@ describe('Component: Gear Component', () => {
         component.comp = mock;
 
         component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
-            'Test Layer', 100, false, null, {});
+            'Test Layer', 100, false);
         component['originalOptions'].append(new WidgetNonPrimitiveOption('testOption1', 'TestOption', ''), {});
 
         component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
-            'Test Layer', 100, false, null, {});
+            'Test Layer', 100, false);
         component.modifiedOptions.append(new WidgetNonPrimitiveOption('testOption1', 'TestOption', ''), {});
         expect(component.changeMade).toEqual(false);
         expect(component.modifiedOptions.testOption1).toEqual({});

--- a/src/app/components/gear/gear.component.spec.ts
+++ b/src/app/components/gear/gear.component.spec.ts
@@ -23,7 +23,7 @@ import { AbstractWidgetService } from '../../services/abstract.widget.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { WidgetService } from '../../services/widget.service';
 
-import { NeonFieldMetaData } from '../../models/types';
+import { NeonFieldMetaData } from '../../models/dataset';
 
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 import { neonEvents } from '../../models/neon-namespaces';
@@ -54,7 +54,7 @@ class MockConfigurable implements ConfigurableWidget {
     calledExportData = 0;
 
     constructor(dashboardState: DashboardState) {
-        this.options = new RootWidgetOptionCollection(() => [], () => [], dashboardState, 'Test Layer', 100, false, null, {});
+        this.options = new RootWidgetOptionCollection(() => [], () => [], dashboardState.asDataset(), 'Test Layer', 100, false, null, {});
     }
 
     changeData(__options?: WidgetOptionCollection, __databaseOrTableChange?: boolean): void {
@@ -151,7 +151,7 @@ describe('Component: Gear Component', () => {
     });
 
     it('getLayerList does return expected list', () => {
-        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'], 'Test Layer', 100, null, {});
+        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'].asDataset(), 'Test Layer', 100, null, {});
         expect(component.getLayerList(layer)).toEqual(['limit']);
 
         layer.append(new WidgetFieldOption('field', '', true));
@@ -170,12 +170,12 @@ describe('Component: Gear Component', () => {
             calledCloseSidenav++;
         };
 
-        component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'], 'Test Layer', 100,
-            false, null, {});
+        component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
+            'Test Layer', 100, false, null, {});
         component['originalOptions'].append(new WidgetFreeTextOption('testOption', '', ''), '');
 
-        component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'], 'Test Layer', 100,
-            false, null, {});
+        component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
+            'Test Layer', 100, false, null, {});
         component.modifiedOptions.append(new WidgetFreeTextOption('testOption', '', ''), 'testText');
 
         expect(component['originalOptions'].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
@@ -210,12 +210,12 @@ describe('Component: Gear Component', () => {
             calledCloseSidenav++;
         };
 
-        component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'], 'Test Layer', 100,
-            false, null, {});
+        component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
+            'Test Layer', 100, false, null, {});
         component['originalOptions'].append(new WidgetFieldOption('testField', '', true), NeonFieldMetaData.get());
 
-        component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'], 'Test Layer', 100,
-            false, null, {});
+        component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
+            'Test Layer', 100, false, null, {});
         component.modifiedOptions.append(new WidgetFieldOption('testField', '', true), DashboardServiceMock.FIELD_MAP.NAME);
 
         expect(component['originalOptions'].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
@@ -250,11 +250,11 @@ describe('Component: Gear Component', () => {
             calledCloseSidenav++;
         };
 
-        component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'], 'Test Layer', 100,
-            false, null, {});
+        component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
+            'Test Layer', 100, false, null, {});
 
-        component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'], 'Test Layer', 100,
-            false, null, {});
+        component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
+            'Test Layer', 100, false, null, {});
         component.modifiedOptions.database = DashboardServiceMock.DATABASES.testDatabase2;
 
         expect(component['originalOptions'].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
@@ -286,11 +286,11 @@ describe('Component: Gear Component', () => {
             calledCloseSidenav++;
         };
 
-        component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'], 'Test Layer', 100,
-            false, null, {});
+        component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
+            'Test Layer', 100, false, null, {});
 
-        component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'], 'Test Layer', 100,
-            false, null, {});
+        component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
+            'Test Layer', 100, false, null, {});
         component.modifiedOptions.table = DashboardServiceMock.TABLES.testTable2;
 
         expect(component['originalOptions'].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
@@ -322,13 +322,13 @@ describe('Component: Gear Component', () => {
             calledCloseSidenav++;
         };
 
-        component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'], 'Test Layer', 100,
-            false, null, {});
+        component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
+            'Test Layer', 100, false, null, {});
 
-        component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'], 'Test Layer', 100,
-            false, null, {});
+        component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
+            'Test Layer', 100, false, null, {});
 
-        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'], 'Test Layer', 100, null, {});
+        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'].asDataset(), 'Test Layer', 100, null, {});
         component.modifiedOptions.layers.push(layer);
 
         expect(component['originalOptions'].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
@@ -367,16 +367,16 @@ describe('Component: Gear Component', () => {
             calledCloseSidenav++;
         };
 
-        component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'], 'Test Layer', 100,
-            false, null, {});
+        component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
+            'Test Layer', 100, false, null, {});
 
-        component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'], 'Test Layer', 100,
-            false, null, {});
+        component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
+            'Test Layer', 100, false, null, {});
 
-        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'], 'Test Layer', 100, null, {});
+        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'].asDataset(), 'Test Layer', 100, null, {});
         layer.append(new WidgetFreeTextOption('testNestedOption', '', ''), '');
         component['originalOptions'].layers.push(layer);
-        component.modifiedOptions.layers.push(layer.copy(component['dashboardState']));
+        component.modifiedOptions.layers.push(layer.copy());
         component.modifiedOptions.layers[0].testNestedOption = 'testNestedText';
 
         expect(component['originalOptions'].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
@@ -419,14 +419,14 @@ describe('Component: Gear Component', () => {
             calledCloseSidenav++;
         };
 
-        component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'], 'Test Layer', 100,
-            false, null, {});
+        component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
+            'Test Layer', 100, false, null, {});
 
-        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'], 'Test Layer', 100, null, {});
+        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'].asDataset(), 'Test Layer', 100, null, {});
         component['originalOptions'].layers.push(layer);
 
-        component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'], 'Test Layer', 100,
-            false, null, {});
+        component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
+            'Test Layer', 100, false, null, {});
 
         expect(component['originalOptions'].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
         expect(component['originalOptions'].table).toEqual(DashboardServiceMock.TABLES.testTable1);
@@ -463,22 +463,22 @@ describe('Component: Gear Component', () => {
             calledCloseSidenav++;
         };
 
-        component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'], 'Test Layer', 100,
-            false, null, {});
+        component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
+            'Test Layer', 100, false, null, {});
         component['originalOptions'].append(new WidgetFreeTextOption('testOption', '', ''), '');
         component['originalOptions'].append(new WidgetFieldOption('testField', '', true), NeonFieldMetaData.get());
 
-        component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'], 'Test Layer', 100,
-            false, null, {});
+        component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
+            'Test Layer', 100, false, null, {});
         component.modifiedOptions.database = DashboardServiceMock.DATABASES.testDatabase2;
         component.modifiedOptions.table = DashboardServiceMock.TABLES.testTable2;
         component.modifiedOptions.append(new WidgetFreeTextOption('testOption', '', ''), 'testText');
         component.modifiedOptions.append(new WidgetFieldOption('testField', '', true), DashboardServiceMock.FIELD_MAP.NAME);
 
-        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'], 'Test Layer', 100, null, {});
+        let layer: any = new WidgetOptionCollection(() => [], component['dashboardState'].asDataset(), 'Test Layer', 100, null, {});
         layer.append(new WidgetFreeTextOption('testNestedOption', '', ''), '');
         component['originalOptions'].layers.push(layer);
-        component.modifiedOptions.layers.push(layer.copy(component['dashboardState']));
+        component.modifiedOptions.layers.push(layer.copy());
         component.modifiedOptions.layers[0].testNestedOption = 'testNestedText';
 
         expect(component['originalOptions'].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
@@ -619,12 +619,12 @@ describe('Component: Gear Component', () => {
         const mock = new MockConfigurable(component['dashboardState']);
         component.comp = mock;
 
-        component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'], 'Test Layer', 100,
-            false, null, {});
+        component['originalOptions'] = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
+            'Test Layer', 100, false, null, {});
         component['originalOptions'].append(new WidgetNonPrimitiveOption('testOption1', 'TestOption', ''), {});
 
-        component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'], 'Test Layer', 100,
-            false, null, {});
+        component.modifiedOptions = new RootWidgetOptionCollection(() => [], () => [], component['dashboardState'].asDataset(),
+            'Test Layer', 100, false, null, {});
         component.modifiedOptions.append(new WidgetNonPrimitiveOption('testOption1', 'TestOption', ''), {});
         expect(component.changeMade).toEqual(false);
         expect(component.modifiedOptions.testOption1).toEqual({});

--- a/src/app/components/gear/gear.component.ts
+++ b/src/app/components/gear/gear.component.ts
@@ -27,7 +27,6 @@ import {
 
 import { MatSidenav } from '@angular/material';
 
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { OptionType, WidgetOption } from '../../models/widget-option';
 import { WidgetOptionCollection, ConfigurableWidget } from '../../models/widget-option-collection';
@@ -76,8 +75,7 @@ export class GearComponent implements OnInit, OnDestroy {
 
     constructor(
         private changeDetection: ChangeDetectorRef,
-        dashboardService: DashboardService,
-        protected widgetService: AbstractWidgetService
+        dashboardService: DashboardService
     ) {
         this.messenger = new eventing.Messenger();
         this.dashboardState = dashboardService.state;

--- a/src/app/components/gear/gear.component.ts
+++ b/src/app/components/gear/gear.component.ts
@@ -234,7 +234,7 @@ export class GearComponent implements OnInit, OnDestroy {
      * @arg {any} options A WidgetOptionCollection
      */
     public handleChangeDatabase(options: WidgetOptionCollection): void {
-        options.updateTables(this.dashboardState);
+        options.updateTables(this.dashboardState.asDataset());
         this.changeMade = true;
     }
 
@@ -244,7 +244,7 @@ export class GearComponent implements OnInit, OnDestroy {
      * @arg {any} options A WidgetOptionCollection
      */
     public handleChangeTable(options: WidgetOptionCollection): void {
-        options.updateFields(this.dashboardState);
+        options.updateFields();
         this.changeMade = true;
     }
 

--- a/src/app/components/legend/legend.component.html
+++ b/src/app/components/legend/legend.component.html
@@ -4,7 +4,7 @@
         <mat-icon class="neon-icon-small legend-text">{{ menuIcon }}</mat-icon>
     </button>
 
-    <mat-menu #menu="matMenu" [backdropClass]="widgetService.getTheme()" [overlapTrigger]="false">
+    <mat-menu #menu="matMenu" [backdropClass]="colorThemeService.getTheme()" [overlapTrigger]="false">
         <div *ngFor="let colorSet of colorSets">
             <div *ngIf="filteringOn">
                 <button mat-menu-item *ngFor="let key of colorSet.getAllKeys()"

--- a/src/app/components/legend/legend.component.ts
+++ b/src/app/components/legend/legend.component.ts
@@ -26,7 +26,7 @@ import {
 
 import { ColorSet } from '../../models/color';
 
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
+import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
 
 /**
  * Shows a legend of colors using the given color keys.
@@ -76,7 +76,7 @@ export class LegendComponent implements OnInit {
     public colorSets: ColorSet[] = [];
     private _colorKeys: string[];
 
-    constructor(public widgetService: AbstractWidgetService) {
+    constructor(public colorThemeService: AbstractColorThemeService) {
         this.menuIcon = 'keyboard_arrow_down';
     }
 
@@ -95,7 +95,7 @@ export class LegendComponent implements OnInit {
     private loadAllColorSets() {
         this.colorSets = [];
         for (let colorKey of (this.colorKeys || [])) {
-            let colorSet = this.widgetService.getColorSet(colorKey || '');
+            let colorSet = this.colorThemeService.getColorSet(colorKey || '');
             if (colorSet) {
                 this.colorSets.push(colorSet);
             }

--- a/src/app/components/map/map.component.spec.ts
+++ b/src/app/components/map/map.component.spec.ts
@@ -31,7 +31,7 @@ import { WidgetService } from '../../services/widget.service';
 
 import { By } from '@angular/platform-browser';
 import { AbstractMap, BoundingBoxByDegrees, MapPoint, MapType } from './map.type.abstract';
-import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/types';
+import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
 import { WidgetOptionCollection } from '../../models/widget-option-collection';
 
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
@@ -120,7 +120,7 @@ function updateMapLayer1(component: TestMapComponent) {
     component.filterVisible.set('testLayer1', true);
     (component as any).layerIdToElementCount.set('testLayer1', 1);
 
-    component.options.layers[0] = new WidgetOptionCollection(() => [], component['dashboardState'], 'Test Layer', 100, undefined, {});
+    component.options.layers[0] = new WidgetOptionCollection(() => [], component['dataset'], 'Test Layer', 100, undefined, {});
     component.options.layers[0]._id = 'testLayer1';
     component.options.layers[0].databases = [];
     component.options.layers[0].database = DashboardServiceMock.DATABASES.testDatabase1;
@@ -145,7 +145,7 @@ function updateMapLayer2(component: TestMapComponent) {
     component.filterVisible.set('testLayer2', true);
     (component as any).layerIdToElementCount.set('testLayer2', 10);
 
-    component.options.layers[1] = new WidgetOptionCollection(() => [], component['dashboardState'], 'Test Layer', 100, undefined, {});
+    component.options.layers[1] = new WidgetOptionCollection(() => [], component['dataset'], 'Test Layer', 100, undefined, {});
     component.options.layers[1]._id = 'testLayer2';
     component.options.layers[1].databases = [];
     component.options.layers[1].database = DashboardServiceMock.DATABASES.testDatabase2;

--- a/src/app/components/map/map.component.spec.ts
+++ b/src/app/components/map/map.component.spec.ts
@@ -24,10 +24,10 @@ import {
 import { MapComponent } from './map.component';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
+import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterService } from '../../services/filter.service';
-import { WidgetService } from '../../services/widget.service';
+import { ColorThemeService } from '../../services/color-theme.service';
 
 import { By } from '@angular/platform-browser';
 import { AbstractMap, BoundingBoxByDegrees, MapPoint, MapType } from './map.type.abstract';
@@ -181,7 +181,7 @@ describe('Component: Map', () => {
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector,
-            { provide: AbstractWidgetService, useClass: WidgetService }
+            { provide: AbstractColorThemeService, useClass: ColorThemeService }
 
         ],
         imports: [
@@ -252,12 +252,12 @@ describe('Component: Map', () => {
         let filter4 = new Map<string, any>().set('filterFields', [2, 4]);
         let filter5 = new Map<string, any>().set('filterFields', [5]);
 
-        let widgetService = getService(AbstractWidgetService);
+        let colorThemeService = getService(AbstractColorThemeService);
 
-        let aColor = widgetService.getColor('myDatabase', 'myTable', 'category', 'a').getComputedCss(component.visualization);
-        let bColor = widgetService.getColor('myDatabase', 'myTable', 'category', 'b').getComputedCss(component.visualization);
-        let cColor = widgetService.getColor('myDatabase', 'myTable', 'category', 'c').getComputedCss(component.visualization);
-        let dColor = widgetService.getColor('myDatabase', 'myTable', 'category', 'd').getComputedCss(component.visualization);
+        let aColor = colorThemeService.getColor('myDatabase', 'myTable', 'category', 'a').getComputedCss(component.visualization);
+        let bColor = colorThemeService.getColor('myDatabase', 'myTable', 'category', 'b').getComputedCss(component.visualization);
+        let cColor = colorThemeService.getColor('myDatabase', 'myTable', 'category', 'c').getComputedCss(component.visualization);
+        let dColor = colorThemeService.getColor('myDatabase', 'myTable', 'category', 'd').getComputedCss(component.visualization);
 
         let dataset1 = {
             data: [
@@ -1147,7 +1147,7 @@ describe('Component: Map with config', () => {
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector,
-            { provide: AbstractWidgetService, useClass: WidgetService },
+            { provide: AbstractColorThemeService, useClass: ColorThemeService },
             { provide: 'tableKey', useValue: 'table_key_1' },
             {
                 provide: 'layers',

--- a/src/app/components/map/map.component.spec.ts
+++ b/src/app/components/map/map.component.spec.ts
@@ -120,7 +120,7 @@ function updateMapLayer1(component: TestMapComponent) {
     component.filterVisible.set('testLayer1', true);
     (component as any).layerIdToElementCount.set('testLayer1', 1);
 
-    component.options.layers[0] = new WidgetOptionCollection(() => [], component['dataset'], 'Test Layer', 100, undefined, {});
+    component.options.layers[0] = new WidgetOptionCollection(() => [], component['dataset'], 'Test Layer', 100);
     component.options.layers[0]._id = 'testLayer1';
     component.options.layers[0].databases = [];
     component.options.layers[0].database = DashboardServiceMock.DATABASES.testDatabase1;
@@ -145,7 +145,7 @@ function updateMapLayer2(component: TestMapComponent) {
     component.filterVisible.set('testLayer2', true);
     (component as any).layerIdToElementCount.set('testLayer2', 10);
 
-    component.options.layers[1] = new WidgetOptionCollection(() => [], component['dataset'], 'Test Layer', 100, undefined, {});
+    component.options.layers[1] = new WidgetOptionCollection(() => [], component['dataset'], 'Test Layer', 100);
     component.options.layers[1]._id = 'testLayer2';
     component.options.layers[1].databases = [];
     component.options.layers[1].database = DashboardServiceMock.DATABASES.testDatabase2;

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -26,7 +26,7 @@ import {
 } from '@angular/core';
 
 import { AbstractSearchService, CompoundFilterType, FilterClause, QueryPayload } from '../../services/abstract.search.service';
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
+import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import {
     CompoundFilterDesign,
@@ -99,7 +99,7 @@ export class MapComponent extends BaseNeonComponent implements OnInit, OnDestroy
         filterService: FilterService,
         searchService: AbstractSearchService,
         injector: Injector,
-        protected widgetService: AbstractWidgetService,
+        protected colorThemeService: AbstractColorThemeService,
         ref: ChangeDetectorRef,
         dialog: MatDialog,
         public visualization: ElementRef
@@ -340,11 +340,11 @@ export class MapComponent extends BaseNeonComponent implements OnInit, OnDestroy
         }
 
         let mapPoints: MapPoint[] = [];
-        let rgbColor = this.widgetService.getThemeAccentColorHex();
+        let rgbColor = this.colorThemeService.getThemeAccentColorHex();
         map.forEach((unique) => {
             let color = rgbColor;
             if (!this.options.singleColor) {
-                color = !unique.colorValue ? whiteString : this.widgetService.getColor(databaseName, tableName, colorField,
+                color = !unique.colorValue ? whiteString : this.colorThemeService.getColor(databaseName, tableName, colorField,
                     unique.colorValue).getComputedCss(this.visualization);
             }
 
@@ -419,7 +419,7 @@ export class MapComponent extends BaseNeonComponent implements OnInit, OnDestroy
         let colorKeys: string[] = [];
         for (let layer of this.options.layers) {
             if (layer.colorField.columnName !== '') {
-                colorKeys.push(this.widgetService.getColorKey(layer.database.name, layer.table.name, layer.colorField.columnName));
+                colorKeys.push(this.colorThemeService.getColorKey(layer.database.name, layer.table.name, layer.colorField.columnName));
             }
         }
         this.colorKeys = colorKeys;

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -47,7 +47,7 @@ import {
     whiteString
 } from './map.type.abstract';
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
-import { NeonFieldMetaData } from '../../models/types';
+import { NeonFieldMetaData } from '../../models/dataset';
 import { LeafletNeonMap } from './map.type.leaflet';
 import { neonUtilities } from '../../models/neon-namespaces';
 import {

--- a/src/app/components/media-viewer/media-viewer.component.spec.ts
+++ b/src/app/components/media-viewer/media-viewer.component.spec.ts
@@ -14,7 +14,8 @@
  */
 import { By } from '@angular/platform-browser';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData, MediaTypes } from '../../models/types';
+import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
+import { MediaTypes } from '../../models/types';
 import { Injector } from '@angular/core';
 
 import { } from 'jasmine-core';

--- a/src/app/components/network-graph/network-graph.component.spec.ts
+++ b/src/app/components/network-graph/network-graph.component.spec.ts
@@ -19,8 +19,8 @@ import { DashboardService } from '../../services/dashboard.service';
 import { NeonFieldMetaData } from '../../models/dataset';
 import { FilterService } from '../../services/filter.service';
 import { AbstractSearchService } from '../../services/abstract.search.service';
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
-import { WidgetService } from '../../services/widget.service';
+import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
+import { ColorThemeService } from '../../services/color-theme.service';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 import { By } from '@angular/platform-browser';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
@@ -39,7 +39,7 @@ describe('Component: NetworkGraph', () => {
             FilterService,
             Injector,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
-            { provide: AbstractWidgetService, useClass: WidgetService },
+            { provide: AbstractColorThemeService, useClass: ColorThemeService },
             { provide: 'limit', useValue: 'testLimit' }
         ],
         imports: [

--- a/src/app/components/network-graph/network-graph.component.spec.ts
+++ b/src/app/components/network-graph/network-graph.component.spec.ts
@@ -16,7 +16,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CUSTOM_ELEMENTS_SCHEMA, Injector } from '@angular/core';
 import { NetworkGraphComponent } from './network-graph.component';
 import { DashboardService } from '../../services/dashboard.service';
-import { NeonFieldMetaData } from '../../models/types';
+import { NeonFieldMetaData } from '../../models/dataset';
 import { FilterService } from '../../services/filter.service';
 import { AbstractSearchService } from '../../services/abstract.search.service';
 import { AbstractWidgetService } from '../../services/abstract.widget.service';
@@ -907,7 +907,7 @@ describe('Component: NetworkGraph', () => {
     });
 
     it('designEachFilterWithNoValues with layers does return expected object', () => {
-        component.options.layers = [new WidgetOptionCollection(() => [], component['dashboardState'], 'Test Layer', 100)];
+        component.options.layers = [new WidgetOptionCollection(() => [], component['dataset'], 'Test Layer', 100)];
         component.options.edgeColorField = DashboardServiceMock.FIELD_MAP.TYPE;
         component.options.layers[0].layerType = 'nodes';
         component.options.layers[0].filterFields = [DashboardServiceMock.FIELD_MAP.CATEGORY, DashboardServiceMock.FIELD_MAP.TEXT];

--- a/src/app/components/network-graph/network-graph.component.ts
+++ b/src/app/components/network-graph/network-graph.component.ts
@@ -37,7 +37,7 @@ import { DashboardService } from '../../services/dashboard.service';
 import { CompoundFilterDesign, FilterBehavior, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
-import { NeonFieldMetaData } from '../../models/types';
+import { NeonFieldMetaData } from '../../models/dataset';
 import { neonUtilities } from '../../models/neon-namespaces';
 import {
     OptionChoices,

--- a/src/app/components/network-graph/network-graph.component.ts
+++ b/src/app/components/network-graph/network-graph.component.ts
@@ -32,7 +32,7 @@ import {
     QueryPayload,
     SortOrder
 } from '../../services/abstract.search.service';
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
+import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { CompoundFilterDesign, FilterBehavior, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
 
@@ -225,7 +225,7 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
         filterService: FilterService,
         searchService: AbstractSearchService,
         injector: Injector,
-        protected widgetService: AbstractWidgetService,
+        protected colorThemeService: AbstractColorThemeService,
         ref: ChangeDetectorRef,
         dialog: MatDialog,
         public visualization: ElementRef,
@@ -894,7 +894,7 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
 
             // If there is a valid nodeColorField and no modifications to the legend labels, override the default nodeColor
             if (colorField && this.prettifiedNodeLabels.length === 0) {
-                color = this.widgetService.getColor(this.options.database.name, this.options.table.name, colorField,
+                color = this.colorThemeService.getColor(this.options.database.name, this.options.table.name, colorField,
                     colorMapVal).getComputedCss(this.visualization);
             }
 
@@ -909,7 +909,7 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
                         let shortName = this.labelCleanUp(colorMapVal);
                         for (const nodeLabel of this.prettifiedNodeLabels) {
                             if (nodeLabel === shortName) {
-                                color = this.widgetService.getColor(this.options.database.name, this.options.table.name, colorField,
+                                color = this.colorThemeService.getColor(this.options.database.name, this.options.table.name, colorField,
                                     nodeLabel).getComputedCss(this.visualization);
                                 break;
                             }
@@ -937,7 +937,7 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
 
         // If there is a valid colorField and no modifications to the legend labels, override the default colorString
         if (colorField && this.prettifiedEdgeLabels.length === 0) {
-            color = this.widgetService.getColor(this.options.database.name, this.options.table.name, colorField,
+            color = this.colorThemeService.getColor(this.options.database.name, this.options.table.name, colorField,
                 colorMapVal).getComputedCss(this.visualization);
         }
 
@@ -952,7 +952,7 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
                 for (const edgeLabel of this.prettifiedEdgeLabels) {
                     if (edgeLabel === shortName) {
                         colorMapVal = edgeLabel;
-                        color = this.widgetService.getColor(this.options.database.name, this.options.table.name,
+                        color = this.colorThemeService.getColor(this.options.database.name, this.options.table.name,
                             colorField, edgeLabel).getComputedCss(this.visualization);
                         colorObject = { color: color, highlight: color };
                         break;
@@ -1155,10 +1155,10 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
     updateLegend() {
         let colorKeys: string[] = [];
         if (this.options.nodeColorField.columnName !== '') {
-            colorKeys.push(this.widgetService.getColorKey(this.options.database.name, this.options.table.name,
+            colorKeys.push(this.colorThemeService.getColorKey(this.options.database.name, this.options.table.name,
                 this.options.nodeColorField.columnName));
         } else if (this.options.edgeColorField.columnName !== '') {
-            colorKeys.push(this.widgetService.getColorKey(this.options.database.name, this.options.table.name,
+            colorKeys.push(this.colorThemeService.getColorKey(this.options.database.name, this.options.table.name,
                 this.options.edgeColorField.columnName));
         }
         this.colorKeys = colorKeys;

--- a/src/app/components/news-feed/news-feed.component.spec.ts
+++ b/src/app/components/news-feed/news-feed.component.spec.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/types';
+import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
 import { Injector } from '@angular/core';
 
 import { } from 'jasmine-core';

--- a/src/app/components/options-list/options-list.component.ts
+++ b/src/app/components/options-list/options-list.component.ts
@@ -18,7 +18,7 @@ import {
     Input,
     ViewEncapsulation
 } from '@angular/core';
-import { NeonFieldMetaData } from '../../models/types';
+import { NeonFieldMetaData } from '../../models/dataset';
 import { WidgetOption } from '../../models/widget-option';
 
 @Component({

--- a/src/app/components/query-bar/query-bar.component.html
+++ b/src/app/components/query-bar/query-bar.component.html
@@ -7,7 +7,8 @@
             <input #queryBar matInput [placeholder]="options.placeHolder" class="query-bar-input" [matAutocomplete]="auto"
                 [formControl]="filterFormControl" (keyup)="createFilter(queryBar.value)" (keyup.enter)="createFilter(queryBar.value)"
                 autofocus>
-            <mat-autocomplete #auto="matAutocomplete" (optionSelected)="createFilter(queryBar.value)" [class]="widgetService.getTheme()">
+            <mat-autocomplete #auto="matAutocomplete" (optionSelected)="createFilter(queryBar.value)"
+                [class]="colorThemeService.getTheme()">
                 <mat-option *ngFor="let option of queryOptions | async" [value]="option">
                     <span [matTooltip]="option">{{ option }}</span>
                 </mat-option>

--- a/src/app/components/query-bar/query-bar.component.spec.ts
+++ b/src/app/components/query-bar/query-bar.component.spec.ts
@@ -18,10 +18,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
+import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterService } from '../../services/filter.service';
-import { WidgetService } from '../../services/widget.service';
+import { ColorThemeService } from '../../services/color-theme.service';
 
 import { NeonConfig } from '../../models/types';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -63,7 +63,7 @@ class queryBarTester {
             ],
             providers: [
                 { provide: FilterService, useClass: MockFilterService },
-                { provide: AbstractWidgetService, useClass: WidgetService },
+                { provide: AbstractColorThemeService, useClass: ColorThemeService },
                 { provide: DashboardService, useClass: mockDataset ? MockDashboardService : DashboardService },
 
             ],

--- a/src/app/components/query-bar/query-bar.component.ts
+++ b/src/app/components/query-bar/query-bar.component.ts
@@ -23,7 +23,7 @@ import { DashboardService } from '../../services/dashboard.service';
 import { CompoundFilterDesign, FilterBehavior, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
-import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/types';
+import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
 import { neonUtilities } from '../../models/neon-namespaces';
 import {
     OptionChoices,

--- a/src/app/components/query-bar/query-bar.component.ts
+++ b/src/app/components/query-bar/query-bar.component.ts
@@ -18,7 +18,7 @@ import { FormControl } from '@angular/forms';
 import { map, startWith } from 'rxjs/operators';
 
 import { AbstractSearchService, CompoundFilterType, FilterClause, QueryPayload } from '../../services/abstract.search.service';
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
+import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { CompoundFilterDesign, FilterBehavior, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
 
@@ -62,7 +62,7 @@ export class QueryBarComponent extends BaseNeonComponent {
         filterService: FilterService,
         searchService: AbstractSearchService,
         injector: Injector,
-        protected widgetService: AbstractWidgetService,
+        protected colorThemeService: AbstractColorThemeService,
         ref: ChangeDetectorRef,
         dialog: MatDialog
     ) {

--- a/src/app/components/sample/sample.component.spec.ts
+++ b/src/app/components/sample/sample.component.spec.ts
@@ -27,7 +27,7 @@ import { DashboardService } from '../../services/dashboard.service';
 import { FilterService } from '../../services/filter.service';
 import { SearchService } from '../../services/search.service';
 
-import { NeonFieldMetaData } from '../../models/types';
+import { NeonFieldMetaData } from '../../models/dataset';
 
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';

--- a/src/app/components/sample/sample.component.spec.ts
+++ b/src/app/components/sample/sample.component.spec.ts
@@ -194,7 +194,7 @@ describe('Component: Sample', () => {
         expect(component.finalizeVisualizationQuery(component.options, {}, [])).toEqual({
             aggregation: [{
                 field: 'testRequiredField1',
-                name: '_count',
+                name: '_aggregation',
                 type: 'count'
             }],
             filter: {
@@ -204,7 +204,7 @@ describe('Component: Sample', () => {
             },
             groups: ['testRequiredField1'],
             sort: {
-                field: '_count',
+                field: '_aggregation',
                 order: -1
             }
         });
@@ -225,7 +225,7 @@ describe('Component: Sample', () => {
         expect(component.finalizeVisualizationQuery(component.options, {}, [])).toEqual({
             aggregation: [{
                 field: 'testOptionalField1',
-                name: '_count',
+                name: '_aggregation',
                 type: 'count'
             }],
             filter: {
@@ -242,7 +242,7 @@ describe('Component: Sample', () => {
             },
             groups: ['testRequiredField1', 'testOptionalField1'],
             sort: {
-                field: '_count',
+                field: '_aggregation',
                 order: -1
             }
         });
@@ -374,10 +374,10 @@ describe('Component: Sample', () => {
         });
 
         let actual = component.transformVisualizationQueryResults(component.options, [{
-            _count: 2,
+            _aggregation: 2,
             testRequiredField1: 'a'
         }, {
-            _count: 1,
+            _aggregation: 1,
             testRequiredField1: 'z'
         }]);
         expect(component.visualizationData).toEqual([{
@@ -416,11 +416,11 @@ describe('Component: Sample', () => {
         });
 
         let actual = component.transformVisualizationQueryResults(component.options, [{
-            _count: 2,
+            _aggregation: 2,
             testOptionalField1: 'alpha',
             testRequiredField1: 'a'
         }, {
-            _count: 1,
+            _aggregation: 1,
             testOptionalField1: 'omega',
             testRequiredField1: 'z'
         }]);

--- a/src/app/components/sample/sample.component.ts
+++ b/src/app/components/sample/sample.component.ts
@@ -189,8 +189,9 @@ export class SampleComponent extends BaseNeonComponent implements OnInit, OnDest
         }
 
         this.searchService.updateFilter(query, this.searchService.buildCompoundFilterClause(sharedFilters.concat(filters)))
-            .updateGroups(query, groups).updateAggregation(query, AggregationType.COUNT, '_count', countField)
-            .updateSort(query, '_count', SortOrder.DESCENDING);
+            .updateGroups(query, groups)
+            .updateAggregation(query, AggregationType.COUNT, this.searchService.getAggregationName(), countField)
+            .updateSort(query, this.searchService.getAggregationName(), SortOrder.DESCENDING);
 
         return query;
     }
@@ -326,13 +327,13 @@ export class SampleComponent extends BaseNeonComponent implements OnInit, OnDest
     transformVisualizationQueryResults(options: any, results: any[]): number {
         // TODO Change this behavior as needed to handle your query results:  update and/or redraw and properties and/or subcomponents.
 
-        // The aggregation query response data will have a _count field and all visualization fields.
+        // The aggregation query response data will have an _aggregation field and all visualization fields.
         this.visualizationData = results.map((item) => {
             let label = item[options.sampleRequiredField.columnName] + (options.sampleOptionalField.columnName ? ' - ' +
                 item[options.sampleOptionalField.columnName] : '');
 
             return {
-                count: item._count,
+                count: item[this.searchService.getAggregationName()],
                 field: options.sampleRequiredField,
                 label: label,
                 value: item[options.sampleRequiredField.columnName]

--- a/src/app/components/sample/sample.component.ts
+++ b/src/app/components/sample/sample.component.ts
@@ -35,7 +35,7 @@ import { FilterBehavior, FilterDesign, FilterService, SimpleFilterDesign } from 
 
 import { AbstractSubcomponent } from './subcomponent.abstract';
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
-import { NeonFieldMetaData } from '../../models/types';
+import { NeonFieldMetaData } from '../../models/dataset';
 import {
     AggregationType,
     OptionChoices,

--- a/src/app/components/save-state/save-state.component.spec.ts
+++ b/src/app/components/save-state/save-state.component.spec.ts
@@ -19,10 +19,8 @@ import { ViewContainerRef, NgModuleFactoryLoader } from '@angular/core';
 import { SaveStateComponent } from './save-state.component';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterService } from '../../services/filter.service';
-import { WidgetService } from '../../services/widget.service';
 
 import { MatSnackBar } from '@angular/material';
 import { NeonConfig } from '../../models/types';
@@ -58,7 +56,6 @@ describe('Component: SaveStateComponent', () => {
             { provide: DashboardService, useClass: DashboardServiceMock },
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
-            { provide: AbstractWidgetService, useClass: WidgetService },
             MatSnackBar,
             ViewContainerRef
         ]

--- a/src/app/components/settings/settings.component.html
+++ b/src/app/components/settings/settings.component.html
@@ -6,7 +6,7 @@
     <h3 class="header">Themes</h3>
     <div class='radio-container' layout="row" mat-margin>
         <mat-radio-group [(ngModel)]="formData.currentTheme" name="currentThemeGroup" (change)="setCurrentTheme(formData.currentTheme)">
-            <mat-radio-button class="radio-btn" *ngFor="let theme of widgetService.getThemes()" [value]="theme.id">{{ theme.name }}
+            <mat-radio-button class="radio-btn" *ngFor="let theme of colorThemeService.getThemes()" [value]="theme.id">{{ theme.name }}
             </mat-radio-button>
         </mat-radio-group>
     </div>

--- a/src/app/components/settings/settings.component.spec.ts
+++ b/src/app/components/settings/settings.component.spec.ts
@@ -18,10 +18,10 @@ import { } from 'jasmine-core';
 
 import { SettingsComponent } from './settings.component';
 
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
+import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterService } from '../../services/filter.service';
-import { WidgetService } from '../../services/widget.service';
+import { ColorThemeService } from '../../services/color-theme.service';
 
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
@@ -41,7 +41,7 @@ describe('Component: Settings', () => {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
             FilterService,
-            { provide: AbstractWidgetService, useClass: WidgetService }
+            { provide: AbstractColorThemeService, useClass: ColorThemeService }
         ],
         imports: [
             MatDividerModule,

--- a/src/app/components/settings/settings.component.ts
+++ b/src/app/components/settings/settings.component.ts
@@ -18,7 +18,7 @@ import { ChangeDetectorRef, ChangeDetectionStrategy, Component, Input, OnDestroy
 import { MatDialog } from '@angular/material';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
-import { NeonFieldMetaData, NeonTableMetaData } from '../../models/types';
+import { NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
 import { neonEvents } from '../../models/neon-namespaces';
 
 import { AbstractWidgetService } from '../../services/abstract.widget.service';

--- a/src/app/components/settings/settings.component.ts
+++ b/src/app/components/settings/settings.component.ts
@@ -21,7 +21,7 @@ import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
 import { NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
 import { neonEvents } from '../../models/neon-namespaces';
 
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
+import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 
 import { eventing } from 'neon-framework';
@@ -56,7 +56,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
         private dashboardService: DashboardService,
         private dialog: MatDialog,
         public injector: Injector,
-        public widgetService: AbstractWidgetService
+        public colorThemeService: AbstractColorThemeService
     ) {
         this.injector = injector;
         this.messenger = new eventing.Messenger();
@@ -76,7 +76,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
-        this.formData.currentTheme = this.widgetService.getTheme();
+        this.formData.currentTheme = this.colorThemeService.getTheme();
 
         this.updateSimpleSearchFilter();
 
@@ -134,7 +134,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
 
     setCurrentTheme(themeId: any) {
         if (themeId) {
-            this.widgetService.setTheme(themeId);
+            this.colorThemeService.setTheme(themeId);
         }
     }
 

--- a/src/app/components/simple-filter/simple-filter.component.ts
+++ b/src/app/components/simple-filter/simple-filter.component.ts
@@ -14,7 +14,7 @@
  */
 import { ChangeDetectorRef, ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { AbstractSearchService } from '../../services/abstract.search.service';
-import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/types';
+import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterService, SimpleFilterDesign } from '../../services/filter.service';
 import { neonEvents } from '../../models/neon-namespaces';

--- a/src/app/components/taxonomy-viewer/taxonomy-viewer.component.spec.ts
+++ b/src/app/components/taxonomy-viewer/taxonomy-viewer.component.spec.ts
@@ -21,7 +21,7 @@ import { AbstractSearchService } from '../../services/abstract.search.service';
 import { CompoundFilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
 import { DashboardService } from '../../services/dashboard.service';
 
-import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/types';
+import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';

--- a/src/app/components/taxonomy-viewer/taxonomy-viewer.component.ts
+++ b/src/app/components/taxonomy-viewer/taxonomy-viewer.component.ts
@@ -29,7 +29,7 @@ import { DashboardService } from '../../services/dashboard.service';
 import { CompoundFilterDesign, FilterBehavior, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
 import { KEYS, TREE_ACTIONS, TreeNode } from 'angular-tree-component';
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
-import { NeonFieldMetaData } from '../../models/types';
+import { NeonFieldMetaData } from '../../models/dataset';
 import { neonUtilities } from '../../models/neon-namespaces';
 import {
     OptionChoices,

--- a/src/app/components/text-cloud/text-cloud.component.spec.ts
+++ b/src/app/components/text-cloud/text-cloud.component.spec.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/types';
+import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
 
 import { Injector } from '@angular/core';
 

--- a/src/app/components/text-cloud/text-cloud.component.spec.ts
+++ b/src/app/components/text-cloud/text-cloud.component.spec.ts
@@ -20,11 +20,11 @@ import { Injector } from '@angular/core';
 import { TextCloudComponent } from './text-cloud.component';
 
 import { AbstractSearchService, CompoundFilterType } from '../../services/abstract.search.service';
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
+import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
 import { AggregationType } from '../../models/widget-option';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterService } from '../../services/filter.service';
-import { WidgetService } from '../../services/widget.service';
+import { ColorThemeService } from '../../services/color-theme.service';
 
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
@@ -38,7 +38,7 @@ describe('Component: TextCloud', () => {
 
     initializeTestBed('Text Cloud', {
         providers: [
-            { provide: AbstractWidgetService, useClass: WidgetService },
+            { provide: AbstractColorThemeService, useClass: ColorThemeService },
             {
                 provide: DashboardService,
                 useClass: DashboardServiceMock

--- a/src/app/components/text-cloud/text-cloud.component.ts
+++ b/src/app/components/text-cloud/text-cloud.component.ts
@@ -188,8 +188,8 @@ export class TextCloudComponent extends BaseNeonComponent implements OnInit, OnD
 
         this.searchService.updateFilter(query, this.searchService.buildCompoundFilterClause(sharedFilters.concat(filter)))
             .updateGroups(query, [this.searchService.buildQueryGroup(options.dataField.columnName)])
-            .updateAggregation(query, options.aggregation, '_aggregation', aggregationField)
-            .updateSort(query, '_aggregation', SortOrder.DESCENDING);
+            .updateAggregation(query, options.aggregation, this.searchService.getAggregationName(), aggregationField)
+            .updateSort(query, this.searchService.getAggregationName(), SortOrder.DESCENDING);
 
         return query;
     }
@@ -274,7 +274,7 @@ export class TextCloudComponent extends BaseNeonComponent implements OnInit, OnD
                 key: key,
                 keyTranslated: key,
                 selected: this.isFiltered(this.createFilterDesignOnText(key)),
-                value: item._aggregation
+                value: item[this.searchService.getAggregationName()]
             };
         });
 

--- a/src/app/components/text-cloud/text-cloud.component.ts
+++ b/src/app/components/text-cloud/text-cloud.component.ts
@@ -36,7 +36,7 @@ import { DashboardService } from '../../services/dashboard.service';
 import { FilterBehavior, FilterService, FilterDesign, SimpleFilterDesign } from '../../services/filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
-import { NeonFieldMetaData } from '../../models/types';
+import { NeonFieldMetaData } from '../../models/dataset';
 import {
     AggregationType,
     OptionChoices,

--- a/src/app/components/text-cloud/text-cloud.component.ts
+++ b/src/app/components/text-cloud/text-cloud.component.ts
@@ -31,7 +31,7 @@ import {
     QueryPayload,
     SortOrder
 } from '../../services/abstract.search.service';
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
+import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterBehavior, FilterService, FilterDesign, SimpleFilterDesign } from '../../services/filter.service';
 
@@ -70,7 +70,7 @@ export class TextCloudComponent extends BaseNeonComponent implements OnInit, OnD
         searchService: AbstractSearchService,
         injector: Injector,
         ref: ChangeDetectorRef,
-        protected widgetService: AbstractWidgetService,
+        protected colorThemeService: AbstractColorThemeService,
         dialog: MatDialog,
         public visualization: ElementRef
     ) {
@@ -94,7 +94,7 @@ export class TextCloudComponent extends BaseNeonComponent implements OnInit, OnD
         this.options.aggregation = (this.options.aggregation || this.injector.get('sizeAggregation', AggregationType.COUNT)).toLowerCase();
 
         // This should happen before execute query as #refreshVisualization() depends on this.textCloud
-        this.textColor = this.widgetService.getThemeMainColorHex();
+        this.textColor = this.colorThemeService.getThemeMainColorHex();
     }
 
     /**

--- a/src/app/components/thumbnail-grid/thumbnail-grid.component.spec.ts
+++ b/src/app/components/thumbnail-grid/thumbnail-grid.component.spec.ts
@@ -14,7 +14,7 @@
  */
 import { By } from '@angular/platform-browser';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NeonFieldMetaData } from '../../models/types';
+import { NeonFieldMetaData } from '../../models/dataset';
 import { Injector } from '@angular/core';
 
 import { } from 'jasmine-core';

--- a/src/app/components/thumbnail-grid/thumbnail-grid.component.ts
+++ b/src/app/components/thumbnail-grid/thumbnail-grid.component.ts
@@ -31,7 +31,8 @@ import { DashboardService } from '../../services/dashboard.service';
 import { CompoundFilterDesign, FilterBehavior, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
-import { NeonFieldMetaData, MediaTypes } from '../../models/types';
+import { NeonFieldMetaData } from '../../models/dataset';
+import { MediaTypes } from '../../models/types';
 import { neonUtilities } from '../../models/neon-namespaces';
 import {
     OptionChoices,

--- a/src/app/components/timeline/timeline.component.spec.ts
+++ b/src/app/components/timeline/timeline.component.spec.ts
@@ -20,12 +20,12 @@ import { } from 'jasmine-core';
 import { TimelineComponent } from './timeline.component';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
+import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterService } from '../../services/filter.service';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';
-import { WidgetService } from '../../services/widget.service';
+import { ColorThemeService } from '../../services/color-theme.service';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 
 import { TimelineModule } from './timeline.module';
@@ -37,7 +37,7 @@ describe('Component: Timeline', () => {
 
     initializeTestBed('Timeline', {
         providers: [
-            { provide: AbstractWidgetService, useClass: WidgetService },
+            { provide: AbstractColorThemeService, useClass: ColorThemeService },
             { provide: DashboardService, useClass: DashboardServiceMock },
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },

--- a/src/app/components/timeline/timeline.component.spec.ts
+++ b/src/app/components/timeline/timeline.component.spec.ts
@@ -29,7 +29,7 @@ import { WidgetService } from '../../services/widget.service';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 
 import { TimelineModule } from './timeline.module';
-import { NeonFieldMetaData } from '../../models/types';
+import { NeonFieldMetaData } from '../../models/dataset';
 
 describe('Component: Timeline', () => {
     let component: TimelineComponent;

--- a/src/app/components/timeline/timeline.component.ts
+++ b/src/app/components/timeline/timeline.component.ts
@@ -56,7 +56,7 @@ import {
 } from '../../models/widget-option';
 import { TimelineSelectorChart, TimelineSeries, TimelineData, TimelineItem } from './TimelineSelectorChart';
 import { YearBucketizer } from '../bucketizers/YearBucketizer';
-import { NeonFieldMetaData } from '../../models/types';
+import { NeonFieldMetaData } from '../../models/dataset';
 
 import * as _ from 'lodash';
 import { MatDialog } from '@angular/material';

--- a/src/app/components/timeline/timeline.component.ts
+++ b/src/app/components/timeline/timeline.component.ts
@@ -294,8 +294,10 @@ export class TimelineComponent extends BaseNeonComponent implements OnInit, OnDe
         }
 
         this.searchService.updateFilter(query, this.searchService.buildCompoundFilterClause(sharedFilters.concat(filter)))
-            .updateGroups(query, groups).updateAggregation(query, AggregationType.MIN, '_date', options.dateField.columnName)
-            .updateSort(query, '_date').updateAggregation(query, AggregationType.COUNT, '_aggregation', '_' + options.granularity);
+            .updateGroups(query, groups)
+            .updateAggregation(query, AggregationType.MIN, this.searchService.getAggregationName('date'), options.dateField.columnName)
+            .updateSort(query, this.searchService.getAggregationName('date'))
+            .updateAggregation(query, AggregationType.COUNT, this.searchService.getAggregationName(), '_' + options.granularity);
 
         return query;
     }
@@ -330,8 +332,8 @@ export class TimelineComponent extends BaseNeonComponent implements OnInit, OnDe
                         value: 1,
                         ids: [uniqueIdentifier],
                         filters: [currentItem[options.filterField.columnName]],
-                        origDate: currentItem._date,
-                        date: new Date(currentItem._date)
+                        origDate: currentItem[this.searchService.getAggregationName('date')],
+                        date: new Date(currentItem[this.searchService.getAggregationName('date')])
                     });
                 }
 
@@ -339,8 +341,8 @@ export class TimelineComponent extends BaseNeonComponent implements OnInit, OnDe
             }, []);
         } else {
             this.timelineQueryResults = results.map((item) => ({
-                value: item._aggregation,
-                date: new Date(item._date)
+                value: item[this.searchService.getAggregationName()],
+                date: new Date(item[this.searchService.getAggregationName('date')])
             }));
         }
 
@@ -358,7 +360,7 @@ export class TimelineComponent extends BaseNeonComponent implements OnInit, OnDe
      */
     findDateInPreviousItem(previousItems: any[], current: any) {
         if (previousItems.length) {
-            let currentDate = new Date(current._date);
+            let currentDate = new Date(current[this.searchService.getAggregationName('date')]);
             let currentMonth = currentDate.getUTCMonth();
             let currentYear = currentDate.getUTCFullYear();
 

--- a/src/app/components/timeline/timeline.component.ts
+++ b/src/app/components/timeline/timeline.component.ts
@@ -31,7 +31,7 @@ import {
     QueryPayload,
     TimeInterval
 } from '../../services/abstract.search.service';
-import { AbstractWidgetService } from '../../services/abstract.widget.service';
+import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import {
     CompoundFilterDesign,
@@ -95,7 +95,7 @@ export class TimelineComponent extends BaseNeonComponent implements OnInit, OnDe
         searchService: AbstractSearchService,
         injector: Injector,
         ref: ChangeDetectorRef,
-        protected widgetService: AbstractWidgetService,
+        protected colorThemeService: AbstractColorThemeService,
         dialog: MatDialog,
         public visualization: ElementRef
     ) {
@@ -405,7 +405,7 @@ export class TimelineComponent extends BaseNeonComponent implements OnInit, OnDe
      */
     filterAndRefreshData(data: any[]) {
         let series: TimelineSeries = {
-            color: this.widgetService.getThemeMainColorHex(),
+            color: this.colorThemeService.getThemeMainColorHex(),
             name: 'Total',
             type: 'bar',
             options: {},

--- a/src/app/components/unshared-filter/unshared-filter.component.ts
+++ b/src/app/components/unshared-filter/unshared-filter.component.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
-import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/types';
+import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
 
 /**
  * Component for managing the unshared filter of a visualization.

--- a/src/app/components/wiki-viewer/wiki-viewer.component.spec.ts
+++ b/src/app/components/wiki-viewer/wiki-viewer.component.spec.ts
@@ -14,7 +14,7 @@
  */
 import { By } from '@angular/platform-browser';
 import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
-import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/types';
+import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
 import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
 import { Injector } from '@angular/core';
 

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -1,4 +1,4 @@
-<mat-sidenav-container class="neon-sidenav" [ngClass]="widgetService.getTheme()">
+<mat-sidenav-container class="neon-sidenav" [ngClass]="colorThemeService.getTheme()">
     <mat-sidenav class="neon-sidenav neon-sidenav-info" mat-fill position="end" (closed)="currentPanel = ''">
         <div>
             <mat-toolbar class="title" color="primary">
@@ -60,7 +60,7 @@
                 <mat-icon class="neon-icon-large">menu</mat-icon>
             </button>
 
-            <mat-menu #appMenu="matMenu" [backdropClass]="widgetService.getTheme()" yPosition="below" [overlapTrigger]="false">
+            <mat-menu #appMenu="matMenu" [backdropClass]="colorThemeService.getTheme()" yPosition="below" [overlapTrigger]="false">
                 <button mat-menu-item (click)="setPanel('addVis', 'Add Visualizations');">
                     <mat-icon color="secondary">add_circle</mat-icon>Add Visualizations
                 </button>

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -24,10 +24,10 @@ import { NeonGridItem } from '../models/neon-grid-item';
 import { neonEvents } from '../models/neon-namespaces';
 
 import { AbstractSearchService } from '../services/abstract.search.service';
-import { AbstractWidgetService } from '../services/abstract.widget.service';
+import { AbstractColorThemeService } from '../services/abstract.color-theme.service';
 import { DashboardService } from '../services/dashboard.service';
 import { FilterService } from '../services/filter.service';
-import { WidgetService } from '../services/widget.service';
+import { ColorThemeService } from '../services/color-theme.service';
 
 import { DashboardServiceMock, EmptyDashboardServiceMock } from '../../testUtils/MockServices/DashboardServiceMock';
 import { SearchServiceMock } from '../../testUtils/MockServices/SearchServiceMock';
@@ -64,7 +64,7 @@ describe('Dashboard', () => {
             { provide: DashboardService, useClass: DashboardServiceMock },
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
-            { provide: AbstractWidgetService, useClass: WidgetService }
+            { provide: AbstractColorThemeService, useClass: ColorThemeService }
         ]
     }, false);
 
@@ -851,7 +851,7 @@ describe('Dashboard Custom', () => {
             { provide: DashboardService, useClass: EmptyDashboardServiceMock },
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
-            { provide: AbstractWidgetService, useClass: WidgetService }
+            { provide: AbstractColorThemeService, useClass: ColorThemeService }
         ]
     }, false);
 

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -216,6 +216,8 @@ export class DashboardComponent implements AfterViewInit, OnInit, OnDestroy {
             this.widgets.clear();
             this.changeDetection.detectChanges();
 
+            this.colorThemeService.initializeColors(state.getOptions().colorMaps);
+
             const layout = this.dashboardService.config.layouts[state.getLayout()];
 
             const pairs = GridState.getAllGridItems(layout);

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -26,7 +26,7 @@ import {
 
 import { eventing } from 'neon-framework';
 
-import { AbstractWidgetService } from '../services/abstract.widget.service';
+import { AbstractColorThemeService } from '../services/abstract.color-theme.service';
 import { BaseNeonComponent } from '../components/base-neon-component/base-neon.component';
 import { DashboardService } from '../services/dashboard.service';
 import { DomSanitizer } from '@angular/platform-browser';
@@ -128,7 +128,7 @@ export class DashboardComponent implements AfterViewInit, OnInit, OnDestroy {
         public filterService: FilterService,
         private matIconRegistry: MatIconRegistry,
         public snackBar: MatSnackBar,
-        public widgetService: AbstractWidgetService,
+        public colorThemeService: AbstractColorThemeService,
         public viewContainerRef: ViewContainerRef,
         public router: Router,
         public location: Location

--- a/src/app/models/color.ts
+++ b/src/app/models/color.ts
@@ -14,6 +14,8 @@
  */
 import { ElementRef } from '@angular/core';
 
+export type ColorMap = Record<string, Record<string, Record<string, Record<string, string>>>>;
+
 /**
  * General color class.
  * This class can provide colors in a hex string, RGB formatted, or in RGB percent.

--- a/src/app/models/dashboard-state.ts
+++ b/src/app/models/dashboard-state.ts
@@ -14,7 +14,7 @@
  */
 import { Dataset, NeonDatabaseMetaData, NeonDatastoreConfig, NeonFieldMetaData, NeonTableMetaData, SingleField } from './dataset';
 import { NeonDashboardLeafConfig } from './types';
-import { DataUtil } from '../util/data.util';
+import { DatasetUtil } from '../util/dataset.util';
 
 export class DashboardState {
     modified = false;
@@ -32,14 +32,14 @@ export class DashboardState {
      * Returns database name from matching table key within the dashboard passed in.
      */
     deconstructTableName(key: string) {
-        return DataUtil.deconstructTableName(this.dashboard.tables, key);
+        return DatasetUtil.deconstructTableName(this.dashboard.tables, key);
     }
 
     /**
      * Returns database name from matching table key within the dashboard passed in.
      */
     deconstructFieldName(key: string) {
-        return DataUtil.deconstructFieldName(this.dashboard.fields, key);
+        return DatasetUtil.deconstructFieldName(this.dashboard.fields, key);
     }
 
     /**
@@ -286,7 +286,7 @@ export class DashboardState {
      * If field key is referenced in config file, find field value using current dashboard.
      */
     public translateFieldKeyToValue(fieldKey: string): string {
-        return DataUtil.translateFieldKeyToValue(this.dashboard.fields, fieldKey);
+        return DatasetUtil.translateFieldKeyToValue(this.dashboard.fields, fieldKey);
     }
 
     /**

--- a/src/app/models/dashboard-state.ts
+++ b/src/app/models/dashboard-state.ts
@@ -137,26 +137,6 @@ export class DashboardState {
     }
 
     /**
-     * Returns the database with the given Dashboard name or an Object with an empty name if no such database exists in the datastore.
-     * @return The database containing {String} name, {Array} fields, and {Object} labelOptions if a match exists
-     * or undefined otherwise.  Dashboard name only includes part of the database pretty name
-     */
-    public getDatabase(): NeonDatabaseMetaData {
-        if (!this.dashboard) {
-            return undefined;
-        }
-        let tableKeys = this.dashboard.tables;
-
-        let keyArray = Object.keys(tableKeys || {});
-
-        if (keyArray.length) {
-            const { database } = this.deconstructTableName(keyArray[0]);
-            return this.getDatabaseWithName(database);
-        }
-        return undefined;
-    }
-
-    /**
      * Returns the tables for the database with the given name in the active datastore.
      * @return An array of table Objects containing {String} name, {Array} fields, and {Object} labelOptions.
      */

--- a/src/app/models/dashboard-state.ts
+++ b/src/app/models/dashboard-state.ts
@@ -12,13 +12,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-    NeonDatastoreConfig, NeonDatabaseMetaData,
-    NeonTableMetaData, NeonFieldMetaData, SingleField, NeonDashboardLeafConfig
-} from './types';
-
-import * as _ from 'lodash';
-import { ConfigUtil } from '../util/config.util';
+import { Dataset, NeonDatabaseMetaData, NeonDatastoreConfig, NeonFieldMetaData, NeonTableMetaData, SingleField } from './dataset';
+import { NeonDashboardLeafConfig } from './types';
+import { DataUtil } from '../util/data.util';
 
 export class DashboardState {
     modified = false;
@@ -36,14 +32,14 @@ export class DashboardState {
      * Returns database name from matching table key within the dashboard passed in.
      */
     deconstructTableName(key: string) {
-        return ConfigUtil.deconstructDottedReference(this.dashboard.tables[key] || key);
+        return DataUtil.deconstructTableName(this.dashboard.tables, key);
     }
 
     /**
      * Returns database name from matching table key within the dashboard passed in.
      */
     deconstructFieldName(key: string) {
-        return ConfigUtil.deconstructDottedReference(this.dashboard.fields[key] || key);
+        return DataUtil.deconstructFieldName(this.dashboard.fields, key);
     }
 
     /**
@@ -131,16 +127,9 @@ export class DashboardState {
     }
 
     /**
-     * Returns the databases for the active datastore.
-     */
-    public getDatabases(): NeonDatabaseMetaData[] {
-        return Object.values(this.datastore.databases).sort((db1, db2) => db1.name.localeCompare(db2.name));
-    }
-
-    /**
      * Returns the database with the given name or an Object with an empty name if no such database exists in the datastore.
      * @param  The database name
-     * @return The database containing {String} name, {Array} fields, and {Object} mappings if a match exists
+     * @return The database containing {String} name, {Array} fields, and {Object} labelOptions if a match exists
      * or undefined otherwise.
      */
     public getDatabaseWithName(databaseName: string): NeonDatabaseMetaData {
@@ -149,7 +138,7 @@ export class DashboardState {
 
     /**
      * Returns the database with the given Dashboard name or an Object with an empty name if no such database exists in the datastore.
-     * @return The database containing {String} name, {Array} fields, and {Object} mappings if a match exists
+     * @return The database containing {String} name, {Array} fields, and {Object} labelOptions if a match exists
      * or undefined otherwise.  Dashboard name only includes part of the database pretty name
      */
     public getDatabase(): NeonDatabaseMetaData {
@@ -169,7 +158,7 @@ export class DashboardState {
 
     /**
      * Returns the tables for the database with the given name in the active datastore.
-     * @return An array of table Objects containing {String} name, {Array} fields, and {Array} mappings.
+     * @return An array of table Objects containing {String} name, {Array} fields, and {Object} labelOptions.
      */
     public getTables(databaseName: string): { [key: string]: NeonTableMetaData } {
         let database = this.getDatabaseWithName(databaseName);
@@ -178,7 +167,7 @@ export class DashboardState {
 
     /**
      * Returns the table with the given name or an Object with an empty name if no such table exists in the database with the given name.
-     * @return {Object} The table containing {String} name, {Array} fields, and {Object} mappings if a match exists
+     * @return {Object} The table containing {String} name, {Array} fields, and {Object} labelOptions if a match exists
      * or undefined otherwise.
      */
     public getTableWithName(databaseName: string, tableName: string): NeonTableMetaData {
@@ -215,88 +204,6 @@ export class DashboardState {
         }
 
         return table.fields;
-    }
-
-    /**
-     * Returns a sorted copy of the array of field objects for the database and table with the given names,
-     * ignoring hidden fields if specified.
-     * @param Whether to ignore fields in the table marked as hidden (optional)
-     * @return The sorted copy of the array of field objects if a match exists or an empty array otherwise.
-     */
-    public getSortedFields(databaseName: string, tableName: string, ignoreHiddenFields?: boolean): NeonFieldMetaData[] {
-        let table = this.getTableWithName(databaseName, tableName);
-
-        if (!table) {
-            return [];
-        }
-
-        let fields = _.cloneDeep(table.fields).filter((field) => (ignoreHiddenFields ? !field.hide : true));
-
-        fields.sort((field1, field2) => {
-            if (!field1.prettyName || !field2.prettyName) {
-                return 0;
-            }
-            // Compare field pretty names and ignore case.
-            return (field1.prettyName.toUpperCase() < field2.prettyName.toUpperCase()) ?
-                -1 : ((field1.prettyName.toUpperCase() > field2.prettyName.toUpperCase()) ? 1 : 0);
-        });
-
-        return fields;
-    }
-
-    /**
-    /**
-     * Returns the the first table in the database with the given name containing all the given mappings.
-     * @param The array of mapping keys that the table must contain.
-     * @return The name of the table containing {String} name, {Array} fields, and {Object} mappings if a match exists
-     * or undefined otherwise.
-     */
-    public getFirstTableWithMappings(databaseName: string, keys: string[]): NeonTableMetaData {
-        let tables = this.getTables(databaseName);
-        for (const table of Object.values(tables)) {
-            for (let key of keys) {
-                if (!(table.mappings[key])) {
-                    return table;
-                }
-            }
-        }
-
-        return undefined;
-    }
-
-    /**
-     * Returns an object containing the first database, table, and fields found in the active datastore with all the given mappings.
-     * @param The array of mapping keys that the database and table must contain.
-     * @return An object containing {String} database, {String} table,
-     * and {Object} fields linking {String} mapping to {String} field.
-     * If no match was found, an empty object is returned instead.
-     */
-    public getFirstDatabaseAndTableWithMappings(keys: string[]): any {
-        for (let database of Object.values(this.datastore.databases)) {
-            for (let table of Object.values(database.tables)) {
-                let success = true;
-                let fields = {};
-                if (keys && keys.length > 0) {
-                    for (let key of keys) {
-                        if (table.mappings[key]) {
-                            fields[key] = table.mappings[key];
-                        } else {
-                            success = false;
-                        }
-                    }
-                }
-
-                if (success) {
-                    return {
-                        database: database.name,
-                        table: table.name,
-                        fields: fields
-                    };
-                }
-            }
-        }
-
-        return {};
     }
 
     /**
@@ -399,6 +306,18 @@ export class DashboardState {
      * If field key is referenced in config file, find field value using current dashboard.
      */
     public translateFieldKeyToValue(fieldKey: string): string {
-        return this.deconstructFieldName(fieldKey).field || fieldKey;
+        return DataUtil.translateFieldKeyToValue(this.dashboard.fields, fieldKey);
+    }
+
+    /**
+     * Returns the current dashboard state as a dataset.
+     */
+    public asDataset(): Dataset {
+        return {
+            datastores: [this.datastore],
+            tableKeys: this.dashboard.tables,
+            fieldKeys: this.dashboard.fields,
+            relations: this.findRelationDataList()
+        };
     }
 }

--- a/src/app/models/dataset.ts
+++ b/src/app/models/dataset.ts
@@ -1,0 +1,143 @@
+/**
+ * Copyright 2019 Next Century Corporation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type Primitive = number | string | Date | boolean | undefined;
+
+/**
+ * This is a recursive mapped type (https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types)
+ * that makes all fields optional but type checked (either it's missing or it's the correct type)
+ */
+export type DeepPartial<T> = {
+    /* eslint-disable-next-line @typescript-eslint/generic-type-naming */
+    [P in keyof T]?: T[P] |
+    (T[P] extends (Primitive | Primitive[] | Record<string, Primitive>) ?
+        (T[P] | undefined) :
+        (T[P] extends any[] ?
+            DeepPartial<T[P][0]>[] | undefined :
+            (T[P] extends Record<string, any> ?
+                (T[P][''] extends any[] ?
+                    Record<string, DeepPartial<T[P][''][0]>[]> :
+                    Record<string, DeepPartial<T[P]['']>>) :
+                DeepPartial<T[P]>)));
+} & {
+    [key: string]: any;
+};
+
+export function translateValues<T>(
+    obj: Record<string, Partial<T>>,
+    transform: (input: Partial<T>) => T,
+    applyNames = false
+): Record<string, T> {
+    for (const key of Object.keys(obj)) {
+        obj[key] = transform(obj[key]);
+        if (applyNames && !obj[key]['name']) {
+            obj[key]['name'] = key;
+        }
+    }
+    return obj as Record<string, T>;
+}
+
+function translate<T>(values: Partial<T>[], transform: (input: Partial<T>) => T): T[] {
+    return values.map(transform);
+}
+
+export interface NeonFieldMetaData {
+    columnName: string;
+    prettyName: string;
+    hide: boolean;
+    type: string;
+}
+
+export class NeonFieldMetaData {
+    static get(field: DeepPartial<NeonFieldMetaData> = {}) {
+        return {
+            columnName: '',
+            prettyName: '',
+            hide: false,
+            type: '',
+            ...field
+        } as NeonFieldMetaData;
+    }
+}
+
+export interface NeonTableMetaData {
+    name: string;
+    prettyName: string;
+    fields: NeonFieldMetaData[];
+    labelOptions: Record<string, any | Record<string, any>>;
+}
+
+export class NeonTableMetaData {
+    static get(table: DeepPartial<NeonTableMetaData> = {}) {
+        return {
+            name: '',
+            prettyName: '',
+            mappings: {},
+            labelOptions: {},
+            ...table,
+            fields: translate(table.fields || [], NeonFieldMetaData.get.bind(null))
+        } as NeonTableMetaData;
+    }
+}
+
+export interface NeonDatabaseMetaData {
+    name: string;
+    prettyName: string;
+    tables: Record<string, NeonTableMetaData>;
+}
+
+export class NeonDatabaseMetaData {
+    static get(db: DeepPartial<NeonDatabaseMetaData> = {}) {
+        return {
+            name: '',
+            prettyName: '',
+            ...db,
+            tables: translateValues(db.tables || {}, NeonTableMetaData.get.bind(null), true)
+        } as NeonDatabaseMetaData;
+    }
+}
+
+export interface NeonDatastoreConfig {
+    name: string;
+    host: string;
+    type: string;
+    databases: Record<string, NeonDatabaseMetaData>;
+}
+
+export class NeonDatastoreConfig {
+    static get(config: DeepPartial<NeonDatastoreConfig> = {}) {
+        return {
+            name: '',
+            host: '',
+            type: '',
+            ...config,
+            databases: translateValues(config.databases || {}, NeonDatabaseMetaData.get.bind(null), true)
+        } as NeonDatastoreConfig;
+    }
+}
+
+export interface SingleField {
+    datastore: string;
+    database: NeonDatabaseMetaData;
+    table: NeonTableMetaData;
+    field: NeonFieldMetaData;
+}
+
+export interface Dataset {
+    datastores: NeonDatastoreConfig[];
+    tableKeys: Record<string, string>;
+    fieldKeys: Record<string, string>;
+    relations: SingleField[][][];
+}

--- a/src/app/models/types.ts
+++ b/src/app/models/types.ts
@@ -13,97 +13,7 @@
  * limitations under the License.
  */
 
-type Primitive = number | string | Date | boolean | undefined;
-
-// This is a recursive mapped type (https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types)
-//  that makes all fields optional but type checked (either it's missing or it's the correct type)
-
-type DeepPartial<T> = {
-    /* eslint-disable-next-line @typescript-eslint/generic-type-naming */
-    [P in keyof T]?: T[P] |
-    (T[P] extends (Primitive | Primitive[] | Record<string, Primitive>) ?
-        (T[P] | undefined) :
-        (T[P] extends any[] ?
-            DeepPartial<T[P][0]>[] | undefined :
-            (T[P] extends Record<string, any> ?
-                (T[P][''] extends any[] ?
-                    Record<string, DeepPartial<T[P][''][0]>[]> :
-                    Record<string, DeepPartial<T[P]['']>>) :
-                DeepPartial<T[P]>)));
-} & {
-    [key: string]: any;
-};
-
-function translateValues<T>(obj: Record<string, Partial<T>>, transform: (input: Partial<T>) => T, applyNames = false): Record<string, T> {
-    for (const key of Object.keys(obj)) {
-        obj[key] = transform(obj[key]);
-        if (applyNames && !obj[key]['name']) {
-            obj[key]['name'] = key;
-        }
-    }
-    return obj as Record<string, T>;
-}
-
-function translate<T>(values: Partial<T>[], transform: (input: Partial<T>) => T): T[] {
-    return values.map(transform);
-}
-
-export interface NeonFieldMetaData {
-    columnName: string;
-    prettyName: string;
-    hide: boolean;
-    type: string;
-}
-
-export class NeonFieldMetaData {
-    static get(field: DeepPartial<NeonFieldMetaData> = {}) {
-        return {
-            columnName: '',
-            prettyName: '',
-            hide: false,
-            type: '',
-            ...field
-        } as NeonFieldMetaData;
-    }
-}
-
-export interface NeonTableMetaData {
-    name?: string;
-    prettyName: string;
-    fields: NeonFieldMetaData[];
-    mappings: Record<string, string>;
-    labelOptions: Record<string, any | Record<string, any>>;
-}
-
-export class NeonTableMetaData {
-    static get(table: DeepPartial<NeonTableMetaData> = {}) {
-        return {
-            name: '',
-            prettyName: '',
-            mappings: {},
-            labelOptions: {},
-            ...table,
-            fields: translate(table.fields || [], NeonFieldMetaData.get.bind(null))
-        } as NeonTableMetaData;
-    }
-}
-
-export interface NeonDatabaseMetaData {
-    name: string;
-    prettyName: string;
-    tables: Record<string, NeonTableMetaData>;
-}
-
-export class NeonDatabaseMetaData {
-    static get(db: DeepPartial<NeonDatabaseMetaData> = {}) {
-        return {
-            name: '',
-            prettyName: '',
-            ...db,
-            tables: translateValues(db.tables || {}, NeonTableMetaData.get.bind(null), true)
-        } as NeonDatabaseMetaData;
-    }
-}
+import { DeepPartial, NeonDatastoreConfig, translateValues } from './dataset';
 
 export interface NeonSimpleSearchFilter {
     placeHolder?: string;
@@ -225,25 +135,6 @@ export interface NeonLayoutConfig extends NeonLayoutGridConfig {
 
 }
 
-export interface NeonDatastoreConfig {
-    name: string;
-    host: string;
-    type: string;
-    databases: Record<string, NeonDatabaseMetaData>;
-}
-
-export class NeonDatastoreConfig {
-    static get(config: DeepPartial<NeonDatastoreConfig> = {}) {
-        return {
-            name: '',
-            host: '',
-            type: '',
-            ...config,
-            databases: translateValues(config.databases || {}, NeonDatabaseMetaData.get.bind(null), true)
-        } as NeonDatastoreConfig;
-    }
-}
-
 export interface NeonConfig {
     projectTitle?: string;
     projectIcon?: string;
@@ -303,10 +194,3 @@ export const MediaTypes = {
     audio: 'aud',
     maskImage: 'mask'
 };
-
-export interface SingleField {
-    datastore: string;
-    database: NeonDatabaseMetaData;
-    table: NeonTableMetaData;
-    field: NeonFieldMetaData;
-}

--- a/src/app/models/types.ts
+++ b/src/app/models/types.ts
@@ -28,7 +28,7 @@ export interface NeonSimpleSearchFilter {
 
 export interface NeonDashboardOptions {
     connectOnLoad?: boolean;
-    colorMaps?: Record<string, any>;
+    colorMaps?: Record<string, Record<string, Record<string, Record<string, string>>>>;
     simpleFilter?: NeonSimpleSearchFilter;
 }
 

--- a/src/app/models/types.ts
+++ b/src/app/models/types.ts
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import { ColorMap } from './color';
 import { DeepPartial, NeonDatastoreConfig, translateValues } from './dataset';
 
 export interface NeonSimpleSearchFilter {
@@ -28,7 +29,7 @@ export interface NeonSimpleSearchFilter {
 
 export interface NeonDashboardOptions {
     connectOnLoad?: boolean;
-    colorMaps?: Record<string, Record<string, Record<string, Record<string, string>>>>;
+    colorMaps?: ColorMap;
     simpleFilter?: NeonSimpleSearchFilter;
 }
 

--- a/src/app/models/widget-option-collection.spec.ts
+++ b/src/app/models/widget-option-collection.spec.ts
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ReflectiveInjector } from '@angular/core';
 
 import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from './dataset';
 import {
@@ -25,7 +24,7 @@ import {
     WidgetSelectOption,
     WidgetTableOption
 } from './widget-option';
-import { OptionCollection, RootWidgetOptionCollection, WidgetOptionCollection } from './widget-option-collection';
+import { OptionCollection, OptionConfig, RootWidgetOptionCollection, WidgetOptionCollection } from './widget-option-collection';
 
 import { DATABASES, DATABASES_LIST, DATASET, FIELD_MAP, FIELDS, TABLES, TABLES_LIST } from '../../testUtils/mock-dataset';
 
@@ -36,34 +35,17 @@ describe('OptionCollection', () => {
     let options: OptionCollection;
 
     beforeEach(() => {
-        options = new OptionCollection(ReflectiveInjector.resolveAndCreate([{
-            provide: 'keyA',
-            useValue: 'provideA'
-        }, {
-            provide: 'keyB',
-            useValue: 'provideB'
-        }, {
-            provide: 'testDate',
-            useValue: 'testDateField'
-        }, {
-            provide: 'testFake',
-            useValue: 'testFakeField'
-        }, {
-            provide: 'testList',
-            useValue: ['testDateField', 'testFakeField', 'testNameField', 'testSizeField']
-        }, {
-            provide: 'testName',
-            useValue: 'testNameField'
-        }, {
-            provide: 'testSize',
-            useValue: 'testSizeField'
-        }, {
-            provide: 'testFieldKey',
-            useValue: 'field_key_1'
-        }, {
-            provide: 'testListWithFieldKey',
-            useValue: ['field_key_1', 'field_key_2']
-        }]));
+        options = new OptionCollection(new OptionConfig({
+            keyA: 'provideA',
+            keyB: 'provideB',
+            testDate: 'testDateField',
+            testFake: 'testFakeField',
+            testList: ['testDateField', 'testFakeField', 'testNameField', 'testSizeField'],
+            testName: 'testNameField',
+            testSize: 'testSizeField',
+            testFieldKey: 'field_key_1',
+            testListWithFieldKey: ['field_key_1', 'field_key_2']
+        }));
     });
 
     it('does have an _id', () => {
@@ -316,25 +298,14 @@ describe('WidgetOptionCollection', () => {
             new WidgetFieldOption('testCustomField', 'Test Custom Field', false),
             new WidgetFieldArrayOption('testCustomFieldArray', 'Test Custom Field Array', false),
             new WidgetFreeTextOption('testCustomKey', 'Test Custom Key', 'default value')
-        ], DATASET, 'Test Title', 100, ReflectiveInjector.resolveAndCreate([{
-            provide: 'tableKey',
-            useValue: 'table_key_2'
-        }, {
-            provide: 'limit',
-            useValue: '1234'
-        }, {
-            provide: 'title',
-            useValue: 'Test Custom Title'
-        }, {
-            provide: 'testCustomField',
-            useValue: 'testTextField'
-        }, {
-            provide: 'testCustomFieldArray',
-            useValue: ['testNameField', 'testTypeField']
-        }, {
-            provide: 'testCustomKey',
-            useValue: 'testCustomValue'
-        }]));
+        ], DATASET, 'Test Title', 100, new OptionConfig({
+            tableKey: 'table_key_2',
+            limit: '1234',
+            title: 'Test Custom Title',
+            testCustomField: 'testTextField',
+            testCustomFieldArray: ['testNameField', 'testTypeField'],
+            testCustomKey: 'testCustomValue'
+        }));
     });
 
     it('does have databases, fields, tables, and custom properties', () => {
@@ -421,7 +392,7 @@ describe('WidgetOptionCollection with no bindings', () => {
             new WidgetFieldOption('testCustomField', 'Test Custom Field', false),
             new WidgetFieldArrayOption('testCustomFieldArray', 'Test Custom Field Array', false),
             new WidgetFreeTextOption('testCustomKey', 'Test Custom Key', 'default value')
-        ], DATASET, 'Test Title', 100, ReflectiveInjector.resolveAndCreate([]));
+        ], DATASET, 'Test Title', 100);
     });
 
     it('does have databases, fields, tables, and custom properties with default values', () => {
@@ -452,42 +423,19 @@ describe('RootWidgetOptionCollection', () => {
             new WidgetFieldOption('testCustomLayerField', 'Test Custom Layer Field', false),
             new WidgetFieldArrayOption('testCustomLayerFieldArray', 'Test Custom Layer Field Array', false),
             new WidgetFreeTextOption('testCustomLayerKey', 'Test Custom Layer Key', 'default layer value')
-        ], DATASET, 'Test Title', 100, true, ReflectiveInjector.resolveAndCreate([{
-            provide: 'tableKey',
-            useValue: 'table_key_2'
-        }, {
-            provide: 'contributionKeys',
-            useValue: ['next_century']
-        }, {
-            provide: 'filter',
-            useValue: { lhs: 'a', operator: '!=', rhs: 'b' }
-        }, {
-            provide: 'hideUnfiltered',
-            useValue: true
-        }, {
-            provide: 'limit',
-            useValue: '1234'
-        }, {
-            provide: 'title',
-            useValue: 'Test Custom Title'
-        }, {
-            provide: 'unsharedFilterField',
-            useValue: 'testFilterField'
-        }, {
-            provide: 'unsharedFilterValue',
-            useValue: 'testFilterValue'
-        }, {
-            provide: 'testCustomField',
-            useValue: 'testTextField'
-        }, {
-            provide: 'testCustomFieldArray',
-            useValue: ['testNameField', 'testTypeField']
-        }, {
-            provide: 'testCustomKey',
-            useValue: 'testCustomValue'
-        }, {
-            provide: 'layers',
-            useValue: [{
+        ], DATASET, 'Test Title', 100, true, new OptionConfig({
+            tableKey: 'table_key_2',
+            contributionKeys: ['next_century'],
+            filter: { lhs: 'a', operator: '!=', rhs: 'b' },
+            hideUnfiltered: true,
+            limit: '1234',
+            title: 'Test Custom Title',
+            unsharedFilterField: 'testFilterField',
+            unsharedFilterValue: 'testFilterValue',
+            testCustomField: 'testTextField',
+            testCustomFieldArray: ['testNameField', 'testTypeField'],
+            testCustomKey: 'testCustomValue',
+            layers: [{
                 tableKey: 'table_key_2',
                 limit: 5678,
                 title: 'Test Layer Title',
@@ -495,7 +443,7 @@ describe('RootWidgetOptionCollection', () => {
                 testCustomLayerFieldArray: ['testXField', 'testYField'],
                 testCustomLayerKey: 'testCustomLayerValue'
             }]
-        }]));
+        }));
     });
 
     it('does have databases, fields, tables, custom properties, and custom layers', () => {
@@ -602,7 +550,7 @@ describe('RootWidgetOptionCollection with no bindings', () => {
             new WidgetFieldOption('testCustomLayerField', 'Test Custom Layer Field', false),
             new WidgetFieldArrayOption('testCustomLayerFieldArray', 'Test Custom Layer Field Array', false),
             new WidgetFreeTextOption('testCustomLayerKey', 'Test Custom Layer Key', 'default layer value')
-        ], DATASET, 'Test Title', 100, true, ReflectiveInjector.resolveAndCreate([]));
+        ], DATASET, 'Test Title', 100, true);
     });
 
     it('does have databases, fields, tables, custom properties, and custom layers with default values', () => {

--- a/src/app/models/widget-option-collection.spec.ts
+++ b/src/app/models/widget-option-collection.spec.ts
@@ -13,11 +13,8 @@
  * limitations under the License.
  */
 import { ReflectiveInjector } from '@angular/core';
-import { inject } from '@angular/core/testing';
-import * as yaml from 'js-yaml';
 
-import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from './types';
-import { DashboardService } from '../services/dashboard.service';
+import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from './dataset';
 import {
     WidgetDatabaseOption,
     WidgetFieldOption,
@@ -30,24 +27,15 @@ import {
 } from './widget-option';
 import { OptionCollection, RootWidgetOptionCollection, WidgetOptionCollection } from './widget-option-collection';
 
-import { initializeTestBed } from '../../testUtils/initializeTestBed';
-import { DashboardServiceMock } from '../../testUtils/MockServices/DashboardServiceMock';
+import { DATABASES, DATABASES_LIST, DATASET, FIELD_MAP, FIELDS, TABLES, TABLES_LIST } from '../../testUtils/mock-dataset';
 
 import * as _ from 'lodash';
+import * as yaml from 'js-yaml';
 
 describe('OptionCollection', () => {
     let options: OptionCollection;
-    let dashboardService: DashboardService;
 
-    initializeTestBed('Option Collection', {
-        providers: [
-            { provide: DashboardService, useClass: DashboardServiceMock }
-        ]
-    });
-
-    beforeEach(inject([DashboardService], (_dashboardService) => {
-        dashboardService = _dashboardService;
-
+    beforeEach(() => {
         options = new OptionCollection(ReflectiveInjector.resolveAndCreate([{
             provide: 'keyA',
             useValue: 'provideA'
@@ -76,7 +64,7 @@ describe('OptionCollection', () => {
             provide: 'testListWithFieldKey',
             useValue: ['field_key_1', 'field_key_2']
         }]));
-    }));
+    });
 
     it('does have an _id', () => {
         expect(options._id).toBeDefined();
@@ -129,58 +117,58 @@ describe('OptionCollection', () => {
 
     it('find field functions do not error if fields are not set', () => {
         expect(options.findField('testNameField')).toEqual(undefined);
-        expect(options.findFieldObject(dashboardService.state, 'testName')).toEqual(NeonFieldMetaData.get());
-        expect(options.findFieldObjects(dashboardService.state, 'testList')).toEqual([]);
+        expect(options.findFieldObject(DATASET, 'testName')).toEqual(NeonFieldMetaData.get());
+        expect(options.findFieldObjects(DATASET, 'testList')).toEqual([]);
     });
 
     it('findField does return expected object or undefined', () => {
-        options.fields = DashboardServiceMock.FIELDS;
+        options.fields = FIELDS;
 
-        expect(options.findField('testDateField')).toEqual(DashboardServiceMock.FIELD_MAP.DATE);
-        expect(options.findField('testNameField')).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
-        expect(options.findField('testSizeField')).toEqual(DashboardServiceMock.FIELD_MAP.SIZE);
+        expect(options.findField('testDateField')).toEqual(FIELD_MAP.DATE);
+        expect(options.findField('testNameField')).toEqual(FIELD_MAP.NAME);
+        expect(options.findField('testSizeField')).toEqual(FIELD_MAP.SIZE);
         expect(options.findField('testFakeField')).toEqual(undefined);
     });
 
     it('findField does work as expected if given an array index', () => {
-        options.fields = DashboardServiceMock.FIELDS;
+        options.fields = FIELDS;
 
-        let dateIndex = _.findIndex(DashboardServiceMock.FIELDS, (fieldObject) => fieldObject.columnName === 'testDateField');
-        let nameIndex = _.findIndex(DashboardServiceMock.FIELDS, (fieldObject) => fieldObject.columnName === 'testNameField');
-        let sizeIndex = _.findIndex(DashboardServiceMock.FIELDS, (fieldObject) => fieldObject.columnName === 'testSizeField');
+        let dateIndex = _.findIndex(FIELDS, (fieldObject) => fieldObject.columnName === 'testDateField');
+        let nameIndex = _.findIndex(FIELDS, (fieldObject) => fieldObject.columnName === 'testNameField');
+        let sizeIndex = _.findIndex(FIELDS, (fieldObject) => fieldObject.columnName === 'testSizeField');
 
-        expect(options.findField('' + dateIndex)).toEqual(DashboardServiceMock.FIELD_MAP.DATE);
-        expect(options.findField('' + nameIndex)).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
-        expect(options.findField('' + sizeIndex)).toEqual(DashboardServiceMock.FIELD_MAP.SIZE);
-        expect(options.findField('' + DashboardServiceMock.FIELDS.length)).toEqual(undefined);
+        expect(options.findField('' + dateIndex)).toEqual(FIELD_MAP.DATE);
+        expect(options.findField('' + nameIndex)).toEqual(FIELD_MAP.NAME);
+        expect(options.findField('' + sizeIndex)).toEqual(FIELD_MAP.SIZE);
+        expect(options.findField('' + FIELDS.length)).toEqual(undefined);
         expect(options.findField('-1')).toEqual(undefined);
         expect(options.findField('abcd')).toEqual(undefined);
     });
 
     it('findFieldObject does return expected object', () => {
-        options.fields = DashboardServiceMock.FIELDS;
+        options.fields = FIELDS;
 
-        expect(options.findFieldObject(dashboardService.state, 'testDate')).toEqual(DashboardServiceMock.FIELD_MAP.DATE);
-        expect(options.findFieldObject(dashboardService.state, 'testName')).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
-        expect(options.findFieldObject(dashboardService.state, 'testSize')).toEqual(DashboardServiceMock.FIELD_MAP.SIZE);
-        expect(options.findFieldObject(dashboardService.state, 'testFieldKey')).toEqual(DashboardServiceMock.FIELD_MAP.FIELD_KEY);
-        expect(options.findFieldObject(dashboardService.state, 'testFake')).toEqual(NeonFieldMetaData.get());
-        expect(options.findFieldObject(dashboardService.state, 'fakeBind')).toEqual(NeonFieldMetaData.get());
+        expect(options.findFieldObject(DATASET, 'testDate')).toEqual(FIELD_MAP.DATE);
+        expect(options.findFieldObject(DATASET, 'testName')).toEqual(FIELD_MAP.NAME);
+        expect(options.findFieldObject(DATASET, 'testSize')).toEqual(FIELD_MAP.SIZE);
+        expect(options.findFieldObject(DATASET, 'testFieldKey')).toEqual(FIELD_MAP.FIELD_KEY);
+        expect(options.findFieldObject(DATASET, 'testFake')).toEqual(NeonFieldMetaData.get());
+        expect(options.findFieldObject(DATASET, 'fakeBind')).toEqual(NeonFieldMetaData.get());
     });
 
     it('findFieldObjects does return expected array', () => {
-        options.fields = DashboardServiceMock.FIELDS;
+        options.fields = FIELDS;
 
-        expect(options.findFieldObjects(dashboardService.state, 'testList')).toEqual([
-            DashboardServiceMock.FIELD_MAP.DATE,
-            DashboardServiceMock.FIELD_MAP.NAME,
-            DashboardServiceMock.FIELD_MAP.SIZE
+        expect(options.findFieldObjects(DATASET, 'testList')).toEqual([
+            FIELD_MAP.DATE,
+            FIELD_MAP.NAME,
+            FIELD_MAP.SIZE
         ]);
-        expect(options.findFieldObjects(dashboardService.state, 'testListWithFieldKey')).toEqual([
-            DashboardServiceMock.FIELD_MAP.FIELD_KEY
+        expect(options.findFieldObjects(DATASET, 'testListWithFieldKey')).toEqual([
+            FIELD_MAP.FIELD_KEY
         ]);
-        expect(options.findFieldObjects(dashboardService.state, 'testName')).toEqual([]);
-        expect(options.findFieldObjects(dashboardService.state, 'fakeBind')).toEqual([]);
+        expect(options.findFieldObjects(DATASET, 'testName')).toEqual([]);
+        expect(options.findFieldObjects(DATASET, 'fakeBind')).toEqual([]);
     });
 
     it('inject does add given widget option with provided binding', () => {
@@ -278,66 +266,57 @@ describe('OptionCollection', () => {
         options.table = NeonTableMetaData.get();
         options.fields = [];
 
-        options.updateDatabases(dashboardService.state);
+        options.updateDatabases(DATASET);
 
-        expect(options.databases).toEqual(DashboardServiceMock.DATABASES_LIST);
-        expect(options.database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(options.tables).toEqual(DashboardServiceMock.TABLES_LIST);
-        expect(options.table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(options.fields).toEqual(DashboardServiceMock.FIELDS);
+        expect(options.databases).toEqual(DATABASES_LIST);
+        expect(options.database).toEqual(DATABASES.testDatabase1);
+        expect(options.tables).toEqual(TABLES_LIST);
+        expect(options.table).toEqual(TABLES.testTable1);
+        expect(options.fields).toEqual(FIELDS);
     });
 
     it('updateFields does update fields', () => {
-        options.databases = DashboardServiceMock.DATABASES_LIST;
-        options.database = DashboardServiceMock.DATABASES.testDatabase1;
-        options.tables = DashboardServiceMock.TABLES_LIST;
-        options.table = DashboardServiceMock.TABLES.testTable1;
+        options.databases = DATABASES_LIST;
+        options.database = DATABASES.testDatabase1;
+        options.tables = TABLES_LIST;
+        options.table = TABLES.testTable1;
         options.fields = [];
 
-        options.updateFields(dashboardService.state);
+        options.updateFields();
 
-        expect(options.databases).toEqual(DashboardServiceMock.DATABASES_LIST);
-        expect(options.database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(options.tables).toEqual(DashboardServiceMock.TABLES_LIST);
-        expect(options.table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(options.fields).toEqual(DashboardServiceMock.FIELDS);
+        expect(options.databases).toEqual(DATABASES_LIST);
+        expect(options.database).toEqual(DATABASES.testDatabase1);
+        expect(options.tables).toEqual(TABLES_LIST);
+        expect(options.table).toEqual(TABLES.testTable1);
+        expect(options.fields).toEqual(FIELDS);
     });
 
     it('updateTables does update tables and fields', () => {
-        options.databases = DashboardServiceMock.DATABASES_LIST;
-        options.database = DashboardServiceMock.DATABASES.testDatabase1;
+        options.databases = DATABASES_LIST;
+        options.database = DATABASES.testDatabase1;
         options.tables = [];
         options.table = NeonTableMetaData.get();
         options.fields = [];
 
-        options.updateTables(dashboardService.state);
+        options.updateTables(DATASET);
 
-        expect(options.databases).toEqual(DashboardServiceMock.DATABASES_LIST);
-        expect(options.database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(options.tables).toEqual(DashboardServiceMock.TABLES_LIST);
-        expect(options.table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(options.fields).toEqual(DashboardServiceMock.FIELDS);
+        expect(options.databases).toEqual(DATABASES_LIST);
+        expect(options.database).toEqual(DATABASES.testDatabase1);
+        expect(options.tables).toEqual(TABLES_LIST);
+        expect(options.table).toEqual(TABLES.testTable1);
+        expect(options.fields).toEqual(FIELDS);
     });
 });
 
 describe('WidgetOptionCollection', () => {
     let options: WidgetOptionCollection;
-    let dashboardService: DashboardService;
 
-    initializeTestBed('Widget Option Collection', {
-        providers: [
-            { provide: DashboardService, useClass: DashboardServiceMock }
-        ]
-    });
-
-    beforeEach(inject([DashboardService], (_dashboardService) => {
-        dashboardService = _dashboardService;
-
+    beforeEach(() => {
         options = new WidgetOptionCollection(() => [
             new WidgetFieldOption('testCustomField', 'Test Custom Field', false),
             new WidgetFieldArrayOption('testCustomFieldArray', 'Test Custom Field Array', false),
             new WidgetFreeTextOption('testCustomKey', 'Test Custom Key', 'default value')
-        ], dashboardService.state, 'Test Title', 100, ReflectiveInjector.resolveAndCreate([{
+        ], DATASET, 'Test Title', 100, ReflectiveInjector.resolveAndCreate([{
             provide: 'tableKey',
             useValue: 'table_key_2'
         }, {
@@ -356,20 +335,20 @@ describe('WidgetOptionCollection', () => {
             provide: 'testCustomKey',
             useValue: 'testCustomValue'
         }]));
-    }));
+    });
 
     it('does have databases, fields, tables, and custom properties', () => {
-        expect(options.databases).toEqual(DashboardServiceMock.DATABASES_LIST);
-        expect(options.database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
-        expect(options.tables).toEqual(DashboardServiceMock.TABLES_LIST);
-        expect(options.table).toEqual(DashboardServiceMock.TABLES.testTable2);
-        expect(options.fields).toEqual(DashboardServiceMock.FIELDS);
+        expect(options.databases).toEqual(DATABASES_LIST);
+        expect(options.database).toEqual(DATABASES.testDatabase2);
+        expect(options.tables).toEqual(TABLES_LIST);
+        expect(options.table).toEqual(TABLES.testTable2);
+        expect(options.fields).toEqual(FIELDS);
 
         expect(options.limit).toEqual('1234');
         expect(options.title).toEqual('Test Custom Title');
 
-        expect(options.testCustomField).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
-        expect(options.testCustomFieldArray).toEqual([DashboardServiceMock.FIELD_MAP.NAME, DashboardServiceMock.FIELD_MAP.TYPE]);
+        expect(options.testCustomField).toEqual(FIELD_MAP.TEXT);
+        expect(options.testCustomFieldArray).toEqual([FIELD_MAP.NAME, FIELD_MAP.TYPE]);
         expect(options.testCustomKey).toEqual('testCustomValue');
     });
 
@@ -382,84 +361,75 @@ describe('WidgetOptionCollection', () => {
         options.testCustomField = null;
         options.testCustomFieldArray = null;
 
-        options.updateDatabases(dashboardService.state);
+        options.updateDatabases(DATASET);
 
-        expect(options.databases).toEqual(DashboardServiceMock.DATABASES_LIST);
-        expect(options.database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
-        expect(options.tables).toEqual(DashboardServiceMock.TABLES_LIST);
-        expect(options.table).toEqual(DashboardServiceMock.TABLES.testTable2);
-        expect(options.fields).toEqual(DashboardServiceMock.FIELDS);
-        expect(options.testCustomField).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
-        expect(options.testCustomFieldArray).toEqual([DashboardServiceMock.FIELD_MAP.NAME, DashboardServiceMock.FIELD_MAP.TYPE]);
+        expect(options.databases).toEqual(DATABASES_LIST);
+        expect(options.database).toEqual(DATABASES.testDatabase2);
+        expect(options.tables).toEqual(TABLES_LIST);
+        expect(options.table).toEqual(TABLES.testTable2);
+        expect(options.fields).toEqual(FIELDS);
+        expect(options.testCustomField).toEqual(FIELD_MAP.TEXT);
+        expect(options.testCustomFieldArray).toEqual([FIELD_MAP.NAME, FIELD_MAP.TYPE]);
     });
 
     it('updateFields does update fields with custom properties', () => {
-        options.databases = DashboardServiceMock.DATABASES_LIST;
-        options.database = DashboardServiceMock.DATABASES.testDatabase2;
-        options.tables = DashboardServiceMock.TABLES_LIST;
-        options.table = DashboardServiceMock.TABLES.testTable2;
+        options.databases = DATABASES_LIST;
+        options.database = DATABASES.testDatabase2;
+        options.tables = TABLES_LIST;
+        options.table = TABLES.testTable2;
         options.fields = [];
         options.testCustomField = null;
         options.testCustomFieldArray = null;
 
-        options.updateFields(dashboardService.state);
+        options.updateFields();
 
-        expect(options.databases).toEqual(DashboardServiceMock.DATABASES_LIST);
-        expect(options.database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
-        expect(options.tables).toEqual(DashboardServiceMock.TABLES_LIST);
-        expect(options.table).toEqual(DashboardServiceMock.TABLES.testTable2);
-        expect(options.fields).toEqual(DashboardServiceMock.FIELDS);
-        expect(options.testCustomField).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
-        expect(options.testCustomFieldArray).toEqual([DashboardServiceMock.FIELD_MAP.NAME, DashboardServiceMock.FIELD_MAP.TYPE]);
+        expect(options.databases).toEqual(DATABASES_LIST);
+        expect(options.database).toEqual(DATABASES.testDatabase2);
+        expect(options.tables).toEqual(TABLES_LIST);
+        expect(options.table).toEqual(TABLES.testTable2);
+        expect(options.fields).toEqual(FIELDS);
+        expect(options.testCustomField).toEqual(FIELD_MAP.TEXT);
+        expect(options.testCustomFieldArray).toEqual([FIELD_MAP.NAME, FIELD_MAP.TYPE]);
     });
 
     it('updateTables does update tables and fields with custom properties', () => {
-        options.databases = DashboardServiceMock.DATABASES_LIST;
-        options.database = DashboardServiceMock.DATABASES.testDatabase2;
+        options.databases = DATABASES_LIST;
+        options.database = DATABASES.testDatabase2;
         options.tables = [];
         options.table = NeonTableMetaData.get();
         options.fields = [];
         options.testCustomField = null;
         options.testCustomFieldArray = null;
 
-        options.updateTables(dashboardService.state);
+        options.updateTables(DATASET);
 
-        expect(options.databases).toEqual(DashboardServiceMock.DATABASES_LIST);
-        expect(options.database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
-        expect(options.tables).toEqual(DashboardServiceMock.TABLES_LIST);
-        expect(options.table.prettyName).toEqual(DashboardServiceMock.TABLES.testTable2.prettyName);
-        expect(options.fields).toEqual(DashboardServiceMock.FIELDS);
-        expect(options.testCustomField).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
-        expect(options.testCustomFieldArray).toEqual([DashboardServiceMock.FIELD_MAP.NAME, DashboardServiceMock.FIELD_MAP.TYPE]);
+        expect(options.databases).toEqual(DATABASES_LIST);
+        expect(options.database).toEqual(DATABASES.testDatabase2);
+        expect(options.tables).toEqual(TABLES_LIST);
+        expect(options.table.prettyName).toEqual(TABLES.testTable2.prettyName);
+        expect(options.fields).toEqual(FIELDS);
+        expect(options.testCustomField).toEqual(FIELD_MAP.TEXT);
+        expect(options.testCustomFieldArray).toEqual([FIELD_MAP.NAME, FIELD_MAP.TYPE]);
     });
 });
 
 describe('WidgetOptionCollection with no bindings', () => {
     let options: WidgetOptionCollection;
-    let dashboardService: DashboardService;
 
-    initializeTestBed('Widget Option Collection', {
-        providers: [
-            { provide: DashboardService, useClass: DashboardServiceMock }
-        ]
-    });
-
-    beforeEach(inject([DashboardService], (_dashboardService) => {
-        dashboardService = _dashboardService;
-
+    beforeEach(() => {
         options = new WidgetOptionCollection(() => [
             new WidgetFieldOption('testCustomField', 'Test Custom Field', false),
             new WidgetFieldArrayOption('testCustomFieldArray', 'Test Custom Field Array', false),
             new WidgetFreeTextOption('testCustomKey', 'Test Custom Key', 'default value')
-        ], dashboardService.state, 'Test Title', 100, ReflectiveInjector.resolveAndCreate([]));
-    }));
+        ], DATASET, 'Test Title', 100, ReflectiveInjector.resolveAndCreate([]));
+    });
 
     it('does have databases, fields, tables, and custom properties with default values', () => {
-        expect(options.databases).toEqual(DashboardServiceMock.DATABASES_LIST);
-        expect(options.database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(options.tables).toEqual(DashboardServiceMock.TABLES_LIST);
-        expect(options.table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(options.fields).toEqual(DashboardServiceMock.FIELDS);
+        expect(options.databases).toEqual(DATABASES_LIST);
+        expect(options.database).toEqual(DATABASES.testDatabase1);
+        expect(options.tables).toEqual(TABLES_LIST);
+        expect(options.table).toEqual(TABLES.testTable1);
+        expect(options.fields).toEqual(FIELDS);
 
         expect(options.limit).toEqual(100);
         expect(options.title).toEqual('Test Title');
@@ -472,17 +442,8 @@ describe('WidgetOptionCollection with no bindings', () => {
 
 describe('RootWidgetOptionCollection', () => {
     let options: RootWidgetOptionCollection;
-    let dashboardService: DashboardService;
 
-    initializeTestBed('Root Widget Option Collection', {
-        providers: [
-            { provide: DashboardService, useClass: DashboardServiceMock }
-        ]
-    });
-
-    beforeEach(inject([DashboardService], (_dashboardService) => {
-        dashboardService = _dashboardService;
-
+    beforeEach(() => {
         options = new RootWidgetOptionCollection(() => [
             new WidgetFieldOption('testCustomField', 'Test Custom Field', false),
             new WidgetFieldArrayOption('testCustomFieldArray', 'Test Custom Field Array', false),
@@ -491,7 +452,7 @@ describe('RootWidgetOptionCollection', () => {
             new WidgetFieldOption('testCustomLayerField', 'Test Custom Layer Field', false),
             new WidgetFieldArrayOption('testCustomLayerFieldArray', 'Test Custom Layer Field Array', false),
             new WidgetFreeTextOption('testCustomLayerKey', 'Test Custom Layer Key', 'default layer value')
-        ], dashboardService.state, 'Test Title', 100, true, ReflectiveInjector.resolveAndCreate([{
+        ], DATASET, 'Test Title', 100, true, ReflectiveInjector.resolveAndCreate([{
             provide: 'tableKey',
             useValue: 'table_key_2'
         }, {
@@ -535,37 +496,37 @@ describe('RootWidgetOptionCollection', () => {
                 testCustomLayerKey: 'testCustomLayerValue'
             }]
         }]));
-    }));
+    });
 
     it('does have databases, fields, tables, custom properties, and custom layers', () => {
-        expect(options.databases).toEqual(DashboardServiceMock.DATABASES_LIST);
-        expect(options.database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
-        expect(options.tables).toEqual(DashboardServiceMock.TABLES_LIST);
-        expect(options.table).toEqual(DashboardServiceMock.TABLES.testTable2);
-        expect(options.fields).toEqual(DashboardServiceMock.FIELDS);
+        expect(options.databases).toEqual(DATABASES_LIST);
+        expect(options.database).toEqual(DATABASES.testDatabase2);
+        expect(options.tables).toEqual(TABLES_LIST);
+        expect(options.table).toEqual(TABLES.testTable2);
+        expect(options.fields).toEqual(FIELDS);
 
         expect(options.contributionKeys).toEqual(['next_century']);
         expect(options.filter).toEqual({ lhs: 'a', operator: '!=', rhs: 'b' });
         expect(options.hideUnfiltered).toEqual(true);
         expect(options.limit).toEqual('1234');
         expect(options.title).toEqual('Test Custom Title');
-        expect(options.unsharedFilterField).toEqual(DashboardServiceMock.FIELD_MAP.FILTER);
+        expect(options.unsharedFilterField).toEqual(FIELD_MAP.FILTER);
         expect(options.unsharedFilterValue).toEqual('testFilterValue');
 
-        expect(options.testCustomField).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
-        expect(options.testCustomFieldArray).toEqual([DashboardServiceMock.FIELD_MAP.NAME, DashboardServiceMock.FIELD_MAP.TYPE]);
+        expect(options.testCustomField).toEqual(FIELD_MAP.TEXT);
+        expect(options.testCustomFieldArray).toEqual([FIELD_MAP.NAME, FIELD_MAP.TYPE]);
         expect(options.testCustomKey).toEqual('testCustomValue');
 
         expect(options.layers.length).toEqual(1);
-        expect(options.layers[0].databases).toEqual(DashboardServiceMock.DATABASES_LIST);
-        expect(options.layers[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
-        expect(options.layers[0].tables).toEqual(DashboardServiceMock.TABLES_LIST);
-        expect(options.layers[0].table).toEqual(DashboardServiceMock.TABLES.testTable2);
-        expect(options.layers[0].fields).toEqual(DashboardServiceMock.FIELDS);
+        expect(options.layers[0].databases).toEqual(DATABASES_LIST);
+        expect(options.layers[0].database).toEqual(DATABASES.testDatabase2);
+        expect(options.layers[0].tables).toEqual(TABLES_LIST);
+        expect(options.layers[0].table).toEqual(TABLES.testTable2);
+        expect(options.layers[0].fields).toEqual(FIELDS);
         expect(options.layers[0].limit).toEqual(5678);
         expect(options.layers[0].title).toEqual('Test Layer Title');
-        expect(options.layers[0].testCustomLayerField).toEqual(DashboardServiceMock.FIELD_MAP.DATE);
-        expect(options.layers[0].testCustomLayerFieldArray).toEqual([DashboardServiceMock.FIELD_MAP.X, DashboardServiceMock.FIELD_MAP.Y]);
+        expect(options.layers[0].testCustomLayerField).toEqual(FIELD_MAP.DATE);
+        expect(options.layers[0].testCustomLayerFieldArray).toEqual([FIELD_MAP.X, FIELD_MAP.Y]);
         expect(options.layers[0].testCustomLayerKey).toEqual('testCustomLayerValue');
     });
 
@@ -573,11 +534,11 @@ describe('RootWidgetOptionCollection', () => {
         let newLayer = options.addLayer();
         expect(options.layers.length).toEqual(2);
         expect(options.layers[1].title).toEqual('Layer 2');
-        expect(options.layers[1].databases).toEqual(DashboardServiceMock.DATABASES_LIST);
-        expect(options.layers[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(options.layers[1].tables).toEqual(DashboardServiceMock.TABLES_LIST);
-        expect(options.layers[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(options.layers[1].fields).toEqual(DashboardServiceMock.FIELDS);
+        expect(options.layers[1].databases).toEqual(DATABASES_LIST);
+        expect(options.layers[1].database).toEqual(DATABASES.testDatabase1);
+        expect(options.layers[1].tables).toEqual(TABLES_LIST);
+        expect(options.layers[1].table).toEqual(TABLES.testTable1);
+        expect(options.layers[1].fields).toEqual(FIELDS);
         expect(options.layers[1].testCustomLayerField).toEqual(NeonFieldMetaData.get());
         expect(options.layers[1].testCustomLayerFieldArray).toEqual([]);
         expect(options.layers[1].testCustomLayerKey).toEqual('default layer value');
@@ -594,15 +555,15 @@ describe('RootWidgetOptionCollection', () => {
             testCustomLayerKey: 'testCustomLayerValue'
         });
         expect(options.layers.length).toEqual(2);
-        expect(options.layers[1].databases).toEqual(DashboardServiceMock.DATABASES_LIST);
-        expect(options.layers[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
-        expect(options.layers[1].tables).toEqual(DashboardServiceMock.TABLES_LIST);
-        expect(options.layers[1].table).toEqual(DashboardServiceMock.TABLES.testTable2);
-        expect(options.layers[1].fields).toEqual(DashboardServiceMock.FIELDS);
+        expect(options.layers[1].databases).toEqual(DATABASES_LIST);
+        expect(options.layers[1].database).toEqual(DATABASES.testDatabase2);
+        expect(options.layers[1].tables).toEqual(TABLES_LIST);
+        expect(options.layers[1].table).toEqual(TABLES.testTable2);
+        expect(options.layers[1].fields).toEqual(FIELDS);
         expect(options.layers[1].limit).toEqual(5678);
         expect(options.layers[1].title).toEqual('Test Layer Title');
-        expect(options.layers[1].testCustomLayerField).toEqual(DashboardServiceMock.FIELD_MAP.DATE);
-        expect(options.layers[1].testCustomLayerFieldArray).toEqual([DashboardServiceMock.FIELD_MAP.X, DashboardServiceMock.FIELD_MAP.Y]);
+        expect(options.layers[1].testCustomLayerField).toEqual(FIELD_MAP.DATE);
+        expect(options.layers[1].testCustomLayerFieldArray).toEqual([FIELD_MAP.X, FIELD_MAP.Y]);
         expect(options.layers[1].testCustomLayerKey).toEqual('testCustomLayerValue');
         expect(newLayer).toEqual(options.layers[1]);
     });
@@ -631,17 +592,8 @@ describe('RootWidgetOptionCollection', () => {
 
 describe('RootWidgetOptionCollection with no bindings', () => {
     let options: RootWidgetOptionCollection;
-    let dashboardService: DashboardService;
 
-    initializeTestBed('Root Widget Option Collection', {
-        providers: [
-            { provide: DashboardService, useClass: DashboardServiceMock }
-        ]
-    });
-
-    beforeEach(inject([DashboardService], (_dashboardService) => {
-        dashboardService = _dashboardService;
-
+    beforeEach(() => {
         options = new RootWidgetOptionCollection(() => [
             new WidgetFieldOption('testCustomField', 'Test Custom Field', false),
             new WidgetFieldArrayOption('testCustomFieldArray', 'Test Custom Field Array', false),
@@ -650,15 +602,15 @@ describe('RootWidgetOptionCollection with no bindings', () => {
             new WidgetFieldOption('testCustomLayerField', 'Test Custom Layer Field', false),
             new WidgetFieldArrayOption('testCustomLayerFieldArray', 'Test Custom Layer Field Array', false),
             new WidgetFreeTextOption('testCustomLayerKey', 'Test Custom Layer Key', 'default layer value')
-        ], dashboardService.state, 'Test Title', 100, true, ReflectiveInjector.resolveAndCreate([]));
-    }));
+        ], DATASET, 'Test Title', 100, true, ReflectiveInjector.resolveAndCreate([]));
+    });
 
     it('does have databases, fields, tables, custom properties, and custom layers with default values', () => {
-        expect(options.databases).toEqual(DashboardServiceMock.DATABASES_LIST);
-        expect(options.database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(options.tables).toEqual(DashboardServiceMock.TABLES_LIST);
-        expect(options.table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(options.fields).toEqual(DashboardServiceMock.FIELDS);
+        expect(options.databases).toEqual(DATABASES_LIST);
+        expect(options.database).toEqual(DATABASES.testDatabase1);
+        expect(options.tables).toEqual(TABLES_LIST);
+        expect(options.table).toEqual(TABLES.testTable1);
+        expect(options.fields).toEqual(FIELDS);
 
         expect(options.contributionKeys).toEqual(null);
         expect(options.filter).toEqual(null);

--- a/src/app/models/widget-option-collection.ts
+++ b/src/app/models/widget-option-collection.ts
@@ -14,7 +14,7 @@
  */
 import { Injector } from '@angular/core';
 import { Dataset, NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from './dataset';
-import { DataUtil } from '../util/data.util';
+import { DatasetUtil } from '../util/dataset.util';
 import * as _ from 'lodash';
 import * as uuidv4 from 'uuid/v4';
 import {
@@ -133,7 +133,7 @@ export class OptionCollection {
      */
     public findFieldObject(dataset: Dataset, bindingKey: string): NeonFieldMetaData {
         let fieldKey = (this.config || {})[bindingKey] || (this.injector ? this.injector.get(bindingKey, '') : '');
-        return this.findField(DataUtil.translateFieldKeyToValue(dataset.fieldKeys, fieldKey)) || NeonFieldMetaData.get();
+        return this.findField(DatasetUtil.translateFieldKeyToValue(dataset.fieldKeys, fieldKey)) || NeonFieldMetaData.get();
     }
 
     /**
@@ -142,7 +142,7 @@ export class OptionCollection {
     public findFieldObjects(dataset: Dataset, bindingKey: string): NeonFieldMetaData[] {
         let bindings = (this.config || {})[bindingKey] || (this.injector ? this.injector.get(bindingKey, []) : []);
         return (Array.isArray(bindings) ? bindings : []).map((fieldKey) =>
-            this.findField(DataUtil.translateFieldKeyToValue(dataset.fieldKeys, fieldKey))).filter((fieldsObject) => !!fieldsObject);
+            this.findField(DatasetUtil.translateFieldKeyToValue(dataset.fieldKeys, fieldKey))).filter((fieldsObject) => !!fieldsObject);
     }
 
     protected getConstructor<T>(this: T): new(...args: any[]) => T {
@@ -189,13 +189,13 @@ export class OptionCollection {
         if (this.databases.length) {
             // By default, set the initial database to the first one in the dataset's configured table keys.
             let configuredTableKeys = Object.keys(dataset.tableKeys || {});
-            let configuredDatabase = !configuredTableKeys.length ? null : DataUtil.deconstructTableName(dataset.tableKeys,
+            let configuredDatabase = !configuredTableKeys.length ? null : DatasetUtil.deconstructTableName(dataset.tableKeys,
                 configuredTableKeys[0]).database;
 
             // Look for the table key configured for the specific visualization.
             let configuredTableKey = (this.config || {}).tableKey || (this.injector ? this.injector.get('tableKey', null) : null);
             if (configuredTableKey && dataset.tableKeys[configuredTableKey]) {
-                configuredDatabase = DataUtil.deconstructTableName(dataset.tableKeys, configuredTableKey).database;
+                configuredDatabase = DatasetUtil.deconstructTableName(dataset.tableKeys, configuredTableKey).database;
             }
 
             if (configuredDatabase) {
@@ -242,13 +242,13 @@ export class OptionCollection {
         if (this.tables.length > 0) {
             // By default, set the initial table to the first one in the dataset's configured table keys.
             let configuredTableKeys = Object.keys(dataset.tableKeys || {});
-            let configuredTable = !configuredTableKeys.length ? null : DataUtil.deconstructTableName(dataset.tableKeys,
+            let configuredTable = !configuredTableKeys.length ? null : DatasetUtil.deconstructTableName(dataset.tableKeys,
                 configuredTableKeys[0]).table;
 
             // Look for the table key configured for the specific visualization.
             let configuredTableKey = (this.config || {}).tableKey || (this.injector ? this.injector.get('tableKey', null) : null);
             if (configuredTableKey && dataset.tableKeys[configuredTableKey]) {
-                configuredTable = DataUtil.deconstructTableName(dataset.tableKeys, configuredTableKey).table;
+                configuredTable = DatasetUtil.deconstructTableName(dataset.tableKeys, configuredTableKey).table;
             }
 
             if (configuredTable) {

--- a/src/app/models/widget-option-collection.ts
+++ b/src/app/models/widget-option-collection.ts
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Injector } from '@angular/core';
 import { Dataset, NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from './dataset';
 import { DataUtil } from '../util/data.util';
 import * as _ from 'lodash';
@@ -30,6 +29,15 @@ import {
     WidgetTableOption
 } from './widget-option';
 
+export class OptionConfig {
+    constructor(protected config: any) { }
+
+    public get(bindingKey: string, defaultValue: any): any {
+        // Assume config is just a Record<string, any>
+        return typeof this.config[bindingKey] === 'undefined' ? defaultValue : this.config[bindingKey];
+    }
+}
+
 /**
  * Manages configurable options with databases, tables, and fields.
  */
@@ -46,12 +54,11 @@ export class OptionCollection {
 
     /**
      * @constructor
-     * @arg {Injector} [injector] An injector with bindings; if undefined, uses config.
-     * @arg {any} [config] An object with bindings; used if injector is undefined.
+     * @arg {OptionConfig} [config] An object with configured bindings.
      */
-    constructor(protected injector?: Injector, protected config?: any) {
+    constructor(protected config: OptionConfig = new OptionConfig({})) {
         // TODO Do not use a default _id.  Throw an error if undefined!
-        this._id = (this.injector ? this.injector.get('_id', uuidv4()) : ((this.config || {})._id || uuidv4()));
+        this._id = this.config.get('_id', uuidv4());
         this.append(new WidgetDatabaseOption(), NeonDatabaseMetaData.get());
         this.append(new WidgetTableOption(), NeonTableMetaData.get());
     }
@@ -104,7 +111,7 @@ export class OptionCollection {
      * @return {OptionCollection}
      */
     public copy(): this {
-        let copy = new (this.getConstructor())(this.injector, this.config);
+        let copy = new (this.getConstructor())(this.config);
         return this.copyCommonProperties(copy);
     }
 
@@ -132,7 +139,7 @@ export class OptionCollection {
      * Returns the field object for the given binding key or an empty field object.
      */
     public findFieldObject(dataset: Dataset, bindingKey: string): NeonFieldMetaData {
-        let fieldKey = (this.config || {})[bindingKey] || (this.injector ? this.injector.get(bindingKey, '') : '');
+        let fieldKey = this.config.get(bindingKey, '');
         return this.findField(DataUtil.translateFieldKeyToValue(dataset.fieldKeys, fieldKey)) || NeonFieldMetaData.get();
     }
 
@@ -140,7 +147,7 @@ export class OptionCollection {
      * Returns the array of field objects for the given binding key or an array of empty field objects.
      */
     public findFieldObjects(dataset: Dataset, bindingKey: string): NeonFieldMetaData[] {
-        let bindings = (this.config || {})[bindingKey] || (this.injector ? this.injector.get(bindingKey, []) : []);
+        let bindings = this.config.get(bindingKey, []);
         return (Array.isArray(bindings) ? bindings : []).map((fieldKey) =>
             this.findField(DataUtil.translateFieldKeyToValue(dataset.fieldKeys, fieldKey))).filter((fieldsObject) => !!fieldsObject);
     }
@@ -156,8 +163,7 @@ export class OptionCollection {
      */
     public inject(options: WidgetOption | WidgetOption[]): void {
         (Array.isArray(options) ? options : [options]).forEach((option) => {
-            this.append(option, (this.injector ? this.injector.get(option.bindingKey, option.valueDefault) :
-                ((this.config || {})[option.bindingKey] || option.valueDefault)));
+            this.append(option, this.config.get(option.bindingKey, option.valueDefault));
         });
     }
 
@@ -193,7 +199,7 @@ export class OptionCollection {
                 configuredTableKeys[0]).database;
 
             // Look for the table key configured for the specific visualization.
-            let configuredTableKey = (this.config || {}).tableKey || (this.injector ? this.injector.get('tableKey', null) : null);
+            let configuredTableKey = this.config.get('tableKey', null);
             if (configuredTableKey && dataset.tableKeys[configuredTableKey]) {
                 configuredDatabase = DataUtil.deconstructTableName(dataset.tableKeys, configuredTableKey).database;
             }
@@ -246,7 +252,7 @@ export class OptionCollection {
                 configuredTableKeys[0]).table;
 
             // Look for the table key configured for the specific visualization.
-            let configuredTableKey = (this.config || {}).tableKey || (this.injector ? this.injector.get('tableKey', null) : null);
+            let configuredTableKey = this.config.get('tableKey', null);
             if (configuredTableKey && dataset.tableKeys[configuredTableKey]) {
                 configuredTable = DataUtil.deconstructTableName(dataset.tableKeys, configuredTableKey).table;
             }
@@ -275,18 +281,16 @@ export class WidgetOptionCollection extends OptionCollection {
      * @arg {Dataset} dataset The current dataset.
      * @arg {string} defaultTitle The default value for the injected 'title' option.
      * @arg {number} defaultLimit The default value for the injected 'limit' option.
-     * @arg {Injector} [injector] An injector with bindings; if undefined, uses config.
-     * @arg {any} [config] An object with bindings; used if injector is undefined.
+     * @arg {OptionConfig} [config] An object with configured bindings.
      */
     constructor(
         protected createOptionsCallback: () => WidgetOption[],
         protected dataset: Dataset,
         defaultTitle: string,
         defaultLimit: number,
-        injector?: Injector,
-        config?: any
+        config?: OptionConfig
     ) {
-        super(injector, config);
+        super(config);
 
         let nonFieldOptions = this.createOptions().filter((option) => !isFieldOption(option));
 
@@ -306,8 +310,7 @@ export class WidgetOptionCollection extends OptionCollection {
      * @override
      */
     public copy(): this {
-        let copy = new (this.getConstructor())(this.createOptionsCallback, this.dataset, this.title, this.limit, this.injector,
-            this.config);
+        let copy = new (this.getConstructor())(this.createOptionsCallback, this.dataset, this.title, this.limit, this.config);
         return this.copyCommonProperties(copy);
     }
 
@@ -352,8 +355,7 @@ export class RootWidgetOptionCollection extends WidgetOptionCollection {
      * @arg {string} defaultTitle The default value for the injected 'title' option.
      * @arg {number} defaultLimit The default value for the injected 'limit' option.
      * @arg {boolean} defaultLayer Whether to add a default layer.
-     * @arg {Injector} [injector] An injector with bindings; if undefined, uses config.
-     * @arg {any} [config] An object with bindings; used if injector is undefined.
+     * @arg {OptionConfig} [config] An object with configured bindings.
      */
     constructor(
         createOptionsCallback: () => WidgetOption[],
@@ -362,15 +364,14 @@ export class RootWidgetOptionCollection extends WidgetOptionCollection {
         defaultTitle: string,
         defaultLimit: number,
         defaultLayer: boolean,
-        injector?: Injector,
-        config?: any
+        config?: OptionConfig
     ) {
-        super(createOptionsCallback, dataset, defaultTitle, defaultLimit, injector, config);
+        super(createOptionsCallback, dataset, defaultTitle, defaultLimit, config);
 
         // Backwards compatibility (configFilter deprecated and renamed to filter).
-        this.filter = this.filter || (injector ? injector.get('configFilter', null) : (config || {}).configFilter);
+        this.filter = this.filter || this.config.get('configFilter', null);
 
-        (injector ? injector.get('layers', []) : ((config || {}).layers || [])).forEach((layerBindings) => {
+        this.config.get('layers', []).forEach((layerBindings) => {
             this.addLayer(layerBindings);
         });
 
@@ -385,7 +386,7 @@ export class RootWidgetOptionCollection extends WidgetOptionCollection {
      */
     public addLayer(layerBindings: any = {}): WidgetOptionCollection {
         let layerOptions = new WidgetOptionCollection(this.createOptionsForLayerCallback, this.dataset,
-            'Layer ' + this._nextLayerIndex++, this.limit, undefined, layerBindings);
+            'Layer ' + this._nextLayerIndex++, this.limit, new OptionConfig(layerBindings));
         this.layers.push(layerOptions);
         return layerOptions;
     }
@@ -398,7 +399,7 @@ export class RootWidgetOptionCollection extends WidgetOptionCollection {
      */
     public copy(): this {
         let copy = new (this.getConstructor())(this.createOptionsCallback, this.createOptionsForLayerCallback, this.dataset,
-            this.title, this.limit, false, this.injector, this.config);
+            this.title, this.limit, false, this.config);
         copy.layers = this.layers.map((layer) => layer.copy());
         return this.copyCommonProperties(copy);
     }

--- a/src/app/models/widget-option-collection.ts
+++ b/src/app/models/widget-option-collection.ts
@@ -183,21 +183,26 @@ export class OptionCollection {
     public updateDatabases(dataset: Dataset): void {
         this.databases = dataset.datastores.reduce((list, datastore) =>
             list.concat(Object.values(datastore.databases).sort((one, two) => one.name.localeCompare(two.name))), []);
+
         this.database = this.databases[0] || this.database;
 
         if (this.databases.length) {
-            let tableKey = (this.config || {}).tableKey || (this.injector ? this.injector.get('tableKey', null) : null);
-            let configDatabase: any;
+            // By default, set the initial database to the first one in the dataset's configured table keys.
+            let configuredTableKeys = Object.keys(dataset.tableKeys || {});
+            let configuredDatabase = !configuredTableKeys.length ? null : DataUtil.deconstructTableName(dataset.tableKeys,
+                configuredTableKeys[0]).database;
 
-            if (tableKey && dataset.tableKeys[tableKey]) {
-                configDatabase = DataUtil.deconstructTableName(dataset.tableKeys, tableKey).database;
+            // Look for the table key configured for the specific visualization.
+            let configuredTableKey = (this.config || {}).tableKey || (this.injector ? this.injector.get('tableKey', null) : null);
+            if (configuredTableKey && dataset.tableKeys[configuredTableKey]) {
+                configuredDatabase = DataUtil.deconstructTableName(dataset.tableKeys, configuredTableKey).database;
+            }
 
-                if (configDatabase) {
-                    for (let database of this.databases) {
-                        if (configDatabase === database.name) {
-                            this.database = database;
-                            break;
-                        }
+            if (configuredDatabase) {
+                for (let database of this.databases) {
+                    if (configuredDatabase === database.name) {
+                        this.database = database;
+                        break;
                     }
                 }
             }
@@ -235,18 +240,22 @@ export class OptionCollection {
         this.table = this.tables[0] || this.table;
 
         if (this.tables.length > 0) {
-            let tableKey = (this.config || {}).tableKey || (this.injector ? this.injector.get('tableKey', null) : null);
-            let configTable: any;
+            // By default, set the initial table to the first one in the dataset's configured table keys.
+            let configuredTableKeys = Object.keys(dataset.tableKeys || {});
+            let configuredTable = !configuredTableKeys.length ? null : DataUtil.deconstructTableName(dataset.tableKeys,
+                configuredTableKeys[0]).table;
 
-            if (tableKey && dataset.tableKeys[tableKey]) {
-                configTable = DataUtil.deconstructTableName(dataset.tableKeys, tableKey).table;
+            // Look for the table key configured for the specific visualization.
+            let configuredTableKey = (this.config || {}).tableKey || (this.injector ? this.injector.get('tableKey', null) : null);
+            if (configuredTableKey && dataset.tableKeys[configuredTableKey]) {
+                configuredTable = DataUtil.deconstructTableName(dataset.tableKeys, configuredTableKey).table;
+            }
 
-                if (configTable) {
-                    for (let table of this.tables) {
-                        if (configTable === table.name) {
-                            this.table = table;
-                            break;
-                        }
+            if (configuredTable) {
+                for (let table of this.tables) {
+                    if (configuredTable === table.name) {
+                        this.table = table;
+                        break;
                     }
                 }
             }

--- a/src/app/services/abstract.color-theme.service.ts
+++ b/src/app/services/abstract.color-theme.service.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 import { Injectable } from '@angular/core';
-import { Color, ColorSet } from '../models/color';
+import { Color, ColorMap, ColorSet } from '../models/color';
 
 /**
  * @interface Theme
@@ -99,10 +99,10 @@ export abstract class AbstractColorThemeService {
     /**
      * Initializes the starting colors using the given input.
      *
-     * @arg {Record<string, Record<string, Record<string, Record<string, string>>>>} colors
+     * @arg {ColorMap} colors
      * @abstract
      */
-    public abstract initializeColors(colors: Record<string, Record<string, Record<string, Record<string, string>>>>): void;
+    public abstract initializeColors(colors: ColorMap): void;
 
     /**
      * Sets the current application theme to the theme with the given ID.

--- a/src/app/services/abstract.color-theme.service.ts
+++ b/src/app/services/abstract.color-theme.service.ts
@@ -97,6 +97,14 @@ export abstract class AbstractColorThemeService {
     public abstract getThemeMainColorHex(): string;
 
     /**
+     * Initializes the starting colors using the given input.
+     *
+     * @arg {Record<string, Record<string, Record<string, Record<string, string>>>>} colors
+     * @abstract
+     */
+    public abstract initializeColors(colors: Record<string, Record<string, Record<string, Record<string, string>>>>): void;
+
+    /**
      * Sets the current application theme to the theme with the given ID.
      *
      * @arg {string} id

--- a/src/app/services/abstract.color-theme.service.ts
+++ b/src/app/services/abstract.color-theme.service.ts
@@ -26,11 +26,11 @@ export interface Theme {
 /**
  * A service for everything a Neon widget needs.
  *
- * @class AbstractWidgetService
+ * @class AbstractColorThemeService
  * @abstract
  */
 @Injectable()
-export abstract class AbstractWidgetService {
+export abstract class AbstractColorThemeService {
     /**
      * Returns the color for the given value from an existing color set for the given database/table/field or creates a new color set if
      * none exists.

--- a/src/app/services/abstract.search.service.ts
+++ b/src/app/services/abstract.search.service.ts
@@ -116,6 +116,16 @@ export abstract class AbstractSearchService {
     public abstract canRunSearch(datastoreType: string, datastoreHost: string): boolean;
 
     /**
+     * Returns an aggregation name from the given descriptor.
+     *
+     * @arg {string} [descriptor]
+     * @return {string}
+     */
+    public getAggregationName(descriptor?: string): string {
+        return descriptor ? ('_' + descriptor) : '_aggregation';
+    }
+
+    /**
      * Runs the given search using the given datastore type and host.
      *
      * @arg {string} datastoreType

--- a/src/app/services/color-theme.service.spec.ts
+++ b/src/app/services/color-theme.service.spec.ts
@@ -16,7 +16,7 @@ import { inject } from '@angular/core/testing';
 
 import { AbstractSearchService } from './abstract.search.service';
 import { DashboardService } from './dashboard.service';
-import { WidgetService } from './widget.service';
+import { ColorThemeService } from './color-theme.service';
 
 import { initializeTestBed } from '../../testUtils/initializeTestBed';
 import { DashboardServiceMock } from '../../testUtils/MockServices/DashboardServiceMock';
@@ -25,11 +25,11 @@ import { FilterService } from './filter.service';
 
 describe('Service: Widget', () => {
     /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-    let service: WidgetService;
+    let service: ColorThemeService;
 
     initializeTestBed('Widget Service', {
         providers: [
-            WidgetService,
+            ColorThemeService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             DashboardService,
             FilterService
@@ -37,8 +37,8 @@ describe('Service: Widget', () => {
         ]
     });
 
-    beforeEach(inject([WidgetService], (widgetService: WidgetService) => {
-        service = widgetService;
+    beforeEach(inject([ColorThemeService], (colorThemeService: ColorThemeService) => {
+        service = colorThemeService;
     }));
 
     it('does have expected default theme and no existing ColorSets', () => {
@@ -85,7 +85,7 @@ describe('Service: Widget', () => {
 describe('ColorSet', () => {
     initializeTestBed('Widget Service ColorSet', {
         providers: [
-            WidgetService,
+            ColorThemeService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             { provide: DashboardService, useClass: DashboardServiceMock }
 

--- a/src/app/services/color-theme.service.spec.ts
+++ b/src/app/services/color-theme.service.spec.ts
@@ -23,7 +23,7 @@ import { DashboardServiceMock } from '../../testUtils/MockServices/DashboardServ
 import { SearchServiceMock } from '../../testUtils/MockServices/SearchServiceMock';
 import { FilterService } from './filter.service';
 
-describe('Service: Widget', () => {
+describe('Service: Color Theme', () => {
     /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     let service: ColorThemeService;
 
@@ -77,13 +77,21 @@ describe('Service: Widget', () => {
         // TODO THOR-936
     });
 
+    it('initializeColors does update colorKeyToColorSet with given hex colors', () => {
+        // TODO THOR-936
+    });
+
+    it('initializeColors does update colorKeyToColorSet with given RGB colors', () => {
+        // TODO THOR-936
+    });
+
     it('setTheme does update theme ID', () => {
         // TODO THOR-936
     });
 });
 
 describe('ColorSet', () => {
-    initializeTestBed('Widget Service ColorSet', {
+    initializeTestBed('Color Theme Service ColorSet', {
         providers: [
             ColorThemeService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },

--- a/src/app/services/color-theme.service.ts
+++ b/src/app/services/color-theme.service.ts
@@ -14,7 +14,7 @@
  */
 import { Injectable } from '@angular/core';
 import { AbstractColorThemeService, Theme } from './abstract.color-theme.service';
-import { Color, ColorSet } from '../models/color';
+import { Color, ColorMap, ColorSet } from '../models/color';
 
 /**
  * @class NeonTheme
@@ -145,10 +145,10 @@ export class ColorThemeService extends AbstractColorThemeService {
     /**
      * Initializes the starting colors using the given input.
      *
-     * @arg {Record<string, Record<string, Record<string, Record<string, string>>>>} colors
+     * @arg {ColorMap} colors
      * @override
      */
-    public initializeColors(colors: Record<string, Record<string, Record<string, Record<string, string>>>>): void {
+    public initializeColors(colors: ColorMap): void {
         this.colorKeyToColorSet = new Map<string, ColorSet>();
         Object.keys(colors || {}).forEach((databaseName) => {
             Object.keys(colors[databaseName]).forEach((tableName) => {

--- a/src/app/services/color-theme.service.ts
+++ b/src/app/services/color-theme.service.ts
@@ -15,9 +15,6 @@
 import { Injectable } from '@angular/core';
 import { AbstractColorThemeService, Theme } from './abstract.color-theme.service';
 import { Color, ColorSet } from '../models/color';
-import { DashboardService } from './dashboard.service';
-import { DashboardState } from '../models/dashboard-state';
-import { distinctUntilKeyChanged } from 'rxjs/operators';
 
 /**
  * @class NeonTheme
@@ -48,20 +45,9 @@ export class ColorThemeService extends AbstractColorThemeService {
     private colorKeyToColorSet: Map<string, ColorSet> = new Map<string, ColorSet>();
     private currentThemeId: string = ColorThemeService.THEME_TEAL.id;
 
-    public readonly dashboardState: DashboardState;
-
-    constructor(dashboardService: DashboardService) {
+    constructor() {
         super();
-        dashboardService.stateSource
-            .pipe(
-                distinctUntilKeyChanged('id')
-            )
-            .subscribe(() => {
-                this.resetColorMap();
-            });
-
         document.body.className = this.currentThemeId;
-        this.dashboardState = dashboardService.state;
     }
 
     /**
@@ -157,29 +143,28 @@ export class ColorThemeService extends AbstractColorThemeService {
     }
 
     /**
-     * Resets the color map and initializes it with colors of the active datasets from the config.
+     * Initializes the starting colors using the given input.
+     *
+     * @arg {Record<string, Record<string, Record<string, Record<string, string>>>>} colors
+     * @override
      */
-    public resetColorMap() {
+    public initializeColors(colors: Record<string, Record<string, Record<string, Record<string, string>>>>): void {
         this.colorKeyToColorSet = new Map<string, ColorSet>();
-        if (this.dashboardState.getOptions()) {
-            let dashboardOptions = this.dashboardState.getOptions();
-            let colorMaps = dashboardOptions.colorMaps || {};
-            Object.keys(colorMaps).forEach((databaseName) => {
-                Object.keys(colorMaps[databaseName]).forEach((tableName) => {
-                    Object.keys(colorMaps[databaseName][tableName]).forEach((fieldName) => {
-                        let valueToColor = new Map<string, Color>();
-                        Object.keys(colorMaps[databaseName][tableName][fieldName]).forEach((valueName) => {
-                            let color = colorMaps[databaseName][tableName][fieldName][valueName];
-                            let isRGB = (color.indexOf('#') < 0);
-                            valueToColor.set(valueName, isRGB ? Color.fromRgbString(color) : Color.fromHexString(color));
-                        });
-                        let colorKey = this.getColorKey(databaseName, tableName, fieldName);
-                        let colorSet = new ColorSet(colorKey, databaseName, tableName, fieldName, valueToColor);
-                        this.colorKeyToColorSet.set(colorKey, colorSet);
+        Object.keys(colors || {}).forEach((databaseName) => {
+            Object.keys(colors[databaseName]).forEach((tableName) => {
+                Object.keys(colors[databaseName][tableName]).forEach((fieldName) => {
+                    let valueToColor = new Map<string, Color>();
+                    Object.keys(colors[databaseName][tableName][fieldName]).forEach((valueName) => {
+                        let color = colors[databaseName][tableName][fieldName][valueName];
+                        let isRGB = (color.indexOf('#') < 0);
+                        valueToColor.set(valueName, isRGB ? Color.fromRgbString(color) : Color.fromHexString(color));
                     });
+                    let colorKey = this.getColorKey(databaseName, tableName, fieldName);
+                    let colorSet = new ColorSet(colorKey, databaseName, tableName, fieldName, valueToColor);
+                    this.colorKeyToColorSet.set(colorKey, colorSet);
                 });
             });
-        }
+        });
     }
 
     /**

--- a/src/app/services/color-theme.service.ts
+++ b/src/app/services/color-theme.service.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 import { Injectable } from '@angular/core';
-import { AbstractWidgetService, Theme } from './abstract.widget.service';
+import { AbstractColorThemeService, Theme } from './abstract.color-theme.service';
 import { Color, ColorSet } from '../models/color';
 import { DashboardService } from './dashboard.service';
 import { DashboardState } from '../models/dashboard-state';
@@ -36,17 +36,17 @@ export class NeonTheme implements Theme {
 /**
  * A service for everything a Neon Dashboard widget needs.
  *
- * @class WidgetService
+ * @class ColorThemeService
  */
 @Injectable()
-export class WidgetService extends AbstractWidgetService {
+export class ColorThemeService extends AbstractColorThemeService {
     public static THEME_DARK: Theme = new NeonTheme('#01B7C1', 'neon-dark', '#515861', 'Dark');
     public static THEME_GREEN: Theme = new NeonTheme('#FFA600', 'neon-green', '#39B54A', 'Green');
     public static THEME_TEAL: Theme = new NeonTheme('#54C8CD', 'neon-teal', '#367588', 'Teal');
 
     // TODO Let different databases and tables in the same dataset have different color maps.
     private colorKeyToColorSet: Map<string, ColorSet> = new Map<string, ColorSet>();
-    private currentThemeId: string = WidgetService.THEME_TEAL.id;
+    private currentThemeId: string = ColorThemeService.THEME_TEAL.id;
 
     public readonly dashboardState: DashboardState;
 
@@ -129,10 +129,10 @@ export class WidgetService extends AbstractWidgetService {
     public getThemes(): Theme[] {
         return [
             // TODO THOR-853 Add dark theme
-            // WidgetService.THEME_DARK,
+            // ColorThemeService.THEME_DARK,
             // TODO THOR-852 Add green theme
-            // WidgetService.THEME_GREEN,
-            WidgetService.THEME_TEAL
+            // ColorThemeService.THEME_GREEN,
+            ColorThemeService.THEME_TEAL
         ];
     }
 

--- a/src/app/services/dashboard.service.spec.ts
+++ b/src/app/services/dashboard.service.spec.ts
@@ -83,10 +83,6 @@ describe('Service: DashboardService', () => {
             databases: {}
         });
     });
-
-    it('getCurrentDatabase does return undefined', () => {
-        expect(dashboardService.state.getDatabase()).not.toBeDefined();
-    });
 });
 
 describe('Service: DashboardService with Mock Data', () => {
@@ -428,10 +424,6 @@ describe('Service: DashboardService with Mock Data', () => {
         }));
 
         expect(dashboardService.state.findRelationDataList()).toEqual([]);
-    });
-
-    it('getCurrentDatabase does return expected object', () => {
-        expect(extractNames(dashboardService.state.getDatabase())).toEqual(extractNames(DashboardServiceMock.DATABASES.testDatabase1));
     });
 
     it('translateFieldKeyToValue does return expected string', () => {

--- a/src/app/services/dashboard.service.spec.ts
+++ b/src/app/services/dashboard.service.spec.ts
@@ -15,7 +15,8 @@
 import { inject } from '@angular/core/testing';
 
 import { AbstractSearchService } from './abstract.search.service';
-import { NeonConfig, NeonDatastoreConfig, NeonDashboardLeafConfig, FilterConfig } from '../models/types';
+import { NeonConfig, NeonDashboardLeafConfig, FilterConfig } from '../models/types';
+import { NeonDatastoreConfig } from '../models/dataset';
 import { DashboardService } from './dashboard.service';
 
 import { initializeTestBed, getConfigService } from '../../testUtils/initializeTestBed';

--- a/src/app/services/dashboard.service.ts
+++ b/src/app/services/dashboard.service.ts
@@ -14,11 +14,8 @@
  */
 import { Injectable } from '@angular/core';
 
-import {
-    NeonConfig, NeonDatastoreConfig,
-    NeonDatabaseMetaData, NeonTableMetaData, NeonFieldMetaData,
-    NeonDashboardLeafConfig, NeonDashboardChoiceConfig
-} from '../models/types';
+import { NeonConfig, NeonDashboardLeafConfig, NeonDashboardChoiceConfig } from '../models/types';
+import { NeonDatastoreConfig, NeonDatabaseMetaData, NeonTableMetaData, NeonFieldMetaData } from '../models/dataset';
 
 import * as _ from 'lodash';
 import { ConfigService } from './config.service';
@@ -124,7 +121,7 @@ export class DashboardService {
      * Sets the active dataset to the given dataset.
      * @param {Object} The dataset containing {String} name, {String} layout, {String} datastore, {String} hostname,
      * and {Array} databases.  Each database is an Object containing {String} name and {Array} tables.
-     * Each table is an Object containing {String} name, {Array} fields, and {Object} mappings.  Each
+     * Each table is an Object containing {String} name, {Array} fields, and {Object} labelOptions.  Each
      * field is an Object containing {String} columnName and {String} prettyName.  Each mapping key is a unique
      * identifier used by the visualizations and each value is a field name.
      */

--- a/src/app/services/filter.service.spec.ts
+++ b/src/app/services/filter.service.spec.ts
@@ -28,7 +28,7 @@ import {
     SimpleFilterDesign
 } from './filter.service';
 
-import { NeonFieldMetaData, NeonDatabaseMetaData, NeonTableMetaData } from '../models/types';
+import { NeonFieldMetaData, NeonDatabaseMetaData, NeonTableMetaData } from '../models/dataset';
 import { neonEvents } from '../models/neon-namespaces';
 
 import { DashboardServiceMock } from '../../testUtils/MockServices/DashboardServiceMock';

--- a/src/app/services/filter.service.ts
+++ b/src/app/services/filter.service.ts
@@ -14,16 +14,15 @@
  */
 import { Injectable } from '@angular/core';
 import { AbstractSearchService, CompoundFilterType, FilterClause } from './abstract.search.service';
-import {
-    NeonDatabaseMetaData, NeonFieldMetaData, SingleField, NeonTableMetaData,
-    FilterConfig, SimpleFilterConfig, CompoundFilterConfig
-} from '../models/types';
+import { FilterConfig, SimpleFilterConfig, CompoundFilterConfig } from '../models/types';
+import { NeonDatabaseMetaData, NeonFieldMetaData, SingleField, NeonTableMetaData } from '../models/dataset';
 import { neonEvents } from '../models/neon-namespaces';
 
 import * as uuidv4 from 'uuid/v4';
 import { eventing } from 'neon-framework';
 import { DashboardState } from '../models/dashboard-state';
 import { ConfigUtil } from '../util/config.util';
+import { DataUtil } from '../util/data.util';
 
 export interface FilterBehavior {
     filterDesign: FilterDesign;
@@ -318,7 +317,7 @@ export class FilterUtil {
         } // Simple filter
         const [field, operator, value, root] = simple as string[];
         return {
-            ...ConfigUtil.deconstructDottedReference(field),
+            ...DataUtil.deconstructDottedReference(field),
             operator,
             value,
             root: root || 'or'

--- a/src/app/services/filter.service.ts
+++ b/src/app/services/filter.service.ts
@@ -22,7 +22,7 @@ import * as uuidv4 from 'uuid/v4';
 import { eventing } from 'neon-framework';
 import { DashboardState } from '../models/dashboard-state';
 import { ConfigUtil } from '../util/config.util';
-import { DataUtil } from '../util/data.util';
+import { DatasetUtil } from '../util/dataset.util';
 
 export interface FilterBehavior {
     filterDesign: FilterDesign;
@@ -317,7 +317,7 @@ export class FilterUtil {
         } // Simple filter
         const [field, operator, value, root] = simple as string[];
         return {
-            ...DataUtil.deconstructDottedReference(field),
+            ...DatasetUtil.deconstructDottedReference(field),
             operator,
             value,
             root: root || 'or'

--- a/src/app/util/config.util.spec.ts
+++ b/src/app/util/config.util.spec.ts
@@ -55,36 +55,6 @@ describe('Config Util Tests', () => {
         expect(ConfigUtil.validateName('abc#$@#@$@#$-de.%%yml')).toEqual('abc-de.yml');
     });
 
-    it('deconstructDotted should work appropriately', () => {
-        expect(ConfigUtil.deconstructDottedReference('')).toEqual({
-            datastore: '',
-            database: '',
-            table: '',
-            field: ''
-        });
-
-        expect(ConfigUtil.deconstructDottedReference('a.b')).toEqual({
-            datastore: 'a',
-            database: 'b',
-            table: '',
-            field: ''
-        });
-
-        expect(ConfigUtil.deconstructDottedReference('...b')).toEqual({
-            datastore: '',
-            database: '',
-            table: '',
-            field: 'b'
-        });
-
-        expect(ConfigUtil.deconstructDottedReference('a.b.c.d.e.f')).toEqual({
-            datastore: 'a',
-            database: 'b',
-            table: 'c',
-            field: 'd.e.f'
-        });
-    });
-
     it('translate should encode and decode appropriately', () => {
         // Forward
         const MAPPING = { NAME: 'NM', AGE: 'A', ME: 'm' };

--- a/src/app/util/config.util.ts
+++ b/src/app/util/config.util.ts
@@ -29,19 +29,6 @@ export class ConfigUtil {
         '﹒': ' '
     };
 
-    /**
-     * Returns dotted reference in constituent parts(datastore.database.table.field).
-     */
-    static deconstructDottedReference(name: string) {
-        const [datastore, database, table, ...field] = (name || '').split('.');
-        return {
-            datastore: datastore || '',
-            database: database || '',
-            table: table || '',
-            field: field.join('.')
-        };
-    }
-
     static validateName(fileName: string): string {
         // Replace / with . and remove ../ and non-alphanumeric characters except ._-+=,
         return fileName.replace(/\.\.\//g, '').replace(/\//g, '.').replace(/[^A-Za-z0-9._\-+=,]/g, '');

--- a/src/app/util/dashboard.util.spec.ts
+++ b/src/app/util/dashboard.util.spec.ts
@@ -13,10 +13,7 @@
  * limitations under the License.
  */
 
-import {
-    NeonDatastoreConfig, NeonDatabaseMetaData, NeonFieldMetaData,
-    NeonTableMetaData
-} from '../models/types';
+import { NeonDatastoreConfig, NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../models/dataset';
 
 import { DashboardUtil } from './dashboard.util';
 
@@ -40,10 +37,6 @@ describe('Util: DashboardUtil', () => {
                         tables: {
                             table1: {
                                 prettyName: 'Table 1',
-                                mappings: {
-                                    mappingA: 'fieldA',
-                                    mappingB: 'fieldB'
-                                },
                                 labelOptions: {
                                     valueA: 'labelA',
                                     valueB: 'labelB'
@@ -76,10 +69,6 @@ describe('Util: DashboardUtil', () => {
             labelOptions: {
                 valueA: 'labelA',
                 valueB: 'labelB'
-            },
-            mappings: {
-                mappingA: 'fieldA',
-                mappingB: 'fieldB'
             }
         });
         let database1 = NeonDatabaseMetaData.get({
@@ -113,10 +102,6 @@ describe('Util: DashboardUtil', () => {
                         tables: {
                             table1: {
                                 prettyName: 'Table 1',
-                                mappings: {
-                                    mappingA: 'fieldA',
-                                    mappingB: 'fieldB'
-                                },
                                 labelOptions: {
                                     valueA: 'labelA',
                                     valueB: 'labelB'
@@ -146,10 +131,6 @@ describe('Util: DashboardUtil', () => {
                         tables: {
                             table2: {
                                 prettyName: 'Table 2',
-                                mappings: {
-                                    mappingC: 'fieldC',
-                                    mappingD: 'fieldD'
-                                },
                                 labelOptions: {
                                     valueC: 'labelC',
                                     valueD: 'labelD'
@@ -186,10 +167,6 @@ describe('Util: DashboardUtil', () => {
                                 valueA: 'labelA',
                                 valueB: 'labelB'
                             },
-                            mappings: {
-                                mappingA: 'fieldA',
-                                mappingB: 'fieldB'
-                            },
                             fields: [
                                 { columnName: 'fieldA', prettyName: 'Field A', hide: false, type: 'text' },
                                 { columnName: 'fieldB', prettyName: 'Field B', hide: true, type: 'date' }
@@ -214,10 +191,6 @@ describe('Util: DashboardUtil', () => {
                             labelOptions: {
                                 valueC: 'labelC',
                                 valueD: 'labelD'
-                            },
-                            mappings: {
-                                mappingC: 'fieldC',
-                                mappingD: 'fieldD'
                             },
                             fields: [
                                 { columnName: 'fieldC', prettyName: 'Field C', hide: false, type: 'text' },
@@ -245,10 +218,6 @@ describe('Util: DashboardUtil', () => {
                         tables: {
                             table1: {
                                 prettyName: 'Table 1',
-                                mappings: {
-                                    mappingA: 'fieldA',
-                                    mappingB: 'fieldB'
-                                },
                                 labelOptions: {
                                     valueA: 'labelA',
                                     valueB: 'labelB'
@@ -280,10 +249,6 @@ describe('Util: DashboardUtil', () => {
             valueA: 'labelA',
             valueB: 'labelB'
         };
-        table1.mappings = {
-            mappingA: 'fieldA',
-            mappingB: 'fieldB'
-        };
         let database1 = NeonDatabaseMetaData.get({ name: 'database1', prettyName: 'Database 1' });
         database1.tables = { [table1.name]: table1 };
         let datastore1 = NeonDatastoreConfig.get({ name: 'datastore1', host: 'host1', type: 'type1' });
@@ -300,10 +265,6 @@ describe('Util: DashboardUtil', () => {
         table1.labelOptions = {
             valueA: 'labelA',
             valueB: 'labelB'
-        };
-        table1.mappings = {
-            mappingA: 'fieldA',
-            mappingB: 'fieldB'
         };
         let database1 = NeonDatabaseMetaData.get({ name: 'database1', prettyName: 'Database 1' });
         database1.tables = { [table1.name]: table1 };
@@ -322,10 +283,6 @@ describe('Util: DashboardUtil', () => {
                         tables: {
                             table2: {
                                 prettyName: 'Table 2',
-                                mappings: {
-                                    mappingC: 'fieldC',
-                                    mappingD: 'fieldD'
-                                },
                                 labelOptions: {
                                     valueC: 'labelC',
                                     valueD: 'labelD'
@@ -357,10 +314,6 @@ describe('Util: DashboardUtil', () => {
             valueC: 'labelC',
             valueD: 'labelD'
         };
-        table2.mappings = {
-            mappingC: 'fieldC',
-            mappingD: 'fieldD'
-        };
         let database2 = NeonDatabaseMetaData.get({ name: 'database2', prettyName: 'Database 2' });
         database2.tables = { [table2.name]: table2 };
         let datastore2 = { name: 'datastore2', host: 'host2', type: 'type2', databases: {} };
@@ -377,10 +330,6 @@ describe('Util: DashboardUtil', () => {
         table1.labelOptions = {
             valueA: 'labelA',
             valueB: 'labelB'
-        };
-        table1.mappings = {
-            mappingA: 'fieldA',
-            mappingB: 'fieldB'
         };
         let database1 = NeonDatabaseMetaData.get({ name: 'database1', prettyName: 'Database 1' });
         database1.tables = { [table1.name]: table1 };
@@ -399,10 +348,6 @@ describe('Util: DashboardUtil', () => {
                         tables: {
                             table1: {
                                 prettyName: 'Table 1',
-                                mappings: {
-                                    mappingA: 'fieldA',
-                                    mappingB: 'fieldB'
-                                },
                                 labelOptions: {
                                     valueA: 'labelA',
                                     valueB: 'labelB'

--- a/src/app/util/dashboard.util.ts
+++ b/src/app/util/dashboard.util.ts
@@ -17,7 +17,7 @@ import * as _ from 'lodash';
 import { NeonDashboardConfig } from '../models/types';
 import { NeonDatastoreConfig, NeonDatabaseMetaData, NeonTableMetaData, NeonFieldMetaData } from '../models/dataset';
 import { ConfigUtil } from './config.util';
-import { DataUtil } from './data.util';
+import { DatasetUtil } from './dataset.util';
 
 /**
  * Common Utility functions for dashboards, specifically
@@ -82,14 +82,14 @@ export class DashboardUtil {
                     if (filter.tableKey) {
                         let tableKey = filter.tableKey;
 
-                        const { database, table } = DataUtil.deconstructDottedReference(leaf.tables[tableKey]);
+                        const { database, table } = DatasetUtil.deconstructDottedReference(leaf.tables[tableKey]);
 
                         filter.databaseName = database;
                         filter.tableName = table;
 
                         if (filter.fieldKey) {
                             let fieldKey = filter.fieldKey;
-                            const { field: fieldName } = DataUtil.deconstructDottedReference(leaf.fields[fieldKey]);
+                            const { field: fieldName } = DatasetUtil.deconstructDottedReference(leaf.fields[fieldKey]);
 
                             filter.fieldName = fieldName;
                         } else {
@@ -121,7 +121,7 @@ export class DashboardUtil {
                 const parent = path[path.length - 1];
 
                 for (const tableKey of tableKeys) {
-                    const { database } = DataUtil.deconstructDottedReference(leaf.tables[tableKey]);
+                    const { database } = DatasetUtil.deconstructDottedReference(leaf.tables[tableKey]);
 
                     if (database === invalidDatabaseName) {
                         delete parent.choices[leaf.name];

--- a/src/app/util/dashboard.util.ts
+++ b/src/app/util/dashboard.util.ts
@@ -14,11 +14,10 @@
  */
 import * as _ from 'lodash';
 
-import {
-    NeonDashboardConfig, NeonDatastoreConfig, NeonDatabaseMetaData,
-    NeonTableMetaData, NeonFieldMetaData
-} from '../models/types';
+import { NeonDashboardConfig } from '../models/types';
+import { NeonDatastoreConfig, NeonDatabaseMetaData, NeonTableMetaData, NeonFieldMetaData } from '../models/dataset';
 import { ConfigUtil } from './config.util';
+import { DataUtil } from './data.util';
 
 /**
  * Common Utility functions for dashboards, specifically
@@ -46,7 +45,6 @@ export class DashboardUtil {
             } else {
                 table.prettyName = table.prettyName || table.name;
                 table.fields = table.fields || [];
-                table.mappings = table.mappings || {};
                 table.labelOptions = table.labelOptions || {};
                 DashboardUtil.validateFields(table);
             }
@@ -84,14 +82,14 @@ export class DashboardUtil {
                     if (filter.tableKey) {
                         let tableKey = filter.tableKey;
 
-                        const { database, table } = ConfigUtil.deconstructDottedReference(leaf.tables[tableKey]);
+                        const { database, table } = DataUtil.deconstructDottedReference(leaf.tables[tableKey]);
 
                         filter.databaseName = database;
                         filter.tableName = table;
 
                         if (filter.fieldKey) {
                             let fieldKey = filter.fieldKey;
-                            const { field: fieldName } = ConfigUtil.deconstructDottedReference(leaf.fields[fieldKey]);
+                            const { field: fieldName } = DataUtil.deconstructDottedReference(leaf.fields[fieldKey]);
 
                             filter.fieldName = fieldName;
                         } else {
@@ -123,7 +121,7 @@ export class DashboardUtil {
                 const parent = path[path.length - 1];
 
                 for (const tableKey of tableKeys) {
-                    const { database } = ConfigUtil.deconstructDottedReference(leaf.tables[tableKey]);
+                    const { database } = DataUtil.deconstructDottedReference(leaf.tables[tableKey]);
 
                     if (database === invalidDatabaseName) {
                         delete parent.choices[leaf.name];
@@ -170,7 +168,6 @@ export class DashboardUtil {
 
                     // Create copies to maintain original config data.
                     outputTable.labelOptions = _.cloneDeep(configTable.labelOptions);
-                    outputTable.mappings = _.cloneDeep(configTable.mappings);
 
                     acc[outputTable.name] = outputTable;
 

--- a/src/app/util/data.util.spec.ts
+++ b/src/app/util/data.util.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2019 Next Century Corporation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DataUtil } from './data.util';
+
+describe('Data Util Tests', () => {
+    it('deconstructDotted should work appropriately', () => {
+        expect(DataUtil.deconstructDottedReference('')).toEqual({
+            datastore: '',
+            database: '',
+            table: '',
+            field: ''
+        });
+
+        expect(DataUtil.deconstructDottedReference('a.b')).toEqual({
+            datastore: 'a',
+            database: 'b',
+            table: '',
+            field: ''
+        });
+
+        expect(DataUtil.deconstructDottedReference('...b')).toEqual({
+            datastore: '',
+            database: '',
+            table: '',
+            field: 'b'
+        });
+
+        expect(DataUtil.deconstructDottedReference('a.b.c.d.e.f')).toEqual({
+            datastore: 'a',
+            database: 'b',
+            table: 'c',
+            field: 'd.e.f'
+        });
+    });
+});

--- a/src/app/util/data.util.ts
+++ b/src/app/util/data.util.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2019 Next Century Corporation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class DataUtil {
+    /**
+     * Returns dotted reference in constituent parts(datastore.database.table.field).
+     */
+    static deconstructDottedReference(name: string): { datastore: string, database: string, table: string, field: string } {
+        const [datastore, database, table, ...field] = (name || '').split('.');
+        return {
+            datastore: datastore || '',
+            database: database || '',
+            table: table || '',
+            field: field.join('.')
+        };
+    }
+
+    /**
+     * Returns the datastore/database/table for the given table key.
+     */
+    static deconstructTableName(
+        tableKeys: Record<string, string>,
+        tableKey: string
+    ): { datastore: string, database: string, table: string, field: string } {
+        return DataUtil.deconstructDottedReference(tableKeys[tableKey] || tableKey);
+    }
+
+    /**
+     * Returns the datastore/database/table/field for the given field key.
+     */
+    static deconstructFieldName(
+        fieldKeys: Record<string, string>,
+        fieldKey: string
+    ): { datastore: string, database: string, table: string, field: string } {
+        return DataUtil.deconstructDottedReference(fieldKeys[fieldKey] || fieldKey);
+    }
+
+    /**
+     * Returns the field for the given field key.
+     */
+    static translateFieldKeyToValue(fieldKeys: Record<string, string>, fieldKey: string): string {
+        return DataUtil.deconstructFieldName(fieldKeys, fieldKey).field || fieldKey;
+    }
+}

--- a/src/app/util/dataset.util.spec.ts
+++ b/src/app/util/dataset.util.spec.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DatasetUtil } from './data.util';
+import { DatasetUtil } from './dataset.util';
 
 describe('Dataset Util Tests', () => {
     it('deconstructDotted should work appropriately', () => {

--- a/src/app/util/dataset.util.spec.ts
+++ b/src/app/util/dataset.util.spec.ts
@@ -12,32 +12,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DataUtil } from './data.util';
+import { DatasetUtil } from './data.util';
 
-describe('Data Util Tests', () => {
+describe('Dataset Util Tests', () => {
     it('deconstructDotted should work appropriately', () => {
-        expect(DataUtil.deconstructDottedReference('')).toEqual({
+        expect(DatasetUtil.deconstructDottedReference('')).toEqual({
             datastore: '',
             database: '',
             table: '',
             field: ''
         });
 
-        expect(DataUtil.deconstructDottedReference('a.b')).toEqual({
+        expect(DatasetUtil.deconstructDottedReference('a.b')).toEqual({
             datastore: 'a',
             database: 'b',
             table: '',
             field: ''
         });
 
-        expect(DataUtil.deconstructDottedReference('...b')).toEqual({
+        expect(DatasetUtil.deconstructDottedReference('...b')).toEqual({
             datastore: '',
             database: '',
             table: '',
             field: 'b'
         });
 
-        expect(DataUtil.deconstructDottedReference('a.b.c.d.e.f')).toEqual({
+        expect(DatasetUtil.deconstructDottedReference('a.b.c.d.e.f')).toEqual({
             datastore: 'a',
             database: 'b',
             table: 'c',

--- a/src/app/util/dataset.util.ts
+++ b/src/app/util/dataset.util.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-export class DataUtil {
+export class DatasetUtil {
     /**
      * Returns dotted reference in constituent parts(datastore.database.table.field).
      */
@@ -34,7 +34,7 @@ export class DataUtil {
         tableKeys: Record<string, string>,
         tableKey: string
     ): { datastore: string, database: string, table: string, field: string } {
-        return DataUtil.deconstructDottedReference(tableKeys[tableKey] || tableKey);
+        return DatasetUtil.deconstructDottedReference(tableKeys[tableKey] || tableKey);
     }
 
     /**
@@ -44,13 +44,13 @@ export class DataUtil {
         fieldKeys: Record<string, string>,
         fieldKey: string
     ): { datastore: string, database: string, table: string, field: string } {
-        return DataUtil.deconstructDottedReference(fieldKeys[fieldKey] || fieldKey);
+        return DatasetUtil.deconstructDottedReference(fieldKeys[fieldKey] || fieldKey);
     }
 
     /**
      * Returns the field for the given field key.
      */
     static translateFieldKeyToValue(fieldKeys: Record<string, string>, fieldKey: string): string {
-        return DataUtil.deconstructFieldName(fieldKeys, fieldKey).field || fieldKey;
+        return DatasetUtil.deconstructFieldName(fieldKeys, fieldKey).field || fieldKey;
     }
 }

--- a/src/testUtils/MockServices/DashboardServiceMock.ts
+++ b/src/testUtils/MockServices/DashboardServiceMock.ts
@@ -12,16 +12,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-    NeonDatastoreConfig,
-    NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData, NeonDashboardLeafConfig
-} from '../../app/models/types';
+import { NeonDashboardLeafConfig } from '../../app/models/types';
+import { NeonDatastoreConfig, NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../app/models/dataset';
 import { DashboardService } from '../../app/services/dashboard.service';
 import { ConfigService } from '../../app/services/config.service';
 import { ConnectionService } from '../../app/services/connection.service';
 import { Injectable } from '@angular/core';
 import { FilterService } from '../../app/services/filter.service';
 import { SearchServiceMock } from './SearchServiceMock';
+import {
+    DATABASES,
+    DATABASES_LIST,
+    DATASTORE,
+    FIELD_KEYS,
+    FIELD_MAP,
+    FIELDS,
+    TABLE_KEYS,
+    TABLES,
+    TABLES_LIST
+} from '../mock-dataset';
 
 export class MockConnectionService extends ConnectionService {
     public connect(__datastoreType: string, __datastoreHost: string) {
@@ -31,72 +40,23 @@ export class MockConnectionService extends ConnectionService {
 
 @Injectable()
 export class DashboardServiceMock extends DashboardService {
-    public static FIELD_MAP = {
-        CATEGORY: NeonFieldMetaData.get({ columnName: 'testCategoryField', prettyName: 'Test Category Field', type: 'string' }),
-        DATE: NeonFieldMetaData.get({ columnName: 'testDateField', prettyName: 'Test Date Field', type: 'date' }),
-        FIELD_KEY: NeonFieldMetaData.get({ columnName: 'testFieldKeyField', prettyName: 'Test Field Key Field', type: 'string' }),
-        FILTER: NeonFieldMetaData.get({ columnName: 'testFilterField', prettyName: 'Test Filter Field', type: 'string' }),
-        ID: NeonFieldMetaData.get({ columnName: 'testIdField', prettyName: 'Test ID Field', type: 'string' }),
-        LINK: NeonFieldMetaData.get({ columnName: 'testLinkField', prettyName: 'Test Link Field', type: 'string' }),
-        NAME: NeonFieldMetaData.get({ columnName: 'testNameField', prettyName: 'Test Name Field', type: 'string' }),
-        RELATION_A: NeonFieldMetaData.get({ columnName: 'testRelationFieldA', prettyName: 'Test Relation Field A', type: 'string' }),
-        RELATION_B: NeonFieldMetaData.get({ columnName: 'testRelationFieldB', prettyName: 'Test Relation Field B', type: 'string' }),
-        SIZE: NeonFieldMetaData.get({ columnName: 'testSizeField', prettyName: 'Test Size Field', type: 'float' }),
-        SORT: NeonFieldMetaData.get({ columnName: 'testSortField', prettyName: 'Test Sort Field', type: 'string' }),
-        TEXT: NeonFieldMetaData.get({ columnName: 'testTextField', prettyName: 'Test Text Field', type: 'string' }),
-        TYPE: NeonFieldMetaData.get({ columnName: 'testTypeField', prettyName: 'Test Type Field', type: 'string' }),
-        X: NeonFieldMetaData.get({ columnName: 'testXField', prettyName: 'Test X Field', type: 'float' }),
-        Y: NeonFieldMetaData.get({ columnName: 'testYField', prettyName: 'Test Y Field', type: 'float' }),
-        ES_ID: NeonFieldMetaData.get({ columnName: '_id', prettyName: '_id' })
-    };
-
-    // Keep in alphabetical order.
-    public static FIELDS: NeonFieldMetaData[] = Object.values(DashboardServiceMock.FIELD_MAP);
-
-    public static TABLES = {
-        testTable1: NeonTableMetaData.get({ name: 'testTable1', prettyName: 'Test Table 1', fields: DashboardServiceMock.FIELDS }),
-        testTable2: NeonTableMetaData.get({ name: 'testTable2', prettyName: 'Test Table 2', fields: DashboardServiceMock.FIELDS })
-    };
-
-    public static TABLES_LIST = [DashboardServiceMock.TABLES.testTable1, DashboardServiceMock.TABLES.testTable2];
-
-    public static DATABASES = {
-        testDatabase1: NeonDatabaseMetaData.get({
-            name: 'testDatabase1',
-            prettyName: 'Test Database 1',
-            tables: DashboardServiceMock.TABLES
-        }),
-        testDatabase2: NeonDatabaseMetaData.get({
-            name: 'testDatabase2',
-            prettyName: 'Test Database 2',
-            tables: DashboardServiceMock.TABLES
-        })
-    };
-
-    public static DATABASES_LIST = [DashboardServiceMock.DATABASES.testDatabase1, DashboardServiceMock.DATABASES.testDatabase2];
+    public static FIELD_MAP = FIELD_MAP;
+    public static FIELDS = FIELDS;
+    public static TABLES = TABLES;
+    public static TABLES_LIST = TABLES_LIST;
+    public static DATABASES = DATABASES;
+    public static DATABASES_LIST = DATABASES_LIST;
 
     static init(svc: DashboardServiceMock) {
-        const datastore = NeonDatastoreConfig.get({
-            name: 'datastore1',
-            host: 'testHostname',
-            type: 'testDatastore',
-            databases: DashboardServiceMock.DATABASES,
-            hasUpdatedFields: true
-        });
+        const datastore = DATASTORE;
 
         svc.setActiveDatastore(datastore);
 
         const dashboard = NeonDashboardLeafConfig.get({
             name: 'Test Discovery Config',
             layout: 'DISCOVERY',
-
-            tables: {
-                table_key_1: 'datastore1.testDatabase1.testTable1',
-                table_key_2: 'datastore1.testDatabase2.testTable2'
-            },
-            fields: {
-                field_key_1: 'datastore1.testDatabase1.testTable1.testFieldKeyField'
-            },
+            tables: TABLE_KEYS,
+            fields: FIELD_KEYS,
             visualizationTitles: {
                 dataTableTitle: 'Documents'
             },

--- a/src/testUtils/mock-dataset.ts
+++ b/src/testUtils/mock-dataset.ts
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2019 Next Century Corporation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Dataset,
+    NeonDatastoreConfig,
+    NeonDatabaseMetaData,
+    NeonFieldMetaData,
+    NeonTableMetaData,
+    SingleField
+} from '../app/models/dataset';
+
+export const FIELD_MAP = {
+    CATEGORY: NeonFieldMetaData.get({ columnName: 'testCategoryField', prettyName: 'Test Category Field', type: 'string' }),
+    DATE: NeonFieldMetaData.get({ columnName: 'testDateField', prettyName: 'Test Date Field', type: 'date' }),
+    FIELD_KEY: NeonFieldMetaData.get({ columnName: 'testFieldKeyField', prettyName: 'Test Field Key Field', type: 'string' }),
+    FILTER: NeonFieldMetaData.get({ columnName: 'testFilterField', prettyName: 'Test Filter Field', type: 'string' }),
+    ID: NeonFieldMetaData.get({ columnName: 'testIdField', prettyName: 'Test ID Field', type: 'string' }),
+    LINK: NeonFieldMetaData.get({ columnName: 'testLinkField', prettyName: 'Test Link Field', type: 'string' }),
+    NAME: NeonFieldMetaData.get({ columnName: 'testNameField', prettyName: 'Test Name Field', type: 'string' }),
+    RELATION_A: NeonFieldMetaData.get({ columnName: 'testRelationFieldA', prettyName: 'Test Relation Field A', type: 'string' }),
+    RELATION_B: NeonFieldMetaData.get({ columnName: 'testRelationFieldB', prettyName: 'Test Relation Field B', type: 'string' }),
+    SIZE: NeonFieldMetaData.get({ columnName: 'testSizeField', prettyName: 'Test Size Field', type: 'float' }),
+    SORT: NeonFieldMetaData.get({ columnName: 'testSortField', prettyName: 'Test Sort Field', type: 'string' }),
+    TEXT: NeonFieldMetaData.get({ columnName: 'testTextField', prettyName: 'Test Text Field', type: 'string' }),
+    TYPE: NeonFieldMetaData.get({ columnName: 'testTypeField', prettyName: 'Test Type Field', type: 'string' }),
+    X: NeonFieldMetaData.get({ columnName: 'testXField', prettyName: 'Test X Field', type: 'float' }),
+    Y: NeonFieldMetaData.get({ columnName: 'testYField', prettyName: 'Test Y Field', type: 'float' }),
+    ES_ID: NeonFieldMetaData.get({ columnName: '_id', prettyName: '_id' })
+};
+
+// Keep in alphabetical order.
+export const FIELDS: NeonFieldMetaData[] = Object.values(FIELD_MAP);
+
+export const TABLES = {
+    testTable1: NeonTableMetaData.get({ name: 'testTable1', prettyName: 'Test Table 1', fields: FIELDS }),
+    testTable2: NeonTableMetaData.get({ name: 'testTable2', prettyName: 'Test Table 2', fields: FIELDS })
+};
+
+export const TABLES_LIST = [TABLES.testTable1, TABLES.testTable2];
+
+export const DATABASES = {
+    testDatabase1: NeonDatabaseMetaData.get({
+        name: 'testDatabase1',
+        prettyName: 'Test Database 1',
+        tables: TABLES
+    }),
+    testDatabase2: NeonDatabaseMetaData.get({
+        name: 'testDatabase2',
+        prettyName: 'Test Database 2',
+        tables: TABLES
+    })
+};
+
+export const DATABASES_LIST = [DATABASES.testDatabase1, DATABASES.testDatabase2];
+
+export const DATASTORE: NeonDatastoreConfig = NeonDatastoreConfig.get({
+    name: 'datastore1',
+    host: 'testHostname',
+    type: 'testDatastore',
+    databases: DATABASES,
+    hasUpdatedFields: true
+});
+
+export const TABLE_KEYS: Record<string, string> = {
+    table_key_1: 'datastore1.testDatabase1.testTable1',
+    table_key_2: 'datastore1.testDatabase2.testTable2'
+};
+
+export const FIELD_KEYS: Record<string, string> = {
+    field_key_1: 'datastore1.testDatabase1.testTable1.testFieldKeyField'
+};
+
+export const DATASET: Dataset = {
+    datastores: [DATASTORE],
+    tableKeys: TABLE_KEYS,
+    fieldKeys: FIELD_KEYS,
+    relations: [
+        [
+            [
+                {
+                    datastore: 'datastore1',
+                    database: DATABASES.testDatabase1,
+                    table: TABLES.testTable1,
+                    field: FIELD_MAP.RELATION_A
+                } as SingleField
+            ],
+            [
+                {
+                    datastore: 'datastore1',
+                    database: DATABASES.testDatabase2,
+                    table: TABLES.testTable2,
+                    field: FIELD_MAP.RELATION_A
+                } as SingleField
+            ]
+        ],
+        [
+            [
+                {
+                    datastore: 'datastore1',
+                    database: DATABASES.testDatabase1,
+                    table: TABLES.testTable1,
+                    field: FIELD_MAP.RELATION_B
+                } as SingleField
+            ],
+            [
+                {
+                    datastore: 'datastore1',
+                    database: DATABASES.testDatabase2,
+                    table: TABLES.testTable2,
+                    field: FIELD_MAP.RELATION_B
+                } as SingleField
+            ]
+        ]
+    ]
+} as Dataset;
+


### PR DESCRIPTION
Goals:
- Remove dependencies on the dashboard configuration (DashboardState and ConfigUtil) from the OptionCollection classes.
- Remove data-specific dependencies on DashboardState from BaseNeonComponent (though non-data-specific dependencies remain, such as with the visualization titles or contributors).

Results:
- Created a Dataset class containing the dataset-specific metadata:  datastores/databases/tables/fields, table/field keys, and relations.
- Moved the datastore/database/table/field metadata interfaces from the "types" file to the "dataset" file.
- Created the DataUtil with deconstructDottedReference (moved from ConfigUtil), deconstructTableName, deconstructFieldName, and translateFieldKeyToValue.
- Created a mock-dataset with test datastores/databases/tables/fields (moved from DashboardServiceMock).
- Updated the BaseNeonComponent and OptionCollection classes.
- Updated imports.