### PR TITLE
THOR-1269 Created Injectable Service Classes

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,8 +20,7 @@ import { CommonModule } from '@angular/common';
 import { AbstractSearchService } from './services/abstract.search.service';
 import { InjectableColorThemeService } from './services/injectable.color-theme.service';
 import { DashboardService } from './services/dashboard.service';
-import { FilterService } from './services/filter.service';
-import { PropertyService } from './services/property.service';
+import { InjectableFilterService } from './services/injectable.filter.service';
 import { SearchService } from './services/search.service';
 
 import { AppComponent } from './app.component';
@@ -47,15 +46,14 @@ import { DynamicDialogComponent } from './components/dynamic-dialog/dynamic-dial
         AppLazyModule
     ],
     providers: [
-        DashboardService,
-        FilterService,
-        PropertyService,
         ConfigService,
+        DashboardService,
+        InjectableColorThemeService,
+        InjectableFilterService,
         {
             provide: AbstractSearchService,
             useClass: SearchService
-        },
-        InjectableColorThemeService
+        }
     ],
     entryComponents: [AppComponent, DynamicDialogComponent],
     bootstrap: [AppComponent]

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,12 +18,11 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CommonModule } from '@angular/common';
 
 import { AbstractSearchService } from './services/abstract.search.service';
-import { AbstractColorThemeService } from './services/abstract.color-theme.service';
+import { InjectableColorThemeService } from './services/injectable.color-theme.service';
 import { DashboardService } from './services/dashboard.service';
 import { FilterService } from './services/filter.service';
 import { PropertyService } from './services/property.service';
 import { SearchService } from './services/search.service';
-import { ColorThemeService } from './services/color-theme.service';
 
 import { AppComponent } from './app.component';
 
@@ -56,10 +55,7 @@ import { DynamicDialogComponent } from './components/dynamic-dialog/dynamic-dial
             provide: AbstractSearchService,
             useClass: SearchService
         },
-        {
-            provide: AbstractColorThemeService,
-            useClass: ColorThemeService
-        }
+        InjectableColorThemeService
     ],
     entryComponents: [AppComponent, DynamicDialogComponent],
     bootstrap: [AppComponent]

--- a/src/app/components/add-visualization/add-visualization.component.spec.ts
+++ b/src/app/components/add-visualization/add-visualization.component.spec.ts
@@ -20,7 +20,7 @@ import { AddVisualizationComponent } from './add-visualization.component';
 import { AddVisualizationModule } from './add-visualization.module';
 
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
@@ -33,7 +33,7 @@ describe('Component: AddVisualization', () => {
     initializeTestBed('Add Visualization', {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService
+            InjectableFilterService
         ],
         imports: [
             MatDividerModule,

--- a/src/app/components/aggregation/aggregation.component.spec.ts
+++ b/src/app/components/aggregation/aggregation.component.spec.ts
@@ -27,7 +27,8 @@ import { AbstractSearchService, CompoundFilterType } from '../../services/abstra
 import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { AggregationType } from '../../models/widget-option';
 import { DashboardService } from '../../services/dashboard.service';
-import { CompoundFilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
+import { CompoundFilterDesign, SimpleFilterDesign } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { Color } from '../../models/color';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
@@ -46,7 +47,7 @@ describe('Component: Aggregation', () => {
         providers: [
             InjectableColorThemeService,
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector
         ],
@@ -3961,7 +3962,7 @@ describe('Component: Aggregation with config', () => {
         providers: [
             InjectableColorThemeService,
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector,
             { provide: 'tableKey', useValue: 'table_key_2' },
@@ -4062,7 +4063,7 @@ describe('Component: Aggregation with XY config', () => {
         providers: [
             InjectableColorThemeService,
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector,
             { provide: 'tableKey', useValue: 'table_key_2' },
@@ -4163,7 +4164,7 @@ describe('Component: Aggregation with date config', () => {
         providers: [
             InjectableColorThemeService,
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector,
             { provide: 'tableKey', useValue: 'table_key_2' },

--- a/src/app/components/aggregation/aggregation.component.spec.ts
+++ b/src/app/components/aggregation/aggregation.component.spec.ts
@@ -24,11 +24,10 @@ import { ChartJsLineSubcomponent } from './subcomponent.chartjs.line';
 import { ChartJsScatterSubcomponent } from './subcomponent.chartjs.scatter';
 
 import { AbstractSearchService, CompoundFilterType } from '../../services/abstract.search.service';
-import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
+import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { AggregationType } from '../../models/widget-option';
 import { DashboardService } from '../../services/dashboard.service';
 import { CompoundFilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
-import { ColorThemeService } from '../../services/color-theme.service';
 
 import { Color } from '../../models/color';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
@@ -45,7 +44,7 @@ describe('Component: Aggregation', () => {
 
     initializeTestBed('Aggregation', {
         providers: [
-            { provide: AbstractColorThemeService, useClass: ColorThemeService },
+            InjectableColorThemeService,
             { provide: DashboardService, useClass: DashboardServiceMock },
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
@@ -3960,7 +3959,7 @@ describe('Component: Aggregation with config', () => {
 
     initializeTestBed('Aggregation', {
         providers: [
-            { provide: AbstractColorThemeService, useClass: ColorThemeService },
+            InjectableColorThemeService,
             { provide: DashboardService, useClass: DashboardServiceMock },
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
@@ -4061,7 +4060,7 @@ describe('Component: Aggregation with XY config', () => {
 
     initializeTestBed('Aggregation', {
         providers: [
-            { provide: AbstractColorThemeService, useClass: ColorThemeService },
+            InjectableColorThemeService,
             { provide: DashboardService, useClass: DashboardServiceMock },
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
@@ -4162,7 +4161,7 @@ describe('Component: Aggregation with date config', () => {
 
     initializeTestBed('Aggregation', {
         providers: [
-            { provide: AbstractColorThemeService, useClass: ColorThemeService },
+            InjectableColorThemeService,
             { provide: DashboardService, useClass: DashboardServiceMock },
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },

--- a/src/app/components/aggregation/aggregation.component.ts
+++ b/src/app/components/aggregation/aggregation.component.ts
@@ -36,7 +36,7 @@ import {
     SortOrder,
     TimeInterval
 } from '../../services/abstract.search.service';
-import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
+import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import {
     CompoundFilterDesign,
@@ -188,7 +188,7 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
         injector: Injector,
         ref: ChangeDetectorRef,
         dialog: MatDialog,
-        protected colorThemeService: AbstractColorThemeService,
+        protected colorThemeService: InjectableColorThemeService,
         public visualization: ElementRef
     ) {
         super(

--- a/src/app/components/aggregation/aggregation.component.ts
+++ b/src/app/components/aggregation/aggregation.component.ts
@@ -42,10 +42,10 @@ import {
     CompoundFilterDesign,
     FilterBehavior,
     FilterDesign,
-    FilterService,
     FilterUtil,
     SimpleFilterDesign
 } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import {
     AbstractAggregationSubcomponent,
@@ -183,7 +183,7 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
 
     constructor(
         dashboardService: DashboardService,
-        filterService: FilterService,
+        filterService: InjectableFilterService,
         searchService: AbstractSearchService,
         injector: Injector,
         ref: ChangeDetectorRef,

--- a/src/app/components/annotation-viewer/annotation-viewer.component.spec.ts
+++ b/src/app/components/annotation-viewer/annotation-viewer.component.spec.ts
@@ -22,7 +22,7 @@ import { AnnotationViewerComponent } from './annotation-viewer.component';
 import { AbstractSearchService } from '../../services/abstract.search.service';
 import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';
@@ -39,7 +39,7 @@ describe('Component: AnnotationViewer', () => {
         providers: [
             InjectableColorThemeService,
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector
         ],

--- a/src/app/components/annotation-viewer/annotation-viewer.component.spec.ts
+++ b/src/app/components/annotation-viewer/annotation-viewer.component.spec.ts
@@ -20,10 +20,9 @@ import { } from 'jasmine-core';
 import { AnnotationViewerComponent } from './annotation-viewer.component';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
-import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
+import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterService } from '../../services/filter.service';
-import { ColorThemeService } from '../../services/color-theme.service';
 
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';
@@ -38,7 +37,7 @@ describe('Component: AnnotationViewer', () => {
 
     initializeTestBed('Annotation Viewer', {
         providers: [
-            { provide: AbstractColorThemeService, useClass: ColorThemeService },
+            InjectableColorThemeService,
             { provide: DashboardService, useClass: DashboardServiceMock },
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },

--- a/src/app/components/annotation-viewer/annotation-viewer.component.ts
+++ b/src/app/components/annotation-viewer/annotation-viewer.component.ts
@@ -25,7 +25,7 @@ import {
 } from '@angular/core';
 
 import { AbstractSearchService, FilterClause, QueryPayload } from '../../services/abstract.search.service';
-import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
+import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterBehavior, FilterDesign, FilterService } from '../../services/filter.service';
 
@@ -107,7 +107,7 @@ export class AnnotationViewerComponent extends BaseNeonComponent implements OnIn
     public offset = 0;
 
     constructor(
-        protected colorThemeService: AbstractColorThemeService,
+        protected colorThemeService: InjectableColorThemeService,
         dashboardService: DashboardService,
         filterService: FilterService,
         searchService: AbstractSearchService,

--- a/src/app/components/annotation-viewer/annotation-viewer.component.ts
+++ b/src/app/components/annotation-viewer/annotation-viewer.component.ts
@@ -27,7 +27,8 @@ import {
 import { AbstractSearchService, FilterClause, QueryPayload } from '../../services/abstract.search.service';
 import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterBehavior, FilterDesign, FilterService } from '../../services/filter.service';
+import { FilterBehavior, FilterDesign } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
 import { NeonFieldMetaData } from '../../models/dataset';
@@ -109,7 +110,7 @@ export class AnnotationViewerComponent extends BaseNeonComponent implements OnIn
     constructor(
         protected colorThemeService: InjectableColorThemeService,
         dashboardService: DashboardService,
-        filterService: FilterService,
+        filterService: InjectableFilterService,
         searchService: AbstractSearchService,
         injector: Injector,
         ref: ChangeDetectorRef,

--- a/src/app/components/base-neon-component/base-neon.component.spec.ts
+++ b/src/app/components/base-neon-component/base-neon.component.spec.ts
@@ -28,7 +28,8 @@ import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterBehavior, FilterService } from '../../services/filter.service';
+import { FilterBehavior } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NeonConfig } from '../../models/types';
@@ -69,7 +70,7 @@ class TestBaseNeonComponent extends BaseNeonComponent implements OnInit, OnDestr
     /* eslint-disable-next-line @typescript-eslint/no-useless-constructor */
     constructor(
         dashboardService: DashboardService,
-        filterService: FilterService,
+        filterService: InjectableFilterService,
         searchService: AbstractSearchService,
         injector: Injector,
         changeDetection: ChangeDetectorRef,
@@ -182,7 +183,7 @@ describe('BaseNeonComponent', () => {
         ],
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector,
             { provide: ConfigService, useValue: getConfigService(testConfig) },
@@ -1818,7 +1819,7 @@ describe('Advanced BaseNeonComponent with config', () => {
         ],
         providers: [
             { provide: DashboardService, useValue: dashboardService },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector,
             { provide: ConfigService, useValue: getConfigService(testConfig) },

--- a/src/app/components/base-neon-component/base-neon.component.ts
+++ b/src/app/components/base-neon-component/base-neon.component.ts
@@ -24,9 +24,9 @@ import {
     FilterBehavior,
     FilterCollection,
     FilterDataSource,
-    FilterDesign,
-    FilterService
+    FilterDesign
 } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 import { Dataset, NeonFieldMetaData } from '../../models/dataset';
 import { neonEvents } from '../../models/neon-namespaces';
 import {
@@ -103,7 +103,7 @@ export abstract class BaseNeonComponent implements AfterViewInit, OnInit, OnDest
 
     constructor(
         protected dashboardService: DashboardService,
-        protected filterService: FilterService,
+        protected filterService: InjectableFilterService,
         protected searchService: AbstractSearchService,
         protected injector: Injector,
         public changeDetection: ChangeDetectorRef,

--- a/src/app/components/contribution-dialog/contribution-dialog.component.spec.ts
+++ b/src/app/components/contribution-dialog/contribution-dialog.component.spec.ts
@@ -18,7 +18,7 @@ import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
 import { ContributionDialogModule } from './contribution-dialog.module';
 
 import { ContributionDialogComponent } from './contribution-dialog.component';
-import { FilterService } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 
@@ -28,7 +28,7 @@ describe('Component: ContributionDialogComponent', () => {
 
     initializeTestBed('ContributionDialogComponent', {
         providers: [
-            FilterService,
+            InjectableFilterService,
             DashboardService,
             { provide: MatDialogRef, useValue: {} },
             { provide: MAT_DIALOG_DATA, useValue: [] }

--- a/src/app/components/current-filters/current-filters.component.spec.ts
+++ b/src/app/components/current-filters/current-filters.component.spec.ts
@@ -19,7 +19,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CurrentFiltersComponent, FilterDisplayUtil } from './current-filters.component';
 
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService, SimpleFilter, CompoundFilter, AbstractFilter } from '../../services/filter.service';
+import { SimpleFilter, CompoundFilter, AbstractFilter } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 
@@ -69,7 +70,7 @@ describe('Component: CurrentFiltersComponent', () => {
     initializeTestBed('Current Filters', {
         providers: [
             DashboardService,
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock }
         ],
         imports: [CurrentFiltersModule]

--- a/src/app/components/current-filters/current-filters.component.ts
+++ b/src/app/components/current-filters/current-filters.component.ts
@@ -16,7 +16,8 @@ import { Component, OnInit, OnDestroy, HostBinding } from '@angular/core';
 import { neonEvents } from '../../models/neon-namespaces';
 
 import { CompoundFilterType } from '../../services/abstract.search.service';
-import { FilterDesign, FilterService, AbstractFilter, SimpleFilter, CompoundFilter } from '../../services/filter.service';
+import { FilterDesign, AbstractFilter, SimpleFilter, CompoundFilter } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import * as moment from 'moment';
 
@@ -131,7 +132,7 @@ export class CurrentFiltersComponent implements OnInit, OnDestroy {
     public groups: FilterGroup[] = [];
 
     constructor(
-        public filterService: FilterService,
+        public filterService: InjectableFilterService,
         public dashboardService: DashboardService
     ) {
         this.messenger = new eventing.Messenger();

--- a/src/app/components/custom-connection/custom-connection.component.ts
+++ b/src/app/components/custom-connection/custom-connection.component.ts
@@ -15,7 +15,7 @@
 import { Component, EventEmitter, Output, QueryList, ViewChildren, AfterContentInit } from '@angular/core';
 import { AbstractSearchService } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { CustomConnectionStep } from './custom-connection-step';
 import { CustomConnectionData } from './custom-connection-data';
@@ -41,7 +41,7 @@ export class CustomConnectionComponent implements AfterContentInit {
 
     constructor(
         private datasetService: DashboardService,
-        private filterService: FilterService,
+        private filterService: InjectableFilterService,
         private searchService: AbstractSearchService
     ) {
         this.messenger = new eventing.Messenger();

--- a/src/app/components/custom-connection/simple-setup.component.ts
+++ b/src/app/components/custom-connection/simple-setup.component.ts
@@ -18,7 +18,8 @@ import { DashboardService } from '../../services/dashboard.service';
 
 import { CustomConnectionStep } from './custom-connection-step';
 import { NeonDatabaseMetaData, NeonTableMetaData, NeonFieldMetaData } from '../../models/dataset';
-import { ConnectionService, Connection } from '../../services/connection.service';
+import { Connection } from '../../services/connection.service';
+import { InjectableConnectionService } from '../../services/injectable.connection.service';
 
 // TODO It's likely worth removing the extends here. I don't do it now just in case we do want to add steps as we iterate.
 
@@ -54,7 +55,7 @@ export class CustomConnectionSimpleSetupStepComponent extends CustomConnectionSt
         }[];
     }[];
 
-    constructor(private datasetService: DashboardService, private connectionService: ConnectionService) {
+    constructor(private datasetService: DashboardService, private connectionService: InjectableConnectionService) {
         super();
         this.selected = true;
         this.stepNumber = 1;

--- a/src/app/components/data-table/data-table.component.spec.ts
+++ b/src/app/components/data-table/data-table.component.spec.ts
@@ -21,7 +21,7 @@ import { DataTableComponent } from './data-table.component';
 
 import { AbstractSearchService, CompoundFilterType } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';
@@ -39,7 +39,7 @@ describe('Component: DataTable', () => {
     initializeTestBed('Data Table', {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector
         ],

--- a/src/app/components/data-table/data-table.component.ts
+++ b/src/app/components/data-table/data-table.component.ts
@@ -27,7 +27,8 @@ import {
 
 import { AbstractSearchService, CompoundFilterType, FilterClause, QueryPayload, SortOrder } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { CompoundFilterDesign, FilterBehavior, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
+import { CompoundFilterDesign, FilterBehavior, FilterDesign, SimpleFilterDesign } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
 import { NeonFieldMetaData } from '../../models/dataset';
@@ -90,7 +91,7 @@ export class DataTableComponent extends BaseNeonComponent implements OnInit, OnD
 
     constructor(
         dashboardService: DashboardService,
-        filterService: FilterService,
+        filterService: InjectableFilterService,
         searchService: AbstractSearchService,
         injector: Injector,
         ref: ChangeDetectorRef,

--- a/src/app/components/document-viewer/document-viewer.component.spec.ts
+++ b/src/app/components/document-viewer/document-viewer.component.spec.ts
@@ -21,7 +21,7 @@ import { DocumentViewerComponent } from './document-viewer.component';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';
@@ -40,7 +40,7 @@ describe('Component: DocumentViewer', () => {
                 provide: DashboardService,
                 useClass: DashboardServiceMock
             },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector
         ],
@@ -879,7 +879,7 @@ describe('Component: Document Viewer with Config', () => {
     initializeTestBed('Document Viewer', {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector,
             { provide: 'title', useValue: 'Document Viewer Title' },

--- a/src/app/components/document-viewer/document-viewer.component.ts
+++ b/src/app/components/document-viewer/document-viewer.component.ts
@@ -27,7 +27,8 @@ import {
 
 import { AbstractSearchService, FilterClause, QueryPayload, SortOrder } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterBehavior, FilterService } from '../../services/filter.service';
+import { FilterBehavior } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
 import { DocumentViewerSingleItemComponent } from '../document-viewer-single-item/document-viewer-single-item.component';
@@ -62,7 +63,7 @@ export class DocumentViewerComponent extends BaseNeonComponent implements OnInit
 
     constructor(
         dashboardService: DashboardService,
-        filterService: FilterService,
+        filterService: InjectableFilterService,
         searchService: AbstractSearchService,
         injector: Injector,
         public viewContainerRef: ViewContainerRef,

--- a/src/app/components/export-control/export-control.component.ts
+++ b/src/app/components/export-control/export-control.component.ts
@@ -17,7 +17,7 @@ import { Component, ViewContainerRef, Input } from '@angular/core';
 import { MatSnackBar, MatSnackBarConfig } from '@angular/material';
 
 import { DashboardService } from '../../services/dashboard.service';
-import { ConnectionService } from '../../services/connection.service';
+import { InjectableConnectionService } from '../../services/injectable.connection.service';
 import { DashboardState } from '../../models/dashboard-state';
 
 @Component({
@@ -41,7 +41,7 @@ export class ExportControlComponent {
 
     constructor(
         dashboardService: DashboardService,
-        protected connectionService: ConnectionService,
+        protected connectionService: InjectableConnectionService,
         private matSnackBar: MatSnackBar,
         private viewContainerRef: ViewContainerRef
     ) {

--- a/src/app/components/filter-builder/filter-builder.component.spec.ts
+++ b/src/app/components/filter-builder/filter-builder.component.spec.ts
@@ -17,7 +17,7 @@ import { } from 'jasmine-core';
 import { FilterBuilderComponent } from './filter-builder.component';
 import { NeonFieldMetaData } from '../../models/dataset';
 
-import { FilterService } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';
@@ -28,7 +28,8 @@ describe('Component: Filter Builder', () => {
     let component: FilterBuilderComponent;
 
     beforeEach(() => {
-        component = new FilterBuilderComponent(new DashboardServiceMock(getConfigService()), new FilterService(), new SearchServiceMock());
+        component = new FilterBuilderComponent(new DashboardServiceMock(getConfigService()), new InjectableFilterService(),
+            new SearchServiceMock());
     });
 
     it('class properties are set to expected defaults', () => {

--- a/src/app/components/filter-builder/filter-builder.component.ts
+++ b/src/app/components/filter-builder/filter-builder.component.ts
@@ -19,7 +19,8 @@ import {
 } from '@angular/core';
 
 import { AbstractSearchService, CompoundFilterType } from '../../services/abstract.search.service';
-import { CompoundFilterDesign, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
+import { CompoundFilterDesign, FilterDesign, SimpleFilterDesign } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 import { DashboardService } from '../../services/dashboard.service';
 
 import { DashboardState } from '../../models/dashboard-state';
@@ -54,7 +55,7 @@ export class FilterBuilderComponent {
 
     constructor(
         public dashboardService: DashboardService,
-        public filterService: FilterService,
+        public filterService: InjectableFilterService,
         public searchService: AbstractSearchService
     ) {
         this.dashboardState = dashboardService.state;

--- a/src/app/components/filters/filters.component.spec.ts
+++ b/src/app/components/filters/filters.component.spec.ts
@@ -21,7 +21,7 @@ import { FiltersComponent } from './filters.component';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
@@ -36,7 +36,7 @@ describe('Component: Filters', () => {
     initializeTestBed('Filters', {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector
         ],

--- a/src/app/components/legend/legend.component.ts
+++ b/src/app/components/legend/legend.component.ts
@@ -26,7 +26,7 @@ import {
 
 import { ColorSet } from '../../models/color';
 
-import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
+import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 
 /**
  * Shows a legend of colors using the given color keys.
@@ -76,7 +76,7 @@ export class LegendComponent implements OnInit {
     public colorSets: ColorSet[] = [];
     private _colorKeys: string[];
 
-    constructor(public colorThemeService: AbstractColorThemeService) {
+    constructor(public colorThemeService: InjectableColorThemeService) {
         this.menuIcon = 'keyboard_arrow_down';
     }
 

--- a/src/app/components/map/map.component.spec.ts
+++ b/src/app/components/map/map.component.spec.ts
@@ -24,10 +24,9 @@ import {
 import { MapComponent } from './map.component';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
-import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
+import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterService } from '../../services/filter.service';
-import { ColorThemeService } from '../../services/color-theme.service';
 
 import { By } from '@angular/platform-browser';
 import { AbstractMap, BoundingBoxByDegrees, MapPoint, MapType } from './map.type.abstract';
@@ -181,7 +180,7 @@ describe('Component: Map', () => {
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector,
-            { provide: AbstractColorThemeService, useClass: ColorThemeService }
+            InjectableColorThemeService
 
         ],
         imports: [
@@ -252,7 +251,7 @@ describe('Component: Map', () => {
         let filter4 = new Map<string, any>().set('filterFields', [2, 4]);
         let filter5 = new Map<string, any>().set('filterFields', [5]);
 
-        let colorThemeService = getService(AbstractColorThemeService);
+        let colorThemeService = getService(InjectableColorThemeService);
 
         let aColor = colorThemeService.getColor('myDatabase', 'myTable', 'category', 'a').getComputedCss(component.visualization);
         let bColor = colorThemeService.getColor('myDatabase', 'myTable', 'category', 'b').getComputedCss(component.visualization);
@@ -1147,7 +1146,7 @@ describe('Component: Map with config', () => {
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector,
-            { provide: AbstractColorThemeService, useClass: ColorThemeService },
+            InjectableColorThemeService,
             { provide: 'tableKey', useValue: 'table_key_1' },
             {
                 provide: 'layers',

--- a/src/app/components/map/map.component.spec.ts
+++ b/src/app/components/map/map.component.spec.ts
@@ -26,7 +26,7 @@ import { MapComponent } from './map.component';
 import { AbstractSearchService } from '../../services/abstract.search.service';
 import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { By } from '@angular/platform-browser';
 import { AbstractMap, BoundingBoxByDegrees, MapPoint, MapType } from './map.type.abstract';
@@ -177,7 +177,7 @@ describe('Component: Map', () => {
         ],
         providers: [
             DashboardService,
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector,
             InjectableColorThemeService
@@ -1143,7 +1143,7 @@ describe('Component: Map with config', () => {
         ],
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector,
             InjectableColorThemeService,

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -32,10 +32,10 @@ import {
     CompoundFilterDesign,
     FilterBehavior,
     FilterDesign,
-    FilterService,
     FilterUtil,
     SimpleFilterDesign
 } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import {
     AbstractMap,
@@ -96,7 +96,7 @@ export class MapComponent extends BaseNeonComponent implements OnInit, OnDestroy
 
     constructor(
         dashboardService: DashboardService,
-        filterService: FilterService,
+        filterService: InjectableFilterService,
         searchService: AbstractSearchService,
         injector: Injector,
         protected colorThemeService: InjectableColorThemeService,

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -26,7 +26,7 @@ import {
 } from '@angular/core';
 
 import { AbstractSearchService, CompoundFilterType, FilterClause, QueryPayload } from '../../services/abstract.search.service';
-import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
+import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import {
     CompoundFilterDesign,
@@ -99,7 +99,7 @@ export class MapComponent extends BaseNeonComponent implements OnInit, OnDestroy
         filterService: FilterService,
         searchService: AbstractSearchService,
         injector: Injector,
-        protected colorThemeService: AbstractColorThemeService,
+        protected colorThemeService: InjectableColorThemeService,
         ref: ChangeDetectorRef,
         dialog: MatDialog,
         public visualization: ElementRef

--- a/src/app/components/media-viewer/media-viewer.component.spec.ts
+++ b/src/app/components/media-viewer/media-viewer.component.spec.ts
@@ -24,7 +24,7 @@ import { MediaViewerComponent } from './media-viewer.component';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
@@ -38,7 +38,7 @@ describe('Component: MediaViewer', () => {
     initializeTestBed('Media Viewer', {
         providers: [
             DashboardService,
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector
 
@@ -1167,7 +1167,7 @@ describe('Component: MediaViewer with config', () => {
     initializeTestBed('Media Viewer', {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector,
             { provide: 'title', useValue: 'Test Title' },

--- a/src/app/components/media-viewer/media-viewer.component.ts
+++ b/src/app/components/media-viewer/media-viewer.component.ts
@@ -28,7 +28,8 @@ import { DomSanitizer } from '@angular/platform-browser';
 
 import { AbstractSearchService, FilterClause, QueryPayload, SortOrder } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterBehavior, FilterService } from '../../services/filter.service';
+import { FilterBehavior } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
 import { MediaTypes } from '../../models/types';
@@ -94,7 +95,7 @@ export class MediaViewerComponent extends BaseNeonComponent implements OnInit, O
 
     constructor(
         dashboardService: DashboardService,
-        filterService: FilterService,
+        filterService: InjectableFilterService,
         searchService: AbstractSearchService,
         injector: Injector,
         ref: ChangeDetectorRef,

--- a/src/app/components/network-graph/network-graph.component.spec.ts
+++ b/src/app/components/network-graph/network-graph.component.spec.ts
@@ -19,8 +19,7 @@ import { DashboardService } from '../../services/dashboard.service';
 import { NeonFieldMetaData } from '../../models/dataset';
 import { FilterService } from '../../services/filter.service';
 import { AbstractSearchService } from '../../services/abstract.search.service';
-import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
-import { ColorThemeService } from '../../services/color-theme.service';
+import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 import { By } from '@angular/platform-browser';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
@@ -39,7 +38,7 @@ describe('Component: NetworkGraph', () => {
             FilterService,
             Injector,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
-            { provide: AbstractColorThemeService, useClass: ColorThemeService },
+            InjectableColorThemeService,
             { provide: 'limit', useValue: 'testLimit' }
         ],
         imports: [

--- a/src/app/components/network-graph/network-graph.component.spec.ts
+++ b/src/app/components/network-graph/network-graph.component.spec.ts
@@ -17,7 +17,7 @@ import { CUSTOM_ELEMENTS_SCHEMA, Injector } from '@angular/core';
 import { NetworkGraphComponent } from './network-graph.component';
 import { DashboardService } from '../../services/dashboard.service';
 import { NeonFieldMetaData } from '../../models/dataset';
-import { FilterService } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 import { AbstractSearchService } from '../../services/abstract.search.service';
 import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
@@ -35,7 +35,7 @@ describe('Component: NetworkGraph', () => {
     initializeTestBed('Network Graph', {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             Injector,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             InjectableColorThemeService,

--- a/src/app/components/network-graph/network-graph.component.ts
+++ b/src/app/components/network-graph/network-graph.component.ts
@@ -34,7 +34,8 @@ import {
 } from '../../services/abstract.search.service';
 import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { CompoundFilterDesign, FilterBehavior, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
+import { CompoundFilterDesign, FilterBehavior, FilterDesign, SimpleFilterDesign } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
 import { NeonFieldMetaData } from '../../models/dataset';
@@ -222,7 +223,7 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
 
     constructor(
         dashboardService: DashboardService,
-        filterService: FilterService,
+        filterService: InjectableFilterService,
         searchService: AbstractSearchService,
         injector: Injector,
         protected colorThemeService: InjectableColorThemeService,

--- a/src/app/components/network-graph/network-graph.component.ts
+++ b/src/app/components/network-graph/network-graph.component.ts
@@ -32,7 +32,7 @@ import {
     QueryPayload,
     SortOrder
 } from '../../services/abstract.search.service';
-import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
+import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { CompoundFilterDesign, FilterBehavior, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
 
@@ -225,7 +225,7 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
         filterService: FilterService,
         searchService: AbstractSearchService,
         injector: Injector,
-        protected colorThemeService: AbstractColorThemeService,
+        protected colorThemeService: InjectableColorThemeService,
         ref: ChangeDetectorRef,
         dialog: MatDialog,
         public visualization: ElementRef,

--- a/src/app/components/news-feed/news-feed.component.spec.ts
+++ b/src/app/components/news-feed/news-feed.component.spec.ts
@@ -20,7 +20,7 @@ import { } from 'jasmine-core';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 import { NewsFeedComponent } from './news-feed.component';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
@@ -36,7 +36,7 @@ describe('Component: NewsFeed', () => {
     initializeTestBed('News Feed', {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector
 

--- a/src/app/components/news-feed/news-feed.component.ts
+++ b/src/app/components/news-feed/news-feed.component.ts
@@ -28,7 +28,8 @@ import { DomSanitizer } from '@angular/platform-browser';
 
 import { AbstractSearchService, FilterClause, QueryPayload, SortOrder } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterBehavior, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
+import { FilterBehavior, FilterDesign, SimpleFilterDesign } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
 import { neonUtilities } from '../../models/neon-namespaces';
@@ -63,7 +64,7 @@ export class NewsFeedComponent extends BaseNeonComponent implements OnInit, OnDe
 
     constructor(
         dashboardService: DashboardService,
-        filterService: FilterService,
+        filterService: InjectableFilterService,
         searchService: AbstractSearchService,
         injector: Injector,
         ref: ChangeDetectorRef,

--- a/src/app/components/query-bar/query-bar.component.spec.ts
+++ b/src/app/components/query-bar/query-bar.component.spec.ts
@@ -18,10 +18,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
-import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
+import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterService } from '../../services/filter.service';
-import { ColorThemeService } from '../../services/color-theme.service';
 
 import { NeonConfig } from '../../models/types';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -63,7 +62,7 @@ class queryBarTester {
             ],
             providers: [
                 { provide: FilterService, useClass: MockFilterService },
-                { provide: AbstractColorThemeService, useClass: ColorThemeService },
+                InjectableColorThemeService,
                 { provide: DashboardService, useClass: mockDataset ? MockDashboardService : DashboardService },
 
             ],

--- a/src/app/components/query-bar/query-bar.component.spec.ts
+++ b/src/app/components/query-bar/query-bar.component.spec.ts
@@ -20,7 +20,7 @@ import { FormsModule } from '@angular/forms';
 
 import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { NeonConfig } from '../../models/types';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -51,7 +51,7 @@ class MockDashboardService extends DashboardService {
 class queryBarTester {
     fixture: ComponentFixture<QueryBarComponent>;
     component: QueryBarComponent;
-    filterService: FilterService;
+    filterService: InjectableFilterService;
     datasetService: DashboardService;
     element: DebugElement;
 
@@ -61,7 +61,7 @@ class queryBarTester {
                 QueryBarComponent
             ],
             providers: [
-                { provide: FilterService, useClass: MockFilterService },
+                { provide: InjectableFilterService, useClass: MockFilterService },
                 InjectableColorThemeService,
                 { provide: DashboardService, useClass: mockDataset ? MockDashboardService : DashboardService },
 
@@ -75,7 +75,7 @@ class queryBarTester {
         let fixture = TestBed.createComponent(QueryBarComponent);
         this.fixture = fixture;
         this.component = fixture.componentInstance;
-        this.filterService = this.getInjected(FilterService);
+        this.filterService = this.getInjected(InjectableFilterService);
         this.detectChanges();
 
         this.element = this.getElement('.simple-filter');

--- a/src/app/components/query-bar/query-bar.component.ts
+++ b/src/app/components/query-bar/query-bar.component.ts
@@ -18,7 +18,7 @@ import { FormControl } from '@angular/forms';
 import { map, startWith } from 'rxjs/operators';
 
 import { AbstractSearchService, CompoundFilterType, FilterClause, QueryPayload } from '../../services/abstract.search.service';
-import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
+import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { CompoundFilterDesign, FilterBehavior, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
 
@@ -62,7 +62,7 @@ export class QueryBarComponent extends BaseNeonComponent {
         filterService: FilterService,
         searchService: AbstractSearchService,
         injector: Injector,
-        protected colorThemeService: AbstractColorThemeService,
+        protected colorThemeService: InjectableColorThemeService,
         ref: ChangeDetectorRef,
         dialog: MatDialog
     ) {

--- a/src/app/components/query-bar/query-bar.component.ts
+++ b/src/app/components/query-bar/query-bar.component.ts
@@ -20,7 +20,8 @@ import { map, startWith } from 'rxjs/operators';
 import { AbstractSearchService, CompoundFilterType, FilterClause, QueryPayload } from '../../services/abstract.search.service';
 import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { CompoundFilterDesign, FilterBehavior, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
+import { CompoundFilterDesign, FilterBehavior, FilterDesign, SimpleFilterDesign } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
 import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
@@ -59,7 +60,7 @@ export class QueryBarComponent extends BaseNeonComponent {
 
     constructor(
         dashboardService: DashboardService,
-        filterService: FilterService,
+        filterService: InjectableFilterService,
         searchService: AbstractSearchService,
         injector: Injector,
         protected colorThemeService: InjectableColorThemeService,

--- a/src/app/components/sample/sample.component.spec.ts
+++ b/src/app/components/sample/sample.component.spec.ts
@@ -24,7 +24,7 @@ import { SubcomponentImpl2 } from './subcomponent.impl2';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 import { SearchService } from '../../services/search.service';
 
 import { NeonFieldMetaData } from '../../models/dataset';
@@ -80,7 +80,7 @@ let validateToggle = (element: any, value: any, content: string, checked: boolea
 class TestSampleComponent extends SampleComponent {
     constructor(
         dashboardService: DashboardService,
-        filterService: FilterService,
+        filterService: InjectableFilterService,
         searchService: AbstractSearchService,
         injector: Injector,
         ref: ChangeDetectorRef,
@@ -130,7 +130,7 @@ describe('Component: Sample', () => {
         ],
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector
 
@@ -554,7 +554,7 @@ describe('Component: Sample with config', () => {
         ],
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchService },
             Injector,
             { provide: 'customEventsToPublish', useValue: [{ id: 'test_publish_event', fields: [{ columnName: 'testPublishField' }] }] },

--- a/src/app/components/sample/sample.component.ts
+++ b/src/app/components/sample/sample.component.ts
@@ -31,7 +31,8 @@ import {
     SortOrder
 } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterBehavior, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
+import { FilterBehavior, FilterDesign, SimpleFilterDesign } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { AbstractSubcomponent } from './subcomponent.abstract';
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
@@ -76,7 +77,7 @@ export class SampleComponent extends BaseNeonComponent implements OnInit, OnDest
     /* eslint-disable @typescript-eslint/no-useless-constructor */
     constructor(
         dashboardService: DashboardService,
-        filterService: FilterService,
+        filterService: InjectableFilterService,
         searchService: AbstractSearchService,
         injector: Injector,
         ref: ChangeDetectorRef,

--- a/src/app/components/save-state/save-state.component.spec.ts
+++ b/src/app/components/save-state/save-state.component.spec.ts
@@ -20,7 +20,7 @@ import { SaveStateComponent } from './save-state.component';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { MatSnackBar } from '@angular/material';
 import { NeonConfig } from '../../models/types';
@@ -54,7 +54,7 @@ describe('Component: SaveStateComponent', () => {
         ],
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             MatSnackBar,
             ViewContainerRef

--- a/src/app/components/settings/settings.component.spec.ts
+++ b/src/app/components/settings/settings.component.spec.ts
@@ -18,10 +18,9 @@ import { } from 'jasmine-core';
 
 import { SettingsComponent } from './settings.component';
 
-import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
+import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterService } from '../../services/filter.service';
-import { ColorThemeService } from '../../services/color-theme.service';
 
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
@@ -41,7 +40,7 @@ describe('Component: Settings', () => {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
             FilterService,
-            { provide: AbstractColorThemeService, useClass: ColorThemeService }
+            InjectableColorThemeService
         ],
         imports: [
             MatDividerModule,

--- a/src/app/components/settings/settings.component.spec.ts
+++ b/src/app/components/settings/settings.component.spec.ts
@@ -20,7 +20,6 @@ import { SettingsComponent } from './settings.component';
 
 import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService } from '../../services/filter.service';
 
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
@@ -39,7 +38,6 @@ describe('Component: Settings', () => {
         ],
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
             InjectableColorThemeService
         ],
         imports: [

--- a/src/app/components/settings/settings.component.ts
+++ b/src/app/components/settings/settings.component.ts
@@ -21,7 +21,7 @@ import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
 import { NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
 import { neonEvents } from '../../models/neon-namespaces';
 
-import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
+import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 
 import { eventing } from 'neon-framework';
@@ -56,7 +56,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
         private dashboardService: DashboardService,
         private dialog: MatDialog,
         public injector: Injector,
-        public colorThemeService: AbstractColorThemeService
+        public colorThemeService: InjectableColorThemeService
     ) {
         this.injector = injector;
         this.messenger = new eventing.Messenger();

--- a/src/app/components/simple-filter/simple-filter.component.spec.ts
+++ b/src/app/components/simple-filter/simple-filter.component.spec.ts
@@ -16,7 +16,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService, SimpleFilterDesign } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
+import { SimpleFilterDesign } from '../../services/filter.service';
 import { SimpleFilterComponent } from './simple-filter.component';
 import { By } from '@angular/platform-browser';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';
@@ -28,7 +29,7 @@ import { SimpleFilterModule } from './simple-filter.module';
 describe('Component: SimpleFilter', () => {
     let component: SimpleFilterComponent;
     let fixture: ComponentFixture<SimpleFilterComponent>;
-    let filterService: FilterService;
+    let filterService: InjectableFilterService;
     let setInput = (input: string) => {
         component.showSimpleSearch = true;
         component['changeDetection'].detectChanges();
@@ -44,7 +45,7 @@ describe('Component: SimpleFilter', () => {
         providers: [
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService
+            InjectableFilterService
         ],
         imports: [
             SimpleFilterModule
@@ -54,7 +55,7 @@ describe('Component: SimpleFilter', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(SimpleFilterComponent);
         component = fixture.componentInstance;
-        filterService = fixture.debugElement.injector.get(FilterService);
+        filterService = fixture.debugElement.injector.get(InjectableFilterService);
         fixture.debugElement.injector.get(DashboardService).state.getOptions().simpleFilter = {
             fieldKey: '',
             tableKey: '',
@@ -184,7 +185,7 @@ describe('Component: SimpleFilter unconfigured', () => {
         providers: [
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             { provide: DashboardService, useClass: DashboardService },
-            FilterService
+            InjectableFilterService
         ],
         imports: [
             SimpleFilterModule

--- a/src/app/components/simple-filter/simple-filter.component.ts
+++ b/src/app/components/simple-filter/simple-filter.component.ts
@@ -16,7 +16,8 @@ import { ChangeDetectorRef, ChangeDetectionStrategy, Component, OnDestroy, OnIni
 import { AbstractSearchService } from '../../services/abstract.search.service';
 import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService, SimpleFilterDesign } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
+import { SimpleFilterDesign } from '../../services/filter.service';
 import { neonEvents } from '../../models/neon-namespaces';
 import { eventing } from 'neon-framework';
 import { DashboardState } from '../../models/dashboard-state';
@@ -38,7 +39,7 @@ export class SimpleFilterComponent implements OnInit, OnDestroy {
     constructor(
         private changeDetection: ChangeDetectorRef,
         dashboardService: DashboardService,
-        protected filterService: FilterService,
+        protected filterService: InjectableFilterService,
         protected searchService: AbstractSearchService
     ) {
         this.dashboardState = dashboardService.state;

--- a/src/app/components/taxonomy-viewer/taxonomy-viewer.component.spec.ts
+++ b/src/app/components/taxonomy-viewer/taxonomy-viewer.component.spec.ts
@@ -18,7 +18,8 @@ import { Injector } from '@angular/core';
 import { } from 'jasmine-core';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
-import { CompoundFilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
+import { CompoundFilterDesign, SimpleFilterDesign } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 import { DashboardService } from '../../services/dashboard.service';
 
 import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
@@ -150,7 +151,7 @@ describe('Component: TaxonomyViewer', () => {
     initializeTestBed('Taxonomy', {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector
 

--- a/src/app/components/taxonomy-viewer/taxonomy-viewer.component.ts
+++ b/src/app/components/taxonomy-viewer/taxonomy-viewer.component.ts
@@ -26,7 +26,8 @@ import {
 
 import { AbstractSearchService, CompoundFilterType, FilterClause, QueryPayload, SortOrder } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { CompoundFilterDesign, FilterBehavior, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
+import { CompoundFilterDesign, FilterBehavior, FilterDesign, SimpleFilterDesign } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 import { KEYS, TREE_ACTIONS, TreeNode } from 'angular-tree-component';
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
 import { NeonFieldMetaData } from '../../models/dataset';
@@ -105,7 +106,7 @@ export class TaxonomyViewerComponent extends BaseNeonComponent implements OnInit
 
     constructor(
         dashboardService: DashboardService,
-        filterService: FilterService,
+        filterService: InjectableFilterService,
         searchService: AbstractSearchService,
         injector: Injector,
         ref: ChangeDetectorRef,

--- a/src/app/components/text-cloud/text-cloud.component.spec.ts
+++ b/src/app/components/text-cloud/text-cloud.component.spec.ts
@@ -20,11 +20,10 @@ import { Injector } from '@angular/core';
 import { TextCloudComponent } from './text-cloud.component';
 
 import { AbstractSearchService, CompoundFilterType } from '../../services/abstract.search.service';
-import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
+import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { AggregationType } from '../../models/widget-option';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterService } from '../../services/filter.service';
-import { ColorThemeService } from '../../services/color-theme.service';
 
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
@@ -38,7 +37,7 @@ describe('Component: TextCloud', () => {
 
     initializeTestBed('Text Cloud', {
         providers: [
-            { provide: AbstractColorThemeService, useClass: ColorThemeService },
+            InjectableColorThemeService,
             {
                 provide: DashboardService,
                 useClass: DashboardServiceMock

--- a/src/app/components/text-cloud/text-cloud.component.spec.ts
+++ b/src/app/components/text-cloud/text-cloud.component.spec.ts
@@ -23,7 +23,7 @@ import { AbstractSearchService, CompoundFilterType } from '../../services/abstra
 import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { AggregationType } from '../../models/widget-option';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
@@ -42,7 +42,7 @@ describe('Component: TextCloud', () => {
                 provide: DashboardService,
                 useClass: DashboardServiceMock
             },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector
 

--- a/src/app/components/text-cloud/text-cloud.component.ts
+++ b/src/app/components/text-cloud/text-cloud.component.ts
@@ -33,7 +33,8 @@ import {
 } from '../../services/abstract.search.service';
 import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterBehavior, FilterService, FilterDesign, SimpleFilterDesign } from '../../services/filter.service';
+import { FilterBehavior, FilterDesign, SimpleFilterDesign } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
 import { NeonFieldMetaData } from '../../models/dataset';
@@ -66,7 +67,7 @@ export class TextCloudComponent extends BaseNeonComponent implements OnInit, OnD
 
     constructor(
         dashboardService: DashboardService,
-        filterService: FilterService,
+        filterService: InjectableFilterService,
         searchService: AbstractSearchService,
         injector: Injector,
         ref: ChangeDetectorRef,

--- a/src/app/components/text-cloud/text-cloud.component.ts
+++ b/src/app/components/text-cloud/text-cloud.component.ts
@@ -31,7 +31,7 @@ import {
     QueryPayload,
     SortOrder
 } from '../../services/abstract.search.service';
-import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
+import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterBehavior, FilterService, FilterDesign, SimpleFilterDesign } from '../../services/filter.service';
 
@@ -70,7 +70,7 @@ export class TextCloudComponent extends BaseNeonComponent implements OnInit, OnD
         searchService: AbstractSearchService,
         injector: Injector,
         ref: ChangeDetectorRef,
-        protected colorThemeService: AbstractColorThemeService,
+        protected colorThemeService: InjectableColorThemeService,
         dialog: MatDialog,
         public visualization: ElementRef
     ) {

--- a/src/app/components/thumbnail-grid/thumbnail-grid.component.spec.ts
+++ b/src/app/components/thumbnail-grid/thumbnail-grid.component.spec.ts
@@ -23,7 +23,7 @@ import { ThumbnailGridComponent } from './thumbnail-grid.component';
 
 import { AbstractSearchService, CompoundFilterType } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';
@@ -37,7 +37,7 @@ describe('Component: ThumbnailGrid', () => {
     initializeTestBed('Thumbnail Grid', {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector
 
@@ -792,7 +792,7 @@ describe('Component: ThumbnailGrid with config', () => {
     initializeTestBed('Thumbnail Grid', {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector,
             { provide: 'filter', useValue: { lhs: 'testConfigFilterField', operator: '=', rhs: 'testConfigFilterValue' } },

--- a/src/app/components/thumbnail-grid/thumbnail-grid.component.ts
+++ b/src/app/components/thumbnail-grid/thumbnail-grid.component.ts
@@ -28,7 +28,8 @@ import { DomSanitizer } from '@angular/platform-browser';
 
 import { AbstractSearchService, CompoundFilterType, FilterClause, QueryPayload, SortOrder } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { CompoundFilterDesign, FilterBehavior, FilterDesign, FilterService, SimpleFilterDesign } from '../../services/filter.service';
+import { CompoundFilterDesign, FilterBehavior, FilterDesign, SimpleFilterDesign } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
 import { NeonFieldMetaData } from '../../models/dataset';
@@ -74,7 +75,7 @@ export class ThumbnailGridComponent extends BaseNeonComponent implements OnInit,
 
     constructor(
         dashboardService: DashboardService,
-        filterService: FilterService,
+        filterService: InjectableFilterService,
         searchService: AbstractSearchService,
         injector: Injector,
         ref: ChangeDetectorRef,

--- a/src/app/components/timeline/timeline.component.spec.ts
+++ b/src/app/components/timeline/timeline.component.spec.ts
@@ -22,7 +22,7 @@ import { TimelineComponent } from './timeline.component';
 import { AbstractSearchService } from '../../services/abstract.search.service';
 import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
@@ -38,7 +38,7 @@ describe('Component: Timeline', () => {
         providers: [
             InjectableColorThemeService,
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector
         ],

--- a/src/app/components/timeline/timeline.component.spec.ts
+++ b/src/app/components/timeline/timeline.component.spec.ts
@@ -20,12 +20,11 @@ import { } from 'jasmine-core';
 import { TimelineComponent } from './timeline.component';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
-import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
+import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { FilterService } from '../../services/filter.service';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 import { SearchServiceMock } from '../../../testUtils/MockServices/SearchServiceMock';
-import { ColorThemeService } from '../../services/color-theme.service';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 
 import { TimelineModule } from './timeline.module';
@@ -37,7 +36,7 @@ describe('Component: Timeline', () => {
 
     initializeTestBed('Timeline', {
         providers: [
-            { provide: AbstractColorThemeService, useClass: ColorThemeService },
+            InjectableColorThemeService,
             { provide: DashboardService, useClass: DashboardServiceMock },
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },

--- a/src/app/components/timeline/timeline.component.ts
+++ b/src/app/components/timeline/timeline.component.ts
@@ -37,10 +37,10 @@ import {
     CompoundFilterDesign,
     FilterBehavior,
     FilterDesign,
-    FilterService,
     FilterUtil,
     SimpleFilterDesign
 } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
 import { DateBucketizer } from '../bucketizers/DateBucketizer';
@@ -91,7 +91,7 @@ export class TimelineComponent extends BaseNeonComponent implements OnInit, OnDe
 
     constructor(
         dashboardService: DashboardService,
-        filterService: FilterService,
+        filterService: InjectableFilterService,
         searchService: AbstractSearchService,
         injector: Injector,
         ref: ChangeDetectorRef,

--- a/src/app/components/timeline/timeline.component.ts
+++ b/src/app/components/timeline/timeline.component.ts
@@ -31,7 +31,7 @@ import {
     QueryPayload,
     TimeInterval
 } from '../../services/abstract.search.service';
-import { AbstractColorThemeService } from '../../services/abstract.color-theme.service';
+import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import {
     CompoundFilterDesign,
@@ -95,7 +95,7 @@ export class TimelineComponent extends BaseNeonComponent implements OnInit, OnDe
         searchService: AbstractSearchService,
         injector: Injector,
         ref: ChangeDetectorRef,
-        protected colorThemeService: AbstractColorThemeService,
+        protected colorThemeService: InjectableColorThemeService,
         dialog: MatDialog,
         public visualization: ElementRef
     ) {

--- a/src/app/components/wiki-viewer/wiki-viewer.component.spec.ts
+++ b/src/app/components/wiki-viewer/wiki-viewer.component.spec.ts
@@ -24,7 +24,7 @@ import { WikiViewerComponent } from './wiki-viewer.component';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterService } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
@@ -39,7 +39,7 @@ describe('Component: WikiViewer', () => {
     initializeTestBed('Wiki Viewer', {
         providers: [
             DashboardService,
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector
 
@@ -172,7 +172,7 @@ describe('Component: WikiViewer with mock HTTP', () => {
     initializeTestBed('Wiki Viewer', {
         providers: [
             DashboardService,
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector
 
@@ -344,7 +344,7 @@ describe('Component: WikiViewer with config', () => {
     initializeTestBed('Wiki Viewer', {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             Injector,
             { provide: 'tableKey', useValue: 'table_key_1' },

--- a/src/app/components/wiki-viewer/wiki-viewer.component.ts
+++ b/src/app/components/wiki-viewer/wiki-viewer.component.ts
@@ -29,7 +29,8 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 
 import { AbstractSearchService, FilterClause, QueryPayload } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterBehavior, FilterService } from '../../services/filter.service';
+import { FilterBehavior } from '../../services/filter.service';
+import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
 import { neonUtilities } from '../../models/neon-namespaces';
@@ -64,7 +65,7 @@ export class WikiViewerComponent extends BaseNeonComponent implements OnInit, On
 
     constructor(
         dashboardService: DashboardService,
-        filterService: FilterService,
+        filterService: InjectableFilterService,
         searchService: AbstractSearchService,
         injector: Injector,
         ref: ChangeDetectorRef,

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -24,10 +24,9 @@ import { NeonGridItem } from '../models/neon-grid-item';
 import { neonEvents } from '../models/neon-namespaces';
 
 import { AbstractSearchService } from '../services/abstract.search.service';
-import { AbstractColorThemeService } from '../services/abstract.color-theme.service';
+import { InjectableColorThemeService } from '../services/injectable.color-theme.service';
 import { DashboardService } from '../services/dashboard.service';
 import { FilterService } from '../services/filter.service';
-import { ColorThemeService } from '../services/color-theme.service';
 
 import { DashboardServiceMock, EmptyDashboardServiceMock } from '../../testUtils/MockServices/DashboardServiceMock';
 import { SearchServiceMock } from '../../testUtils/MockServices/SearchServiceMock';
@@ -64,7 +63,7 @@ describe('Dashboard', () => {
             { provide: DashboardService, useClass: DashboardServiceMock },
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
-            { provide: AbstractColorThemeService, useClass: ColorThemeService }
+            InjectableColorThemeService
         ]
     }, false);
 
@@ -851,7 +850,7 @@ describe('Dashboard Custom', () => {
             { provide: DashboardService, useClass: EmptyDashboardServiceMock },
             FilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
-            { provide: AbstractColorThemeService, useClass: ColorThemeService }
+            InjectableColorThemeService
         ]
     }, false);
 

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -26,7 +26,7 @@ import { neonEvents } from '../models/neon-namespaces';
 import { AbstractSearchService } from '../services/abstract.search.service';
 import { InjectableColorThemeService } from '../services/injectable.color-theme.service';
 import { DashboardService } from '../services/dashboard.service';
-import { FilterService } from '../services/filter.service';
+import { InjectableFilterService } from '../services/injectable.filter.service';
 
 import { DashboardServiceMock, EmptyDashboardServiceMock } from '../../testUtils/MockServices/DashboardServiceMock';
 import { SearchServiceMock } from '../../testUtils/MockServices/SearchServiceMock';
@@ -61,7 +61,7 @@ describe('Dashboard', () => {
         providers: [
             { provide: APP_BASE_HREF, useValue: '/' },
             { provide: DashboardService, useClass: DashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             InjectableColorThemeService
         ]
@@ -848,7 +848,7 @@ describe('Dashboard Custom', () => {
         providers: [
             { provide: APP_BASE_HREF, useValue: '/' },
             { provide: DashboardService, useClass: EmptyDashboardServiceMock },
-            FilterService,
+            InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             InjectableColorThemeService
         ]

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -30,7 +30,8 @@ import { InjectableColorThemeService } from '../services/injectable.color-theme.
 import { BaseNeonComponent } from '../components/base-neon-component/base-neon.component';
 import { DashboardService } from '../services/dashboard.service';
 import { DomSanitizer } from '@angular/platform-browser';
-import { FilterDataSource, FilterDesign, FilterService } from '../services/filter.service';
+import { FilterDataSource, FilterDesign } from '../services/filter.service';
+import { InjectableFilterService } from '../services/injectable.filter.service';
 import { MatSnackBar, MatSidenav } from '@angular/material';
 import { MatIconRegistry } from '@angular/material/icon';
 import { NeonGridItem } from '../models/neon-grid-item';
@@ -130,7 +131,7 @@ export class DashboardComponent implements AfterViewInit, OnInit, OnDestroy {
         public changeDetection: ChangeDetectorRef,
         public dashboardService: DashboardService,
         private domSanitizer: DomSanitizer,
-        public filterService: FilterService,
+        public filterService: InjectableFilterService,
         private matIconRegistry: MatIconRegistry,
         public snackBar: MatSnackBar,
         public colorThemeService: InjectableColorThemeService,

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -26,7 +26,7 @@ import {
 
 import { eventing } from 'neon-framework';
 
-import { AbstractColorThemeService } from '../services/abstract.color-theme.service';
+import { InjectableColorThemeService } from '../services/injectable.color-theme.service';
 import { BaseNeonComponent } from '../components/base-neon-component/base-neon.component';
 import { DashboardService } from '../services/dashboard.service';
 import { DomSanitizer } from '@angular/platform-browser';
@@ -128,7 +128,7 @@ export class DashboardComponent implements AfterViewInit, OnInit, OnDestroy {
         public filterService: FilterService,
         private matIconRegistry: MatIconRegistry,
         public snackBar: MatSnackBar,
-        public colorThemeService: AbstractColorThemeService,
+        public colorThemeService: InjectableColorThemeService,
         public viewContainerRef: ViewContainerRef,
         public router: Router,
         public location: Location

--- a/src/app/services/abstract.color-theme.service.ts
+++ b/src/app/services/abstract.color-theme.service.ts
@@ -12,24 +12,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Injectable } from '@angular/core';
 import { Color, ColorSet } from '../models/color';
 
-/**
- * @interface Theme
- */
 export interface Theme {
     id: string;
     name: string;
 }
 
-/**
- * A service for everything a Neon widget needs.
- *
- * @class AbstractColorThemeService
- * @abstract
- */
-@Injectable()
 export abstract class AbstractColorThemeService {
     /**
      * Returns the color for the given value from an existing color set for the given database/table/field or creates a new color set if

--- a/src/app/services/color-theme.service.spec.ts
+++ b/src/app/services/color-theme.service.spec.ts
@@ -12,34 +12,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { inject } from '@angular/core/testing';
-
-import { AbstractSearchService } from './abstract.search.service';
-import { DashboardService } from './dashboard.service';
 import { ColorThemeService } from './color-theme.service';
-
-import { initializeTestBed } from '../../testUtils/initializeTestBed';
-import { DashboardServiceMock } from '../../testUtils/MockServices/DashboardServiceMock';
-import { SearchServiceMock } from '../../testUtils/MockServices/SearchServiceMock';
-import { FilterService } from './filter.service';
 
 describe('Service: Color Theme', () => {
     /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     let service: ColorThemeService;
 
-    initializeTestBed('Widget Service', {
-        providers: [
-            ColorThemeService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            DashboardService,
-            FilterService
-
-        ]
+    beforeEach(() => {
+        service = new ColorThemeService();
     });
-
-    beforeEach(inject([ColorThemeService], (colorThemeService: ColorThemeService) => {
-        service = colorThemeService;
-    }));
 
     it('does have expected default theme and no existing ColorSets', () => {
         // TODO THOR-936
@@ -90,16 +71,7 @@ describe('Service: Color Theme', () => {
     });
 });
 
-describe('ColorSet', () => {
-    initializeTestBed('Color Theme Service ColorSet', {
-        providers: [
-            ColorThemeService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            { provide: DashboardService, useClass: DashboardServiceMock }
-
-        ]
-    });
-
+describe('ColorThemeService ColorSet', () => {
     it('creates ColorSets for the colorMaps in the dataset', () => {
         // TODO THOR-936
     });

--- a/src/app/services/color-theme.service.ts
+++ b/src/app/services/color-theme.service.ts
@@ -12,13 +12,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Injectable } from '@angular/core';
 import { AbstractColorThemeService, Theme } from './abstract.color-theme.service';
 import { Color, ColorSet } from '../models/color';
 
-/**
- * @class NeonTheme
- */
 export class NeonTheme implements Theme {
     /**
      * @constructor
@@ -30,12 +26,6 @@ export class NeonTheme implements Theme {
     constructor(public accent: string, public id: string, public main: string, public name: string) { }
 }
 
-/**
- * A service for everything a Neon Dashboard widget needs.
- *
- * @class ColorThemeService
- */
-@Injectable()
 export class ColorThemeService extends AbstractColorThemeService {
     public static THEME_DARK: Theme = new NeonTheme('#01B7C1', 'neon-dark', '#515861', 'Dark');
     public static THEME_GREEN: Theme = new NeonTheme('#FFA600', 'neon-green', '#39B54A', 'Green');

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -22,7 +22,7 @@ import { Subject, Observable, combineLatest, of, from, throwError } from 'rxjs';
 import { map, catchError, switchMap, take, shareReplay, tap } from 'rxjs/operators';
 import { NeonConfig, NeonDashboardLeafConfig } from '../models/types';
 import { Injectable } from '@angular/core';
-import { ConnectionService } from './connection.service';
+import { InjectableConnectionService } from './injectable.connection.service';
 import { ConfigUtil } from '../util/config.util';
 
 @Injectable({
@@ -44,7 +44,7 @@ export class ConfigService {
 
     constructor(
         private http: HttpClient,
-        private connectionService: ConnectionService
+        private connectionService: InjectableConnectionService
     ) {
         neon.setNeonServerUrl('../neon');
     }

--- a/src/app/services/connection.service.spec.ts
+++ b/src/app/services/connection.service.spec.ts
@@ -15,22 +15,13 @@
 import { query } from 'neon-framework';
 
 import { ConnectionService, NeonConnection } from './connection.service';
-import { inject } from '@angular/core/testing';
-
-import { initializeTestBed } from '../../testUtils/initializeTestBed';
 
 describe('ConnectionService', () => {
     let service: ConnectionService;
 
-    initializeTestBed('Connection Service', {
-        providers: [
-            ConnectionService
-        ]
+    beforeEach(() => {
+        service = new ConnectionService();
     });
-
-    beforeEach(inject([ConnectionService], (svc) => {
-        service = svc;
-    }));
 
     it('createConnection does return a new connection', () => {
         let connection = new query.Connection();

--- a/src/app/services/connection.service.ts
+++ b/src/app/services/connection.service.ts
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Injectable } from '@angular/core';
 import { NeonConfig } from '../models/types';
 import { query } from 'neon-framework';
 
@@ -276,9 +275,6 @@ export class NeonConnection<T extends { query: any } = { query: any }> implement
     }
 }
 
-@Injectable({
-    providedIn: 'root'
-})
 export class ConnectionService {
     // Maps the datastore types to datastore hosts to connections.
     private connections = new Map<string, Map<string, NeonConnection<any>>>();

--- a/src/app/services/dashboard.service.spec.ts
+++ b/src/app/services/dashboard.service.spec.ts
@@ -26,7 +26,7 @@ import { SearchServiceMock } from '../../testUtils/MockServices/SearchServiceMoc
 import { SearchService } from './search.service';
 
 import * as _ from 'lodash';
-import { FilterService } from './filter.service';
+import { InjectableFilterService } from './injectable.filter.service';
 import { ConfigUtil } from '../util/config.util';
 
 function extractNames(data: { [key: string]: any } | any[]) {
@@ -52,7 +52,7 @@ describe('Service: DashboardService', () => {
         providers: [
             { provide: AbstractSearchService, useClass: SearchServiceMock },
             DashboardService,
-            FilterService
+            InjectableFilterService
         ]
     });
 
@@ -580,7 +580,7 @@ describe('Service: DashboardService with Mock Data', () => {
         const localDashboardService = new DashboardService(
             localConfigService,
             conn,
-            new FilterService(),
+            new InjectableFilterService(),
             new SearchService(conn)
         );
 
@@ -642,7 +642,7 @@ describe('Service: DashboardService with Mock Data', () => {
         const localDashboardService = new DashboardService(
             localConfigService,
             conn,
-            new FilterService(),
+            new InjectableFilterService(),
             new SearchService(conn)
         );
 

--- a/src/app/services/dashboard.service.ts
+++ b/src/app/services/dashboard.service.ts
@@ -19,7 +19,8 @@ import { NeonDatastoreConfig, NeonDatabaseMetaData, NeonTableMetaData, NeonField
 
 import * as _ from 'lodash';
 import { ConfigService } from './config.service';
-import { ConnectionService, Connection } from './connection.service';
+import { Connection } from './connection.service';
+import { InjectableConnectionService } from './injectable.connection.service';
 import { DashboardState } from '../models/dashboard-state';
 import { DashboardUtil } from '../util/dashboard.util';
 
@@ -43,7 +44,7 @@ export class DashboardService {
 
     constructor(
         private configService: ConfigService,
-        private connectionService: ConnectionService,
+        private connectionService: InjectableConnectionService,
         private filterService: FilterService,
         private searchService: AbstractSearchService
     ) {

--- a/src/app/services/dashboard.service.ts
+++ b/src/app/services/dashboard.service.ts
@@ -27,7 +27,8 @@ import { DashboardUtil } from '../util/dashboard.util';
 import { GridState } from '../models/grid-state';
 import { Observable, from, Subject } from 'rxjs';
 import { map, shareReplay, mergeMap } from 'rxjs/operators';
-import { FilterService, FilterUtil } from './filter.service';
+import { FilterUtil } from './filter.service';
+import { InjectableFilterService } from './injectable.filter.service';
 import { AbstractSearchService } from './abstract.search.service';
 
 @Injectable({
@@ -45,7 +46,7 @@ export class DashboardService {
     constructor(
         private configService: ConfigService,
         private connectionService: InjectableConnectionService,
-        private filterService: FilterService,
+        private filterService: InjectableFilterService,
         private searchService: AbstractSearchService
     ) {
         this.configSource = this.configService

--- a/src/app/services/filter.service.ts
+++ b/src/app/services/filter.service.ts
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Injectable } from '@angular/core';
 import { AbstractSearchService, CompoundFilterType, FilterClause } from './abstract.search.service';
 import { FilterConfig, SimpleFilterConfig, CompoundFilterConfig } from '../models/types';
 import { NeonDatabaseMetaData, NeonFieldMetaData, SingleField, NeonTableMetaData } from '../models/dataset';
@@ -435,7 +434,6 @@ export class FilterCollection {
 
 export type FilterChangeListener = (callerId: string, changeCollection: Map<FilterDataSource[], FilterDesign[]>) => void;
 
-@Injectable()
 export class FilterService {
     protected filterCollection: FilterCollection = new FilterCollection();
 

--- a/src/app/services/injectable.color-theme.service.ts
+++ b/src/app/services/injectable.color-theme.service.ts
@@ -12,48 +12,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { Injectable } from '@angular/core';
 import { ColorThemeService } from './color-theme.service';
-import { Color, ColorSet } from '../models/color';
-import { Theme } from './abstract.color-theme.service';
 
-@Injectable()
-export class InjectableColorThemeService {
-    private _service = new ColorThemeService();
+@Injectable({
+    providedIn: 'root'
+})
+export class InjectableColorThemeService extends ColorThemeService { }
 
-    public getColor(databaseName: string, tableName: string, fieldName: string, value: string | string[]): Color {
-        return this._service.getColor(databaseName, tableName, fieldName, value);
-    }
-
-    public getColorKey(databaseName: string, tableName: string, fieldName: string): string {
-        return this._service.getColorKey(databaseName, tableName, fieldName);
-    }
-
-    public getColorSet(colorKey: string): ColorSet {
-        return this._service.getColorSet(colorKey);
-    }
-
-    public getTheme(): string {
-        return this._service.getTheme();
-    }
-
-    public getThemes(): Theme[] {
-        return this._service.getThemes();
-    }
-
-    public getThemeAccentColorHex(): string {
-        return this._service.getThemeAccentColorHex();
-    }
-
-    public getThemeMainColorHex(): string {
-        return this._service.getThemeMainColorHex();
-    }
-
-    public initializeColors(colors: Record<string, Record<string, Record<string, Record<string, string>>>>): void {
-        this._service.initializeColors(colors);
-    }
-
-    public setTheme(id: string): void {
-        this._service.setTheme(id);
-    }
-}

--- a/src/app/services/injectable.color-theme.service.ts
+++ b/src/app/services/injectable.color-theme.service.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2019 Next Century Corporation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Injectable } from '@angular/core';
+import { ColorThemeService } from './color-theme.service';
+import { Color, ColorSet } from '../models/color';
+import { Theme } from './abstract.color-theme.service';
+
+@Injectable()
+export class InjectableColorThemeService {
+    private _service = new ColorThemeService();
+
+    public getColor(databaseName: string, tableName: string, fieldName: string, value: string | string[]): Color {
+        return this._service.getColor(databaseName, tableName, fieldName, value);
+    }
+
+    public getColorKey(databaseName: string, tableName: string, fieldName: string): string {
+        return this._service.getColorKey(databaseName, tableName, fieldName);
+    }
+
+    public getColorSet(colorKey: string): ColorSet {
+        return this._service.getColorSet(colorKey);
+    }
+
+    public getTheme(): string {
+        return this._service.getTheme();
+    }
+
+    public getThemes(): Theme[] {
+        return this._service.getThemes();
+    }
+
+    public getThemeAccentColorHex(): string {
+        return this._service.getThemeAccentColorHex();
+    }
+
+    public getThemeMainColorHex(): string {
+        return this._service.getThemeMainColorHex();
+    }
+
+    public initializeColors(colors: Record<string, Record<string, Record<string, Record<string, string>>>>): void {
+        this._service.initializeColors(colors);
+    }
+
+    public setTheme(id: string): void {
+        this._service.setTheme(id);
+    }
+}

--- a/src/app/services/injectable.connection.service.ts
+++ b/src/app/services/injectable.connection.service.ts
@@ -12,24 +12,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { Injectable } from '@angular/core';
-import { ConnectionService, NeonConnection } from './connection.service';
+import { ConnectionService } from './connection.service';
 
 @Injectable({
     providedIn: 'root'
 })
-export class InjectableConnectionService {
-    private _service = new ConnectionService();
+export class InjectableConnectionService extends ConnectionService { }
 
-    /**
-     * Returns an existing connection to the REST server using the given host and the given datastore type (like elasticsearch or sql), or
-     * creates and returns a Neon connection if none exists.
-     */
-    public connect<T extends { query: any } = { query: any }>(
-        datastoreType: string,
-        datastoreHost: string,
-        ignoreUpdates: boolean = false
-    ): NeonConnection<T> {
-        return this._service.connect(datastoreType, datastoreHost, ignoreUpdates);
-    }
-}

--- a/src/app/services/injectable.connection.service.ts
+++ b/src/app/services/injectable.connection.service.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2019 Next Century Corporation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Injectable } from '@angular/core';
+import { ConnectionService, NeonConnection } from './connection.service';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class InjectableConnectionService {
+    private _service = new ConnectionService();
+
+    /**
+     * Returns an existing connection to the REST server using the given host and the given datastore type (like elasticsearch or sql), or
+     * creates and returns a Neon connection if none exists.
+     */
+    public connect<T extends { query: any } = { query: any }>(
+        datastoreType: string,
+        datastoreHost: string,
+        ignoreUpdates: boolean = false
+    ): NeonConnection<T> {
+        return this._service.connect(datastoreType, datastoreHost, ignoreUpdates);
+    }
+}

--- a/src/app/services/injectable.filter.service.ts
+++ b/src/app/services/injectable.filter.service.ts
@@ -16,6 +16,8 @@
 import { Injectable } from '@angular/core';
 import { FilterService } from './filter.service';
 
-@Injectable()
+@Injectable({
+    providedIn: 'root'
+})
 export class InjectableFilterService extends FilterService { }
 

--- a/src/app/services/injectable.filter.service.ts
+++ b/src/app/services/injectable.filter.service.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2019 Next Century Corporation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable } from '@angular/core';
+import { FilterService } from './filter.service';
+
+@Injectable()
+export class InjectableFilterService extends FilterService { }
+

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -24,7 +24,8 @@ import {
     QueryPayload
 } from './abstract.search.service';
 import { AggregationType } from '../models/widget-option';
-import { NeonConnection, RequestWrapper, ConnectionService } from './connection.service';
+import { NeonConnection, RequestWrapper } from './connection.service';
+import { InjectableConnectionService } from './injectable.connection.service';
 
 import { query } from 'neon-framework';
 
@@ -53,7 +54,7 @@ interface ExportField {
  */
 @Injectable()
 export class SearchService extends AbstractSearchService {
-    constructor(private connectionService: ConnectionService) {
+    constructor(private connectionService: InjectableConnectionService) {
         super();
     }
 

--- a/src/testUtils/MockServices/DashboardServiceMock.ts
+++ b/src/testUtils/MockServices/DashboardServiceMock.ts
@@ -18,7 +18,7 @@ import { DashboardService } from '../../app/services/dashboard.service';
 import { ConfigService } from '../../app/services/config.service';
 import { InjectableConnectionService } from '../../app/services/injectable.connection.service';
 import { Injectable } from '@angular/core';
-import { FilterService } from '../../app/services/filter.service';
+import { InjectableFilterService } from '../../app/services/injectable.filter.service';
 import { SearchServiceMock } from './SearchServiceMock';
 import {
     DATABASES,
@@ -76,7 +76,7 @@ export class DashboardServiceMock extends DashboardService {
         super(
             configService,
             new MockConnectionService(),
-            new FilterService(),
+            new InjectableFilterService(),
             new SearchServiceMock()
         );
 
@@ -91,7 +91,7 @@ export class EmptyDashboardServiceMock extends DashboardService {
         super(
             configService,
             new MockConnectionService(),
-            new FilterService(),
+            new InjectableFilterService(),
             new SearchServiceMock()
         );
     }

--- a/src/testUtils/MockServices/DashboardServiceMock.ts
+++ b/src/testUtils/MockServices/DashboardServiceMock.ts
@@ -16,7 +16,7 @@ import { NeonDashboardLeafConfig } from '../../app/models/types';
 import { NeonDatastoreConfig, NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../app/models/dataset';
 import { DashboardService } from '../../app/services/dashboard.service';
 import { ConfigService } from '../../app/services/config.service';
-import { ConnectionService } from '../../app/services/connection.service';
+import { InjectableConnectionService } from '../../app/services/injectable.connection.service';
 import { Injectable } from '@angular/core';
 import { FilterService } from '../../app/services/filter.service';
 import { SearchServiceMock } from './SearchServiceMock';
@@ -32,7 +32,7 @@ import {
     TABLES_LIST
 } from '../mock-dataset';
 
-export class MockConnectionService extends ConnectionService {
+export class MockConnectionService extends InjectableConnectionService {
     public connect(__datastoreType: string, __datastoreHost: string) {
         return null as any;
     }


### PR DESCRIPTION
Removed the Angular/Injectable dependencies on the service classes that are tied to the visualizations (color theme, connection, and filter).  Created "Injectable" service classes that extend the base service classes for use in the Neon Dashboard.

Most of the diffs are just me updating imports.  The main changes are to the files in `src/app/services`.