### PR TITLE
THOR-1266 Removed cachedFilters

### DIFF
--- a/src/app/components/aggregation/aggregation.component.spec.ts
+++ b/src/app/components/aggregation/aggregation.component.spec.ts
@@ -27,7 +27,7 @@ import { AbstractSearchService, CompoundFilterType } from '../../services/abstra
 import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { AggregationType } from '../../models/widget-option';
 import { DashboardService } from '../../services/dashboard.service';
-import { CompoundFilterDesign, SimpleFilterDesign } from '../../util/filter.util';
+import { CompoundFilterDesign, FilterCollection, SimpleFilter, SimpleFilterDesign } from '../../util/filter.util';
 import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { Color } from '../../models/color';
@@ -176,93 +176,85 @@ describe('Component: Aggregation', () => {
         component.options.groupField = DashboardServiceMock.FIELD_MAP.CATEGORY;
         let actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(1);
-        expect(actual[0].filterDesign.database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[0].filterDesign.table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[0].filterDesign.field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect(actual[0].filterDesign.operator).toEqual('!=');
-        expect(actual[0].filterDesign.value).toBeUndefined();
-        expect(actual[0].redrawCallback.toString()).toEqual((component as any).redrawLegend.bind(component).toString());
+        expect(actual[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect(actual[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect(actual[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect(actual[0].operator).toEqual('!=');
+        expect(actual[0].value).toBeUndefined();
 
         component.options.xField = DashboardServiceMock.FIELD_MAP.X;
         actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(3);
-        expect(actual[0].filterDesign.database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[0].filterDesign.table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[0].filterDesign.field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect(actual[0].filterDesign.operator).toEqual('!=');
-        expect(actual[0].filterDesign.value).toBeUndefined();
-        expect(actual[0].redrawCallback.toString()).toEqual((component as any).redrawLegend.bind(component).toString());
-        expect(actual[1].filterDesign.database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[1].filterDesign.table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[1].filterDesign.field).toEqual(DashboardServiceMock.FIELD_MAP.X);
-        expect(actual[1].filterDesign.operator).toEqual('=');
-        expect(actual[1].filterDesign.value).toBeUndefined();
-        expect(actual[1].redrawCallback.toString()).toEqual((component as any).redrawFilteredItems.bind(component).toString());
-        expect((actual[2].filterDesign).type).toEqual('and');
-        expect((actual[2].filterDesign).filters.length).toEqual(2);
-        expect((actual[2].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[2].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[2].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
-        expect((actual[2].filterDesign).filters[0].operator).toEqual('>=');
-        expect((actual[2].filterDesign).filters[0].value).toBeUndefined();
-        expect((actual[2].filterDesign).filters[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[2].filterDesign).filters[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[2].filterDesign).filters[1].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
-        expect((actual[2].filterDesign).filters[1].operator).toEqual('<=');
-        expect((actual[2].filterDesign).filters[1].value).toBeUndefined();
-        expect(actual[2].redrawCallback.toString()).toEqual((component as any).redrawDomain.bind(component).toString());
+        expect(actual[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect(actual[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect(actual[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect(actual[0].operator).toEqual('!=');
+        expect(actual[0].value).toBeUndefined();
+        expect(actual[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect(actual[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect(actual[1].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
+        expect(actual[1].operator).toEqual('=');
+        expect(actual[1].value).toBeUndefined();
+        expect((actual[2]).type).toEqual('and');
+        expect((actual[2]).filters.length).toEqual(2);
+        expect((actual[2]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[2]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[2]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
+        expect((actual[2]).filters[0].operator).toEqual('>=');
+        expect((actual[2]).filters[0].value).toBeUndefined();
+        expect((actual[2]).filters[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[2]).filters[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[2]).filters[1].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
+        expect((actual[2]).filters[1].operator).toEqual('<=');
+        expect((actual[2]).filters[1].value).toBeUndefined();
 
         component.options.yField = DashboardServiceMock.FIELD_MAP.Y;
         actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(4);
-        expect(actual[0].filterDesign.database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[0].filterDesign.table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[0].filterDesign.field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect(actual[0].filterDesign.operator).toEqual('!=');
-        expect(actual[0].filterDesign.value).toBeUndefined();
-        expect(actual[0].redrawCallback.toString()).toEqual((component as any).redrawLegend.bind(component).toString());
-        expect(actual[1].filterDesign.database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[1].filterDesign.table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[1].filterDesign.field).toEqual(DashboardServiceMock.FIELD_MAP.X);
-        expect(actual[1].filterDesign.operator).toEqual('=');
-        expect(actual[1].filterDesign.value).toBeUndefined();
-        expect(actual[1].redrawCallback.toString()).toEqual((component as any).redrawFilteredItems.bind(component).toString());
-        expect((actual[2].filterDesign).type).toEqual('and');
-        expect((actual[2].filterDesign).filters.length).toEqual(2);
-        expect((actual[2].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[2].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[2].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
-        expect((actual[2].filterDesign).filters[0].operator).toEqual('>=');
-        expect((actual[2].filterDesign).filters[0].value).toBeUndefined();
-        expect((actual[2].filterDesign).filters[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[2].filterDesign).filters[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[2].filterDesign).filters[1].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
-        expect((actual[2].filterDesign).filters[1].operator).toEqual('<=');
-        expect((actual[2].filterDesign).filters[1].value).toBeUndefined();
-        expect(actual[2].redrawCallback.toString()).toEqual((component as any).redrawDomain.bind(component).toString());
-        expect((actual[3].filterDesign).type).toEqual('and');
-        expect((actual[3].filterDesign).filters.length).toEqual(4);
-        expect((actual[3].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[3].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[3].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
-        expect((actual[3].filterDesign).filters[0].operator).toEqual('>=');
-        expect((actual[3].filterDesign).filters[0].value).toBeUndefined();
-        expect((actual[3].filterDesign).filters[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[3].filterDesign).filters[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[3].filterDesign).filters[1].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
-        expect((actual[3].filterDesign).filters[1].operator).toEqual('<=');
-        expect((actual[3].filterDesign).filters[1].value).toBeUndefined();
-        expect((actual[3].filterDesign).filters[2].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[3].filterDesign).filters[2].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[3].filterDesign).filters[2].field).toEqual(DashboardServiceMock.FIELD_MAP.Y);
-        expect((actual[3].filterDesign).filters[2].operator).toEqual('>=');
-        expect((actual[3].filterDesign).filters[2].value).toBeUndefined();
-        expect((actual[3].filterDesign).filters[3].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[3].filterDesign).filters[3].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[3].filterDesign).filters[3].field).toEqual(DashboardServiceMock.FIELD_MAP.Y);
-        expect((actual[3].filterDesign).filters[3].operator).toEqual('<=');
-        expect((actual[3].filterDesign).filters[3].value).toBeUndefined();
-        expect(actual[3].redrawCallback.toString()).toEqual((component as any).redrawBounds.bind(component).toString());
+        expect(actual[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect(actual[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect(actual[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect(actual[0].operator).toEqual('!=');
+        expect(actual[0].value).toBeUndefined();
+        expect(actual[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect(actual[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect(actual[1].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
+        expect(actual[1].operator).toEqual('=');
+        expect(actual[1].value).toBeUndefined();
+        expect((actual[2]).type).toEqual('and');
+        expect((actual[2]).filters.length).toEqual(2);
+        expect((actual[2]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[2]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[2]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
+        expect((actual[2]).filters[0].operator).toEqual('>=');
+        expect((actual[2]).filters[0].value).toBeUndefined();
+        expect((actual[2]).filters[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[2]).filters[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[2]).filters[1].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
+        expect((actual[2]).filters[1].operator).toEqual('<=');
+        expect((actual[2]).filters[1].value).toBeUndefined();
+        expect((actual[3]).type).toEqual('and');
+        expect((actual[3]).filters.length).toEqual(4);
+        expect((actual[3]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[3]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[3]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
+        expect((actual[3]).filters[0].operator).toEqual('>=');
+        expect((actual[3]).filters[0].value).toBeUndefined();
+        expect((actual[3]).filters[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[3]).filters[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[3]).filters[1].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
+        expect((actual[3]).filters[1].operator).toEqual('<=');
+        expect((actual[3]).filters[1].value).toBeUndefined();
+        expect((actual[3]).filters[2].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[3]).filters[2].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[3]).filters[2].field).toEqual(DashboardServiceMock.FIELD_MAP.Y);
+        expect((actual[3]).filters[2].operator).toEqual('>=');
+        expect((actual[3]).filters[2].value).toBeUndefined();
+        expect((actual[3]).filters[3].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[3]).filters[3].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[3]).filters[3].field).toEqual(DashboardServiceMock.FIELD_MAP.Y);
+        expect((actual[3]).filters[3].operator).toEqual('<=');
+        expect((actual[3]).filters[3].value).toBeUndefined();
     });
 
     it('finalizeVisualizationQuery does return expected count aggregation query', () => {
@@ -796,7 +788,8 @@ describe('Component: Aggregation', () => {
         expect(component.legendDisabledGroups).toEqual(['b']);
     });
 
-    it('redrawBounds does call subcomponentMain.select and refreshVisualization', () => {
+    /*
+    It('redrawBounds does call subcomponentMain.select and refreshVisualization', () => {
         let spySelect = spyOn(component.subcomponentMain, 'select');
         let spyRedraw = spyOn(component, 'refreshVisualization');
 
@@ -1795,6 +1788,7 @@ describe('Component: Aggregation', () => {
         expect(component.legendActiveGroups).toEqual(['testGroup1', 'testGroup2', 'testGroup3']);
         expect(component.legendDisabledGroups).toEqual([]);
     });
+    */
 
     it('shouldFilterSelf does return expected boolean', () => {
         component.options.ignoreSelf = false;
@@ -1863,7 +1857,7 @@ describe('Component: Aggregation', () => {
         }, {
             testXField: 3,
             testYField: 4
-        }]);
+        }], new FilterCollection());
 
         expect(component.legendActiveGroups).toEqual(['All']);
         expect(component.legendGroups).toEqual(['All']);
@@ -1893,7 +1887,7 @@ describe('Component: Aggregation', () => {
         }, {
             _aggregation: 4,
             testXField: 3
-        }]);
+        }], new FilterCollection());
 
         expect(component.legendActiveGroups).toEqual(['All']);
         expect(component.legendGroups).toEqual(['All']);
@@ -1936,7 +1930,7 @@ describe('Component: Aggregation', () => {
             testCategoryField: 'b',
             testXField: 7,
             testYField: 8
-        }]);
+        }], new FilterCollection());
 
         expect(component.legendActiveGroups).toEqual(['a', 'b']);
         expect(component.legendGroups).toEqual(['a', 'b']);
@@ -1987,7 +1981,7 @@ describe('Component: Aggregation', () => {
             _aggregation: 8,
             testCategoryField: 'b',
             testXField: 7
-        }]);
+        }], new FilterCollection());
 
         expect(component.legendActiveGroups).toEqual(['a', 'b']);
         expect(component.legendGroups).toEqual(['a', 'b']);
@@ -2022,7 +2016,31 @@ describe('Component: Aggregation', () => {
         component.options.groupField = DashboardServiceMock.FIELD_MAP.CATEGORY;
         component.options.xField = DashboardServiceMock.FIELD_MAP.X;
 
-        component.legendDisabledGroups = ['a'];
+        let testStatus;
+        let filterA = new SimpleFilter('', DashboardServiceMock.DATABASES.testDatabase1, DashboardServiceMock.TABLES.testTable1,
+            DashboardServiceMock.FIELD_MAP.CATEGORY, '!=', 'a');
+        let filterB = new SimpleFilter('', DashboardServiceMock.DATABASES.testDatabase1, DashboardServiceMock.TABLES.testTable1,
+            DashboardServiceMock.FIELD_MAP.CATEGORY, '!=', 'b');
+        let filterC = new SimpleFilter('', DashboardServiceMock.DATABASES.testDatabase1, DashboardServiceMock.TABLES.testTable1,
+            DashboardServiceMock.FIELD_MAP.CATEGORY, '!=', 'c');
+
+        let testCollection = new FilterCollection();
+        spyOn(testCollection, 'getCompatibleFilters').and.callFake((design) => {
+            if (design.field && design.field.columnName === DashboardServiceMock.FIELD_MAP.CATEGORY.columnName) {
+                if (testStatus === 1) {
+                    return [filterA];
+                }
+                if (testStatus === 2) {
+                    return [filterA, filterB];
+                }
+                if (testStatus === 3) {
+                    return [filterA, filterB, filterC];
+                }
+            }
+            return [];
+        });
+
+        testStatus = 1;
         component.transformVisualizationQueryResults(component.options, [{
             testCategoryField: 'a',
             testXField: 1,
@@ -2039,12 +2057,12 @@ describe('Component: Aggregation', () => {
             testCategoryField: 'c',
             testXField: 7,
             testYField: 8
-        }]);
+        }], testCollection);
         expect(component.legendActiveGroups).toEqual(['b', 'c']);
         expect(component.legendDisabledGroups).toEqual(['a']);
         expect(component.legendGroups).toEqual(['a', 'b', 'c']);
 
-        component.legendDisabledGroups = ['a', 'b'];
+        testStatus = 2;
         component.transformVisualizationQueryResults(component.options, [{
             _aggregation: 2,
             testCategoryField: 'a',
@@ -2061,12 +2079,12 @@ describe('Component: Aggregation', () => {
             _aggregation: 8,
             testCategoryField: 'c',
             testXField: 7
-        }]);
+        }], testCollection);
         expect(component.legendActiveGroups).toEqual(['c']);
         expect(component.legendDisabledGroups).toEqual(['a', 'b']);
         expect(component.legendGroups).toEqual(['a', 'b', 'c']);
 
-        component.legendDisabledGroups = ['a', 'b', 'c'];
+        testStatus = 3;
         component.transformVisualizationQueryResults(component.options, [{
             testCategoryField: 'a',
             testXField: 1,
@@ -2083,7 +2101,7 @@ describe('Component: Aggregation', () => {
             testCategoryField: 'c',
             testXField: 7,
             testYField: 8
-        }]);
+        }], testCollection);
         expect(component.legendActiveGroups).toEqual([]);
         expect(component.legendDisabledGroups).toEqual(['a', 'b', 'c']);
         expect(component.legendGroups).toEqual(['a', 'b', 'c']);
@@ -2102,7 +2120,7 @@ describe('Component: Aggregation', () => {
         }, {
             _date: '2018-01-03T00:00:00.000Z',
             testYField: 4
-        }]);
+        }], new FilterCollection());
 
         expect(component.legendActiveGroups).toEqual(['All']);
         expect(component.legendGroups).toEqual(['All']);
@@ -2133,7 +2151,7 @@ describe('Component: Aggregation', () => {
         }, {
             _aggregation: 4,
             _date: '2018-01-03T00:00:00.000Z'
-        }]);
+        }], new FilterCollection());
 
         expect(component.legendActiveGroups).toEqual(['All']);
         expect(component.legendGroups).toEqual(['All']);
@@ -2165,7 +2183,7 @@ describe('Component: Aggregation', () => {
         }, {
             _aggregation: 4,
             testTextField: 'c'
-        }]);
+        }], new FilterCollection());
 
         expect(component.legendActiveGroups).toEqual(['All']);
         expect(component.legendGroups).toEqual(['All']);
@@ -2197,7 +2215,7 @@ describe('Component: Aggregation', () => {
         }, {
             _aggregation: 4,
             testXField: 3
-        }]);
+        }], new FilterCollection());
 
         expect(component.legendActiveGroups).toEqual(['All']);
         expect(component.legendGroups).toEqual(['All']);
@@ -2236,7 +2254,7 @@ describe('Component: Aggregation', () => {
         }, {
             _date: '2018-01-04T00:00:00.000Z',
             testYField: 4
-        }]);
+        }], new FilterCollection());
 
         expect(component.legendActiveGroups).toEqual(['All']);
         expect(component.legendGroups).toEqual(['All']);
@@ -2274,7 +2292,7 @@ describe('Component: Aggregation', () => {
         }, {
             _date: '2018-01-03T00:00:00.000Z',
             testYField: 4
-        }]);
+        }], new FilterCollection());
 
         expect(component.legendActiveGroups).toEqual(['All']);
         expect(component.legendGroups).toEqual(['All']);
@@ -2319,7 +2337,7 @@ describe('Component: Aggregation', () => {
         }, {
             _date: '2018-01-04T00:00:00.000Z',
             testYField: 5
-        }]);
+        }], new FilterCollection());
 
         expect(component.legendActiveGroups).toEqual(['All']);
         expect(component.legendGroups).toEqual(['All']);
@@ -2377,7 +2395,7 @@ describe('Component: Aggregation', () => {
             _date: '2018-01-04T00:00:00.000Z',
             testCategoryField: 'b',
             testYField: 5
-        }]);
+        }], new FilterCollection());
 
         expect(component.legendActiveGroups).toEqual(['a', 'b']);
         expect(component.legendGroups).toEqual(['a', 'b']);
@@ -2450,7 +2468,7 @@ describe('Component: Aggregation', () => {
         }, {
             _date: '2018-01-04T00:00:00.000Z',
             testYField: 4
-        }]);
+        }], new FilterCollection());
 
         expect(component.legendActiveGroups).toEqual(['All']);
         expect(component.legendGroups).toEqual(['All']);
@@ -2501,7 +2519,7 @@ describe('Component: Aggregation', () => {
         }, {
             testXField: 3,
             testYField: 4
-        }]);
+        }], new FilterCollection());
 
         expect(component.legendActiveGroups).toEqual(['All']);
         expect(component.legendGroups).toEqual(['All']);
@@ -2531,7 +2549,7 @@ describe('Component: Aggregation', () => {
         }, {
             _aggregation: 4,
             testXField: 3
-        }]);
+        }], new FilterCollection());
 
         expect(component.legendActiveGroups).toEqual(['All']);
         expect(component.legendGroups).toEqual(['All']);
@@ -2555,7 +2573,7 @@ describe('Component: Aggregation', () => {
         component.options.xField = DashboardServiceMock.FIELD_MAP.X;
         component.options.yField = DashboardServiceMock.FIELD_MAP.Y;
 
-        let actual = component.transformVisualizationQueryResults(component.options, []);
+        let actual = component.transformVisualizationQueryResults(component.options, [], new FilterCollection());
         expect(component.legendActiveGroups).toEqual(['All']);
         expect(component.legendGroups).toEqual(['All']);
         expect(actual).toEqual(0);
@@ -2714,7 +2732,6 @@ describe('Component: Aggregation', () => {
         expect(spy1.calls.count()).toEqual(1);
         expect(spy1.calls.argsFor(0)).toEqual([component.subcomponentMainElementRef]);
         expect(spy2.calls.count()).toEqual(1);
-        expect(spy2.calls.argsFor(0)).toEqual([true]);
         expect(spy3.calls.count()).toEqual(1);
         expect(spy4.calls.count()).toEqual(1);
     });
@@ -2733,7 +2750,6 @@ describe('Component: Aggregation', () => {
         expect(spy1.calls.argsFor(0)).toEqual([component.subcomponentMainElementRef]);
         expect(spy1.calls.argsFor(1)).toEqual([component.subcomponentZoomElementRef, true]);
         expect(spy2.calls.count()).toEqual(1);
-        expect(spy2.calls.argsFor(0)).toEqual([true]);
         expect(spy3.calls.count()).toEqual(1);
         expect(spy4.calls.count()).toEqual(1);
     });
@@ -3071,7 +3087,8 @@ describe('Component: Aggregation', () => {
         expect(component.colorKeys).toEqual(['testDatabase1_testTable1_testCategoryField']);
     });
 
-    it('refreshVisualization does not draw main data if isFiltered returns true unless dualView is falsey', () => {
+    /*
+    It('refreshVisualization does not draw main data if isFiltered returns true unless dualView is falsey', () => {
         let spy1 = spyOn(component.subcomponentMain, 'draw');
         let spy2 = spyOn(component.subcomponentZoom, 'draw');
         component.options.aggregation = AggregationType.SUM;
@@ -3139,6 +3156,7 @@ describe('Component: Aggregation', () => {
         expect(spy2.calls.count()).toEqual(1);
         expect(component.colorKeys).toEqual(['testDatabase1_testTable1_testCategoryField']);
     });
+    */
 
     it('refreshVisualization does draw main data if given true argument', () => {
         let spy1 = spyOn(component.subcomponentMain, 'draw');
@@ -3161,7 +3179,7 @@ describe('Component: Aggregation', () => {
         component.xList = [1, 3];
         component.yList = [2, 4];
 
-        component.refreshVisualization(true);
+        component.refreshVisualization();
         expect(spy1.calls.count()).toEqual(1);
         expect(spy1.calls.argsFor(0)).toEqual([[{
             x: 1,
@@ -3235,7 +3253,9 @@ describe('Component: Aggregation', () => {
         component.options.dualView = 'filter';
         expect(component.showBothViews()).toEqual(false);
 
-        (component as any).isFiltered = () => true;
+        let fakeCollection = new FilterCollection();
+        spyOn(fakeCollection, 'getFilters').and.returnValue([null]);
+        spyOn(component['filterService'], 'retrieveCompatibleFilterCollection').and.returnValue(fakeCollection);
         expect(component.showBothViews()).toEqual(true);
     });
 

--- a/src/app/components/aggregation/aggregation.component.ts
+++ b/src/app/components/aggregation/aggregation.component.ts
@@ -39,10 +39,12 @@ import {
 import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
 import {
+    AbstractFilter,
+    CompoundFilter,
     CompoundFilterDesign,
-    FilterBehavior,
+    FilterCollection,
     FilterDesign,
-    FilterUtil,
+    SimpleFilter,
     SimpleFilterDesign
 } from '../../util/filter.util';
 import { InjectableFilterService } from '../../services/injectable.filter.service';
@@ -179,7 +181,6 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
     public yList: any[] = [];
 
     private viewInitialized = false;
-    private pendingFilters: FilterDesign[] = [];
 
     constructor(
         dashboardService: DashboardService,
@@ -229,49 +230,32 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
     ngAfterViewInit() {
         super.ngAfterViewInit();
         this.viewInitialized = true;
-        if (this.pendingFilters && this.pendingFilters.length) {
-            this.redrawFilteredItems(this.pendingFilters);
-            delete this.pendingFilters;
-        }
     }
 
     /**
-     * Returns each type of filter made by this visualization as an object containing 1) a filter design with undefined values and 2) a
-     * callback to redraw the filter.  This visualization will automatically update with compatible filters that were set externally.
+     * Returns the design for each type of filter made by this visualization.  This visualization will automatically update itself with all
+     * compatible filters that were set internally or externally whenever it runs a visualization query.
      *
-     * @return {FilterBehavior[]}
+     * @return {FilterDesign[]}
      * @override
      */
-    protected designEachFilterWithNoValues(): FilterBehavior[] {
-        let behaviors: FilterBehavior[] = [];
+    protected designEachFilterWithNoValues(): FilterDesign[] {
+        let designs: FilterDesign[] = [];
 
         if (this.options.groupField.columnName) {
-            behaviors.push({
-                filterDesign: this.createFilterDesignOnLegend(),
-                redrawCallback: this.redrawLegend.bind(this)
-            } as FilterBehavior);
+            designs.push(this.createFilterDesignOnLegend());
         }
 
         if (this.options.xField.columnName) {
-            behaviors.push({
-                filterDesign: this.createFilterDesignOnItem(),
-                redrawCallback: this.redrawFilteredItems.bind(this)
-            } as FilterBehavior);
-
-            behaviors.push({
-                filterDesign: this.createFilterDesignOnDomain(),
-                redrawCallback: this.redrawDomain.bind(this)
-            } as FilterBehavior);
+            designs.push(this.createFilterDesignOnItem());
+            designs.push(this.createFilterDesignOnDomain());
 
             if (this.options.yField.columnName) {
-                behaviors.push({
-                    filterDesign: this.createFilterDesignOnBounds(),
-                    redrawCallback: this.redrawBounds.bind(this)
-                } as FilterBehavior);
+                designs.push(this.createFilterDesignOnBounds());
             }
         }
 
-        return behaviors;
+        return designs;
     }
 
     /**
@@ -566,13 +550,6 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
         }
     }
 
-    private findMatchingFilterDesign(configs: SimpleFilterDesign[], fieldBinding: string, operator: string) {
-        let matching: SimpleFilterDesign[] = configs.filter((config) => config.operator === operator &&
-            this.options.database.name === config.database.name && this.options.table.name === config.table.name &&
-            this.options[fieldBinding].columnName === config.field.columnName);
-        return matching.length ? matching[0].value : undefined;
-    }
-
     /**
      * Returns an object containing the ElementRef objects for the visualization needed for the resizing behavior.
      *
@@ -789,10 +766,11 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
      *
      * @arg {any} options A WidgetOptionCollection object.
      * @arg {any[]} results
+     * @arg {FilterCollection} filters
      * @return {number}
      * @override
      */
-    transformVisualizationQueryResults(options: any, results: any[]): number {
+    transformVisualizationQueryResults(options: any, results: any[], filters: FilterCollection): number {
         let isXY = this.optionsTypeIsXY(options);
         let xList = [];
         let yList = [];
@@ -929,19 +907,22 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
             // TODO Add missing X to xList of numeric histograms.
         }
 
-        // Set the legend groups once with the original groups.  Then (always) update the active groups with the groups in the active data.
+        this.xList = options.savePrevious && this.xList.length ? this.xList : xList;
+        this.yList = yList;
+
+        this.aggregationData = shownResults;
+
+        // Set the legend groups with the original groups.
         let groups = Array.from(groupsToColors.keys()).sort();
         if (!this.legendGroups.length) {
             this.legendGroups = groups;
         }
 
+        this.redrawFilters(filters);
+
+        // Set the active groups to all the groups in the active data.
         this.legendActiveGroups = this.legendGroups.filter((group) => groups.indexOf(group) >= 0 &&
             this.legendDisabledGroups.indexOf(group) < 0);
-
-        this.xList = options.savePrevious && this.xList.length ? this.xList : xList;
-        this.yList = yList;
-
-        this.aggregationData = shownResults;
 
         return this.options.countByAggregation ? this.aggregationData.length : this.aggregationData.reduce((count, element) =>
             count + element.y, 0);
@@ -1079,123 +1060,62 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
         return options.xField.type === 'date';
     }
 
-    private redrawBounds(filters: FilterDesign[]): void {
-        let removeFilter = true;
-
-        // Find the boundds inside the compound filter with an expected structure like createFilterDesignOnBounds.
-        // TODO THOR-1100 How should we handle multiple bounds filters?  Should we draw multiple areas?
-        if (filters.length && FilterUtil.isCompoundFilterDesign(filters[0])) {
-            let boundsFilter: CompoundFilterDesign = (filters[0] as CompoundFilterDesign);
-
-            if (boundsFilter && boundsFilter.type === CompoundFilterType.AND && boundsFilter.filters.length === 4 &&
-                FilterUtil.isSimpleFilterDesign(boundsFilter.filters[0]) &&
-                FilterUtil.isSimpleFilterDesign(boundsFilter.filters[1]) &&
-                FilterUtil.isSimpleFilterDesign(boundsFilter.filters[2]) &&
-                FilterUtil.isSimpleFilterDesign(boundsFilter.filters[3])) {
-                let nestedFilters: SimpleFilterDesign[] = boundsFilter.filters as SimpleFilterDesign[];
-                let beginX = this.findMatchingFilterDesign(nestedFilters, 'xField', '>=');
-                let endX = this.findMatchingFilterDesign(nestedFilters, 'xField', '<=');
-                let beginY = this.findMatchingFilterDesign(nestedFilters, 'yField', '>=');
-                let endY = this.findMatchingFilterDesign(nestedFilters, 'yField', '<=');
-
-                if (this.subcomponentMain && typeof beginX !== 'undefined' && typeof endX !== 'undefined' &&
-                    typeof beginY !== 'undefined' && typeof endY !== 'undefined') {
-                    this.subcomponentMain.select([{
-                        beginX: beginX,
-                        endX: endX,
-                        beginY: beginY,
-                        endY: endY
-                    }]);
-
-                    this.refreshVisualization(true);
-
-                    removeFilter = false;
-
-                    // TODO THOR-1057 Update the selectedArea
-                    // this.selectedArea = null;
-                }
-            }
-        }
-
-        if (removeFilter) {
-            if (this.subcomponentMain) {
-                this.subcomponentMain.select([]);
-                this.refreshVisualization(true);
-            }
-            this.selectedArea = null;
-        }
-    }
-
-    private redrawDomain(filters: FilterDesign[]): void {
-        let removeFilter = true;
-
-        // Find the domain inside the compound filter with an expected structure like createFilterDesignOnDomain.
-        // TODO THOR-1100 How should we handle multiple domain filters?  Should we draw multiple areas?
-        if (filters.length && FilterUtil.isCompoundFilterDesign(filters[0])) {
-            let domainFilter: CompoundFilterDesign = (filters[0] as CompoundFilterDesign);
-
-            if (domainFilter && domainFilter.type === CompoundFilterType.AND && domainFilter.filters.length === 2 &&
-                FilterUtil.isSimpleFilterDesign(domainFilter.filters[0]) &&
-                FilterUtil.isSimpleFilterDesign(domainFilter.filters[1])) {
-                let nestedFilters: SimpleFilterDesign[] = domainFilter.filters as SimpleFilterDesign[];
-                let beginX = this.findMatchingFilterDesign(nestedFilters, 'xField', '>=');
-                let endX = this.findMatchingFilterDesign(nestedFilters, 'xField', '<=');
-
-                if (this.subcomponentMain && typeof beginX !== 'undefined' && typeof endX !== 'undefined') {
-                    this.subcomponentMain.select([{
-                        beginX: beginX,
-                        endX: endX
-                    }]);
-
-                    this.refreshVisualization(true);
-
-                    removeFilter = false;
-
-                    // TODO THOR-1057 Update the selectedArea
-                    // this.selectedArea = null;
-                }
-            }
-        }
-
-        if (removeFilter) {
-            if (this.subcomponentMain) {
-                this.subcomponentMain.select([]);
-                this.refreshVisualization(true);
-            }
-            this.selectedArea = null;
-        }
-    }
-
-    private redrawFilteredItems(filterDesigns: FilterDesign[]): void {
-        if (!this.subcomponentMain && !this.viewInitialized) {
-            this.pendingFilters = filterDesigns;
-        }
-        if (this.subcomponentMain) {
-            // Find the values inside the filters with an expected structure of createFilterDesignOnItem.
-            this.subcomponentMain.select(filterDesigns.reduce((values, filterDesign) => {
-                if (FilterUtil.isSimpleFilterDesign(filterDesign)) {
-                    let value = this.findMatchingFilterDesign([filterDesign], 'xField', '=');
-                    return value ? values.concat(value) : values;
-                }
-                return values;
-            }, []));
-
-            this.refreshVisualization(true);
-        }
-    }
-
-    private redrawLegend(filterDesigns: FilterDesign[]): void {
-        // Find the values inside the filters with an expected structure of createFilterDesignOnLegend.
-        this.legendDisabledGroups = filterDesigns.reduce((groups, filterDesign) => {
-            if (FilterUtil.isSimpleFilterDesign(filterDesign)) {
-                let group = this.findMatchingFilterDesign([filterDesign], 'groupField', '!=');
-                return group ? groups.concat(group) : groups;
-            }
-            return groups;
-        }, []);
+    /**
+     * Redraws this visualization with the given compatible filters.
+     *
+     * @override
+     */
+    protected redrawFilters(filters: FilterCollection): void {
+        // Add or remove disabled legend groups depending on the filtered legend groups.
+        let legendFilters: AbstractFilter[] = filters.getCompatibleFilters(this.createFilterDesignOnLegend());
+        this.legendDisabledGroups = legendFilters.map((filter) => (filter as SimpleFilter).value);
 
         // Set the active groups to all the groups that are NOT disabled/filtered since the group filters are all negative (!=).
         this.legendActiveGroups = this.legendGroups.filter((group) => this.legendDisabledGroups.indexOf(group) < 0);
+
+        // Add or remove the selected bounds/domain on the chart depending on if the bounds/domain is filtered.
+        let boundsFilters: AbstractFilter[] = filters.getCompatibleFilters(this.createFilterDesignOnBounds());
+        let domainFilters: AbstractFilter[] = filters.getCompatibleFilters(this.createFilterDesignOnDomain());
+        if (boundsFilters.length || domainFilters.length) {
+            // TODO THOR-1100 How should we handle multiple bounds and/or domain filters?  Should we draw multiple selected areas?
+            for (const boundsFilter of boundsFilters) {
+                let bounds = (boundsFilter as CompoundFilter).asBoundsFilter();
+                if (bounds.lowerA.field.columnName === this.options.xField.columnName) {
+                    this.subcomponentMain.select([{
+                        beginX: bounds.lowerA.value,
+                        endX: bounds.upperA.value,
+                        beginY: bounds.lowerB.value,
+                        endY: bounds.upperB.value
+                    }]);
+                } else {
+                    this.subcomponentMain.select([{
+                        beginX: bounds.lowerB.value,
+                        endX: bounds.upperB.value,
+                        beginY: bounds.lowerA.value,
+                        endY: bounds.upperA.value
+                    }]);
+                }
+            }
+
+            for (const domainFilter of domainFilters) {
+                let domain = (domainFilter as CompoundFilter).asDomainFilter();
+                this.subcomponentMain.select([{
+                    beginX: domain.lower.value,
+                    endX: domain.upper.value
+                }]);
+            }
+
+            // TODO THOR-1057 Update the selectedArea
+            // this.selectedArea = null;
+        } else {
+            this.subcomponentMain.select([]);
+            this.selectedArea = null;
+        }
+
+        // Select individual filtered items.
+        // TODO THOR-1057 Maybe this should be a "filtered" property on the individual data items.
+        let itemFilters: AbstractFilter[] = filters.getCompatibleFilters(this.createFilterDesignOnItem());
+        this.subcomponentMain.select(itemFilters.map((filter) => (filter as SimpleFilter).value));
     }
 
     /**
@@ -1214,16 +1134,15 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
         if (this.options.dualView) {
             this.subcomponentZoom = this.initializeSubcomponent(this.subcomponentZoomElementRef, true);
         }
-        this.refreshVisualization(true);
+        this.refreshVisualization();
     }
 
     /**
      * Updates and redraws the elements and properties for the visualization.
      *
-     * @arg {boolean} [redrawMain=false]
      * @override
      */
-    refreshVisualization(redrawMain: boolean = false) {
+    refreshVisualization() {
         if (!this.aggregationData) {
             return;
         }
@@ -1250,8 +1169,9 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
             yList: this.yList
         };
 
+        // TODO FIXME Only redraw if the unfiltered data is changed.
         // Update the overview if dualView is off or if it is not filtered.  It will only show the unfiltered data.
-        if (this.subcomponentMain && (redrawMain || !this.options.dualView || !this.isFiltered())) {
+        if (this.subcomponentMain) {
             this.subcomponentMain.draw(this.aggregationData, meta);
         }
 
@@ -1285,7 +1205,8 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
      * @return {boolean}
      */
     showBothViews(): boolean {
-        return this.options.dualView === 'on' || (this.options.dualView === 'filter' && this.isFiltered());
+        return this.options.dualView === 'on' || (this.options.dualView === 'filter' &&
+            !!this.filterService.retrieveCompatibleFilterCollection(this.designEachFilterWithNoValues()).getFilters().length);
     }
 
     /**

--- a/src/app/components/annotation-viewer/annotation-viewer.component.ts
+++ b/src/app/components/annotation-viewer/annotation-viewer.component.ts
@@ -27,7 +27,7 @@ import {
 import { AbstractSearchService, FilterClause, QueryPayload } from '../../services/abstract.search.service';
 import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterBehavior, FilterDesign } from '../../util/filter.util';
+import { FilterCollection, FilterDesign } from '../../util/filter.util';
 import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
@@ -165,30 +165,19 @@ export class AnnotationViewerComponent extends BaseNeonComponent implements OnIn
     }
 
     /**
-     * Returns each type of filter made by this visualization as an object containing 1) a filter design with undefined values and 2) a
-     * callback to redraw the filter.  This visualization will automatically update with compatible filters that were set externally.
+     * Returns the design for each type of filter made by this visualization.  This visualization will automatically update itself with all
+     * compatible filters that were set internally or externally whenever it runs a visualization query.
      *
-     * @return {FilterBehavior[]}
+     * @return {FilterDesign[]}
      * @override
      */
-    protected designEachFilterWithNoValues(): FilterBehavior[] {
-        let behaviors: FilterBehavior[] = [];
+    protected designEachFilterWithNoValues(): FilterDesign[] {
+        // TODO THOR-1099 Should filtered text have specific HTML styles?
+        return this.options.documentTextField.columnName ? [this.createFilterDesignOnAnnotationText()] : [];
 
-        if (this.options.documentTextField.columnName) {
-            behaviors.push({
-                filterDesign: this.createFilterDesignOnAnnotationText(),
-                // TODO THOR-1099 Should filtered text have specific HTML styles?
-                redrawCallback: () => { /* Do nothing */ }
-            } as FilterBehavior);
-        }
-
-        // TODO THOR-1098 createFilterDesignOnAnnotationPart
-        // behaviors.push({
-        //     filterDesign: this.createFilterDesignOnAnnotationPart(),
-        //     redrawCallback: () => {}
-        // } as FilterBehavior);
-
-        return behaviors;
+        // TODO THOR-1098
+        // return this.options.documentTextField.columnName ? [this.createFilterDesignOnAnnotationText(),
+        //     this.createFilterDesignOnAnnotationPart()] : [];
     }
 
     /**
@@ -660,10 +649,11 @@ export class AnnotationViewerComponent extends BaseNeonComponent implements OnIn
      *
      * @arg {any} options A WidgetOptionCollection object.
      * @arg {any[]} results
+     * @arg {FilterCollection} filters
      * @return {number}
      * @override
      */
-    transformVisualizationQueryResults(options: any, results: any[]): number {
+    transformVisualizationQueryResults(options: any, results: any[], __filters: FilterCollection): number {
         this.displayField = options.respondMode ? options.linkField.columnName : options.documentTextField.columnName;
 
         this.disabledSet = [] as any;

--- a/src/app/components/data-table/data-table.component.spec.ts
+++ b/src/app/components/data-table/data-table.component.spec.ts
@@ -21,6 +21,7 @@ import { DataTableComponent } from './data-table.component';
 
 import { AbstractSearchService, CompoundFilterType } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
+import { FilterCollection } from '../../util/filter.util';
 import { InjectableFilterService } from '../../services/injectable.filter.service';
 import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
@@ -60,62 +61,62 @@ describe('Component: DataTable', () => {
         component.options.filterFields = [DashboardServiceMock.FIELD_MAP.CATEGORY];
         let actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(2);
-        expect((actual[0].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[0].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[0].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[0].filterDesign).operator).toEqual('=');
-        expect((actual[0].filterDesign).value).toBeUndefined();
-        expect((actual[1].filterDesign).type).toEqual('and');
-        expect((actual[1].filterDesign).filters.length).toEqual(1);
-        expect((actual[1].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[1].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[1].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[1].filterDesign).filters[0].operator).toEqual('=');
-        expect((actual[1].filterDesign).filters[0].value).toBeUndefined();
+        expect((actual[0]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[0]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[0]).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[0]).operator).toEqual('=');
+        expect((actual[0]).value).toBeUndefined();
+        expect((actual[1]).type).toEqual('and');
+        expect((actual[1]).filters.length).toEqual(1);
+        expect((actual[1]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[1]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[1]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[1]).filters[0].operator).toEqual('=');
+        expect((actual[1]).filters[0].value).toBeUndefined();
 
         component.options.arrayFilterOperator = 'or';
         actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(2);
-        expect((actual[0].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[0].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[0].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[0].filterDesign).operator).toEqual('=');
-        expect((actual[0].filterDesign).value).toBeUndefined();
-        expect((actual[1].filterDesign).type).toEqual('or');
-        expect((actual[1].filterDesign).filters.length).toEqual(1);
-        expect((actual[1].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[1].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[1].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[1].filterDesign).filters[0].operator).toEqual('=');
-        expect((actual[1].filterDesign).filters[0].value).toBeUndefined();
+        expect((actual[0]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[0]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[0]).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[0]).operator).toEqual('=');
+        expect((actual[0]).value).toBeUndefined();
+        expect((actual[1]).type).toEqual('or');
+        expect((actual[1]).filters.length).toEqual(1);
+        expect((actual[1]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[1]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[1]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[1]).filters[0].operator).toEqual('=');
+        expect((actual[1]).filters[0].value).toBeUndefined();
 
         component.options.filterFields = [DashboardServiceMock.FIELD_MAP.CATEGORY, DashboardServiceMock.FIELD_MAP.TEXT];
         actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(4);
-        expect((actual[0].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[0].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[0].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[0].filterDesign).operator).toEqual('=');
-        expect((actual[0].filterDesign).value).toBeUndefined();
-        expect((actual[1].filterDesign).type).toEqual('or');
-        expect((actual[1].filterDesign).filters.length).toEqual(1);
-        expect((actual[1].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[1].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[1].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[1].filterDesign).filters[0].operator).toEqual('=');
-        expect((actual[1].filterDesign).filters[0].value).toBeUndefined();
-        expect((actual[2].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[2].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[2].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
-        expect((actual[2].filterDesign).operator).toEqual('=');
-        expect((actual[2].filterDesign).value).toBeUndefined();
-        expect((actual[3].filterDesign).type).toEqual('or');
-        expect((actual[3].filterDesign).filters.length).toEqual(1);
-        expect((actual[3].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[3].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[3].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
-        expect((actual[3].filterDesign).filters[0].operator).toEqual('=');
-        expect((actual[3].filterDesign).filters[0].value).toBeUndefined();
+        expect((actual[0]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[0]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[0]).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[0]).operator).toEqual('=');
+        expect((actual[0]).value).toBeUndefined();
+        expect((actual[1]).type).toEqual('or');
+        expect((actual[1]).filters.length).toEqual(1);
+        expect((actual[1]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[1]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[1]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[1]).filters[0].operator).toEqual('=');
+        expect((actual[1]).filters[0].value).toBeUndefined();
+        expect((actual[2]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[2]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[2]).field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
+        expect((actual[2]).operator).toEqual('=');
+        expect((actual[2]).value).toBeUndefined();
+        expect((actual[3]).type).toEqual('or');
+        expect((actual[3]).filters.length).toEqual(1);
+        expect((actual[3]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[3]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[3]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
+        expect((actual[3]).filters[0].operator).toEqual('=');
+        expect((actual[3]).filters[0].value).toBeUndefined();
     });
 
     it('onResize does call refreshVisualization', () => {
@@ -671,10 +672,10 @@ describe('Component: DataTable', () => {
 
         let actual = component.transformVisualizationQueryResults(component.options, [
             { _id: 1, category: 'books', testField: 'test', ignore: 'ignore', _docCount: 1 }
-        ]);
+        ], new FilterCollection());
 
         expect(component.tableData).toEqual([
-            { _id: 1, category: 'books', testField: 'test' }
+            { _filtered: false, _id: 1, category: 'books', testField: 'test' }
         ]);
         expect(actual).toEqual(1);
     });
@@ -689,11 +690,11 @@ describe('Component: DataTable', () => {
         let actual = component.transformVisualizationQueryResults(component.options, [
             { _id: 1, category: 'books', testField: 'test', ignore: 'ignore', _docCount: 1 },
             { _id: 2, category: 'books', testField: 'some other value', ignore: 'ignoring' }
-        ]);
+        ], new FilterCollection());
 
         expect(component.tableData).toEqual([
-            { _id: 1, category: 'books', testField: 'test' },
-            { _id: 2, category: 'books', testField: 'some other value' }
+            { _filtered: false, _id: 1, category: 'books', testField: 'test' },
+            { _filtered: false, _id: 2, category: 'books', testField: 'some other value' }
         ]);
         expect(actual).toEqual(2);
     });
@@ -1575,13 +1576,18 @@ describe('Component: DataTable', () => {
     it('getRowClassFunction function does set active to false', () => {
         let rowClassFunction = component.getRowClassFunction();
 
-        expect((component as any).isFiltered()).toEqual(false);
-
         expect(rowClassFunction({})).toEqual({
             active: false
         });
 
         expect(rowClassFunction({
+            testFilterField: 'testFilterValue'
+        })).toEqual({
+            active: false
+        });
+
+        expect(rowClassFunction({
+            _filtered: false,
             testFilterField: 'testFilterValue'
         })).toEqual({
             active: false
@@ -1598,113 +1604,23 @@ describe('Component: DataTable', () => {
         });
 
         expect(rowClassFunction({
-            testFilterField: 'testFilterValue1'
+            testFilterField: 'testFilterValue'
         })).toEqual({
             active: false
         });
 
-        (component as any).isFiltered = (filterDesign) => filterDesign.database === component.options.database &&
-            filterDesign.table === component.options.table && filterDesign.field === DashboardServiceMock.FIELD_MAP.FILTER &&
-            filterDesign.operator === '=' && (filterDesign.value === 'testFilterValue1' || filterDesign.value === 'testFilterValue2');
+        expect(rowClassFunction({
+            _filtered: false,
+            testFilterField: 'testFilterValue'
+        })).toEqual({
+            active: false
+        });
 
         expect(rowClassFunction({
-            testFilterField: 'testFilterValue1'
+            _filtered: true,
+            testFilterField: 'testFilterValue'
         })).toEqual({
             active: true
-        });
-
-        expect(rowClassFunction({
-            testFilterField: 'testFilterValue2'
-        })).toEqual({
-            active: true
-        });
-
-        expect(rowClassFunction({
-            testFilterField: 'testFilterValue3'
-        })).toEqual({
-            active: false
-        });
-
-        expect(rowClassFunction({
-            testFilterField2: 'testFilterValue1'
-        })).toEqual({
-            active: false
-        });
-    });
-
-    it('getRowClassFunction function with compound AND filters and filterFields does set active to expected boolean', () => {
-        let rowClassFunction = component.getRowClassFunction();
-
-        component.options.filterFields = [DashboardServiceMock.FIELD_MAP.FILTER];
-        component.options.singleFilter = false;
-        component.options.arrayFilterOperator = 'and';
-
-        (component as any).isFiltered = (filterDesign) => filterDesign.type === 'and' && filterDesign.filters &&
-            filterDesign.filters.length === 1 && filterDesign.filters[0].database === component.options.database &&
-            filterDesign.filters[0].table === component.options.table &&
-            filterDesign.filters[0].field === DashboardServiceMock.FIELD_MAP.FILTER && filterDesign.filters[0].operator === '=' &&
-            (filterDesign.filters[0].value === 'testFilterValue1' || filterDesign.filters[0].value === 'testFilterValue2');
-
-        expect(rowClassFunction({
-            testFilterField: 'testFilterValue1'
-        })).toEqual({
-            active: true
-        });
-
-        expect(rowClassFunction({
-            testFilterField: 'testFilterValue2'
-        })).toEqual({
-            active: true
-        });
-
-        expect(rowClassFunction({
-            testFilterField: 'testFilterValue3'
-        })).toEqual({
-            active: false
-        });
-
-        expect(rowClassFunction({
-            testFilterField2: 'testFilterValue1'
-        })).toEqual({
-            active: false
-        });
-    });
-
-    it('getRowClassFunction function with compound OR filters and filterFields does set active to expected boolean', () => {
-        let rowClassFunction = component.getRowClassFunction();
-
-        component.options.filterFields = [DashboardServiceMock.FIELD_MAP.FILTER];
-        component.options.singleFilter = false;
-        component.options.arrayFilterOperator = 'or';
-
-        (component as any).isFiltered = (filterDesign) => filterDesign.type === 'or' && filterDesign.filters &&
-            filterDesign.filters.length === 1 && filterDesign.filters[0].database === component.options.database &&
-            filterDesign.filters[0].table === component.options.table &&
-            filterDesign.filters[0].field === DashboardServiceMock.FIELD_MAP.FILTER && filterDesign.filters[0].operator === '=' &&
-            (filterDesign.filters[0].value === 'testFilterValue1' || filterDesign.filters[0].value === 'testFilterValue2');
-
-        expect(rowClassFunction({
-            testFilterField: 'testFilterValue1'
-        })).toEqual({
-            active: true
-        });
-
-        expect(rowClassFunction({
-            testFilterField: 'testFilterValue2'
-        })).toEqual({
-            active: true
-        });
-
-        expect(rowClassFunction({
-            testFilterField: 'testFilterValue3'
-        })).toEqual({
-            active: false
-        });
-
-        expect(rowClassFunction({
-            testFilterField2: 'testFilterValue1'
-        })).toEqual({
-            active: false
         });
     });
 

--- a/src/app/components/data-table/data-table.component.ts
+++ b/src/app/components/data-table/data-table.component.ts
@@ -27,7 +27,7 @@ import {
 
 import { AbstractSearchService, CompoundFilterType, FilterClause, QueryPayload, SortOrder } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { CompoundFilterDesign, FilterBehavior, FilterDesign, SimpleFilterDesign } from '../../util/filter.util';
+import { CompoundFilterDesign, FilterCollection, FilterDesign, SimpleFilterDesign } from '../../util/filter.util';
 import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
@@ -206,32 +206,22 @@ export class DataTableComponent extends BaseNeonComponent implements OnInit, OnD
     }
 
     /**
-     * Returns each type of filter made by this visualization as an object containing 1) a filter design with undefined values and 2) a
-     * callback to redraw the filter.  This visualization will automatically update with compatible filters that were set externally.
+     * Returns the design for each type of filter made by this visualization.  This visualization will automatically update itself with all
+     * compatible filters that were set internally or externally whenever it runs a visualization query.
      *
-     * @return {FilterBehavior[]}
+     * @return {FilterDesign[]}
      * @override
      */
-    protected designEachFilterWithNoValues(): FilterBehavior[] {
-        let behaviors: FilterBehavior[] = [];
-
-        this.options.filterFields.forEach((filterField) => {
-            behaviors.push({
+    protected designEachFilterWithNoValues(): FilterDesign[] {
+        return this.options.filterFields.reduce((designs, filterField) => {
+            if (filterField.columnName) {
                 // Match a single EQUALS filter on the specific filter field.
-                filterDesign: this.createFilterDesignOnOneValue(filterField),
-                // No redraw callback:  The filtered rows will be automatically styled with getRowClassFunction as called by the HTML.
-                redrawCallback: () => { /* Do nothing */ }
-            } as FilterBehavior);
-
-            behaviors.push({
+                designs.push(this.createFilterDesignOnOneValue(filterField));
                 // Match a compound filter with one or more EQUALS filters on the specific filter field.
-                filterDesign: this.createFilterDesignOnArrayValue([this.createFilterDesignOnOneValue(filterField)]),
-                // No redraw callback:  The filtered rows will be automatically styled with getRowClassFunction as called by the HTML.
-                redrawCallback: () => { /* Do nothing */ }
-            } as FilterBehavior);
-        });
-
-        return behaviors;
+                designs.push(this.createFilterDesignOnArrayValue([this.createFilterDesignOnOneValue(filterField)]));
+            }
+            return designs;
+        }, [] as FilterDesign[]);
     }
 
     /**
@@ -494,6 +484,23 @@ export class DataTableComponent extends BaseNeonComponent implements OnInit, OnD
     }
 
     /**
+     * Redraws this visualization with the given compatible filters.
+     *
+     * @override
+     */
+    protected redrawFilters(filters: FilterCollection): void {
+        this.tableData.forEach((item) => {
+            item._filtered = !this.options.filterFields.length ? false : this.options.filterFields.every((filterField: any) => {
+                if (filterField.columnName) {
+                    let filterDesign: FilterDesign = this.createFilterDesignOnOneValue(filterField, item[filterField.columnName]);
+                    return filters.isFiltered(filterDesign) || filters.isFiltered(this.createFilterDesignOnArrayValue([filterDesign]));
+                }
+                return false;
+            });
+        });
+    }
+
+    /**
      * Updates and redraws the elements and properties for the visualization.
      *
      * @override
@@ -588,12 +595,22 @@ export class DataTableComponent extends BaseNeonComponent implements OnInit, OnD
      *
      * @arg {any} options A WidgetOptionCollection object.
      * @arg {any[]} results
+     * @arg {FilterCollection} filters
      * @return {number}
      * @override
      */
-    transformVisualizationQueryResults(options: any, results: any[]): number {
+    transformVisualizationQueryResults(options: any, results: any[], filters: FilterCollection): number {
         this.tableData = results.map((result) => {
-            let row = {};
+            let row = {
+                _filtered: !this.options.filterFields.length ? false : this.options.filterFields.every((filterField: any) => {
+                    if (filterField.columnName) {
+                        let filterDesign: FilterDesign = this.createFilterDesignOnOneValue(filterField, result[filterField.columnName]);
+                        return filters.isFiltered(filterDesign) || filters.isFiltered(this.createFilterDesignOnArrayValue([filterDesign]));
+                    }
+                    return false;
+                })
+            };
+            // TODO THOR-1335 Wrap all of the field properties in the data item to avoid any overlap with the _filtered property.
             for (let field of options.fields) {
                 if (field.type || field.columnName === '_id') {
                     row[field.columnName] = this.toCellString(neonUtilities.deepFind(result, field.columnName), field.type);
@@ -830,14 +847,9 @@ export class DataTableComponent extends BaseNeonComponent implements OnInit, OnD
      */
     getRowClassFunction(): any {
         return (row): any => {
-            let rowClass: any = {};
-            rowClass.active = !this.options.filterFields.length ? false : this.options.filterFields.every((filterField: any) => {
-                if (filterField.columnName) {
-                    let dataFilterDesign: FilterDesign = this.createFilterDesignOnOneValue(filterField, row[filterField.columnName]);
-                    return this.isFiltered(dataFilterDesign) || this.isFiltered(this.createFilterDesignOnArrayValue([dataFilterDesign]));
-                }
-                return false;
-            });
+            let rowClass: any = {
+                active: !!row._filtered
+            };
 
             if (this.options.heatmapField.columnName && this.options.heatmapDivisor) {
                 let heatmapClass = 'heat-0';

--- a/src/app/components/document-viewer/document-viewer.component.spec.ts
+++ b/src/app/components/document-viewer/document-viewer.component.spec.ts
@@ -14,6 +14,7 @@
  */
 import { By } from '@angular/platform-browser';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { FilterCollection } from '../../util/filter.util';
 import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
 import { Injector } from '@angular/core';
 
@@ -169,7 +170,7 @@ describe('Component: DocumentViewer', () => {
         component.options.dateField = DashboardServiceMock.FIELD_MAP.DATE;
         component.options.idField = DashboardServiceMock.FIELD_MAP.ID;
 
-        let actual = component.transformVisualizationQueryResults(component.options, []);
+        let actual = component.transformVisualizationQueryResults(component.options, [], new FilterCollection());
 
         expect(component.documentViewerData).toEqual([]);
         expect(actual).toEqual(0);
@@ -188,7 +189,7 @@ describe('Component: DocumentViewer', () => {
             testTextField: 'text2',
             testDateField: 'date2',
             testIdField: 'id2'
-        }]);
+        }], new FilterCollection());
 
         expect(component.documentViewerData).toEqual([{
             data: {

--- a/src/app/components/document-viewer/document-viewer.component.ts
+++ b/src/app/components/document-viewer/document-viewer.component.ts
@@ -27,7 +27,7 @@ import {
 
 import { AbstractSearchService, FilterClause, QueryPayload, SortOrder } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterBehavior } from '../../util/filter.util';
+import { FilterCollection, FilterDesign } from '../../util/filter.util';
 import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
@@ -106,13 +106,13 @@ export class DocumentViewerComponent extends BaseNeonComponent implements OnInit
     }
 
     /**
-     * Returns each type of filter made by this visualization as an object containing 1) a filter design with undefined values and 2) a
-     * callback to redraw the filter.  This visualization will automatically update with compatible filters that were set externally.
+     * Returns the design for each type of filter made by this visualization.  This visualization will automatically update itself with all
+     * compatible filters that were set internally or externally whenever it runs a visualization query.
      *
-     * @return {FilterBehavior[]}
+     * @return {FilterDesign[]}
      * @override
      */
-    protected designEachFilterWithNoValues(): FilterBehavior[] {
+    protected designEachFilterWithNoValues(): FilterDesign[] {
         // This visualization does not filter.
         return [];
     }
@@ -196,10 +196,11 @@ export class DocumentViewerComponent extends BaseNeonComponent implements OnInit
      *
      * @arg {any} options A WidgetOptionCollection object.
      * @arg {any[]} results
+     * @arg {FilterCollection} filters
      * @return {number}
      * @override
      */
-    transformVisualizationQueryResults(options: any, results: any[]): number {
+    transformVisualizationQueryResults(options: any, results: any[], __filters: FilterCollection): number {
         let configFields: { name?: string, field: string, arrayFilter?: any }[] = neonUtilities.flatten(options.metadataFields).concat(
             neonUtilities.flatten(options.popoutFields)
         );

--- a/src/app/components/map/map.component.spec.ts
+++ b/src/app/components/map/map.component.spec.ts
@@ -27,7 +27,7 @@ import { AbstractSearchService, CompoundFilterType } from '../../services/abstra
 import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { InjectableFilterService } from '../../services/injectable.filter.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { CompoundFilterDesign } from '../../util/filter.util';
+import { CompoundFilterDesign, FilterCollection, FilterUtil } from '../../util/filter.util';
 
 import { By } from '@angular/platform-browser';
 import { AbstractMap, BoundingBoxByDegrees, MapPoint, MapType } from './map.type.abstract';
@@ -400,128 +400,124 @@ describe('Component: Map', () => {
         let actual1 = (component as any).designEachFilterWithNoValues();
         expect(actual1.length).toEqual(2);
         // Layer 1 box filter
-        expect((actual1[0].filterDesign).type).toEqual('and');
-        expect((actual1[0].filterDesign).filters.length).toEqual(4);
-        expect((actual1[0].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual1[0].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual1[0].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.Y);
-        expect((actual1[0].filterDesign).filters[0].operator).toEqual('>=');
-        expect((actual1[0].filterDesign).filters[0].value).toBeUndefined();
-        expect((actual1[0].filterDesign).filters[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual1[0].filterDesign).filters[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual1[0].filterDesign).filters[1].field).toEqual(DashboardServiceMock.FIELD_MAP.Y);
-        expect((actual1[0].filterDesign).filters[1].operator).toEqual('<=');
-        expect((actual1[0].filterDesign).filters[1].value).toBeUndefined();
-        expect((actual1[0].filterDesign).filters[2].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual1[0].filterDesign).filters[2].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual1[0].filterDesign).filters[2].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
-        expect((actual1[0].filterDesign).filters[2].operator).toEqual('>=');
-        expect((actual1[0].filterDesign).filters[2].value).toBeUndefined();
-        expect((actual1[0].filterDesign).filters[3].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual1[0].filterDesign).filters[3].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual1[0].filterDesign).filters[3].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
-        expect((actual1[0].filterDesign).filters[3].operator).toEqual('<=');
-        expect((actual1[0].filterDesign).filters[3].value).toBeUndefined();
-        expect(actual1[0].redrawCallback.toString()).toEqual((component as any).redrawFilterBox.bind(component).toString());
+        expect((actual1[0]).type).toEqual('and');
+        expect((actual1[0]).filters.length).toEqual(4);
+        expect((actual1[0]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual1[0]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual1[0]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.Y);
+        expect((actual1[0]).filters[0].operator).toEqual('>=');
+        expect((actual1[0]).filters[0].value).toBeUndefined();
+        expect((actual1[0]).filters[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual1[0]).filters[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual1[0]).filters[1].field).toEqual(DashboardServiceMock.FIELD_MAP.Y);
+        expect((actual1[0]).filters[1].operator).toEqual('<=');
+        expect((actual1[0]).filters[1].value).toBeUndefined();
+        expect((actual1[0]).filters[2].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual1[0]).filters[2].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual1[0]).filters[2].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
+        expect((actual1[0]).filters[2].operator).toEqual('>=');
+        expect((actual1[0]).filters[2].value).toBeUndefined();
+        expect((actual1[0]).filters[3].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual1[0]).filters[3].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual1[0]).filters[3].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
+        expect((actual1[0]).filters[3].operator).toEqual('<=');
+        expect((actual1[0]).filters[3].value).toBeUndefined();
         // Layer 1 point filter
-        expect((actual1[1].filterDesign).type).toEqual('and');
-        expect((actual1[1].filterDesign).filters.length).toEqual(2);
-        expect((actual1[1].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual1[1].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual1[1].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.Y);
-        expect((actual1[1].filterDesign).filters[0].operator).toEqual('=');
-        expect((actual1[1].filterDesign).filters[0].value).toBeUndefined();
-        expect((actual1[1].filterDesign).filters[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual1[1].filterDesign).filters[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual1[1].filterDesign).filters[1].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
-        expect((actual1[1].filterDesign).filters[1].operator).toEqual('=');
-        expect((actual1[1].filterDesign).filters[1].value).toBeUndefined();
-        expect(actual1[1].redrawCallback.toString()).toEqual((component as any).redrawFilterPoint.bind(component).toString());
+        expect((actual1[1]).type).toEqual('and');
+        expect((actual1[1]).filters.length).toEqual(2);
+        expect((actual1[1]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual1[1]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual1[1]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.Y);
+        expect((actual1[1]).filters[0].operator).toEqual('=');
+        expect((actual1[1]).filters[0].value).toBeUndefined();
+        expect((actual1[1]).filters[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual1[1]).filters[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual1[1]).filters[1].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
+        expect((actual1[1]).filters[1].operator).toEqual('=');
+        expect((actual1[1]).filters[1].value).toBeUndefined();
 
         updateMapLayer2(component);
         let actual2 = (component as any).designEachFilterWithNoValues();
         expect(actual2.length).toEqual(4);
-        expect((actual2[0].filterDesign)).toEqual((actual1[0].filterDesign));
-        expect((actual2[1].filterDesign)).toEqual((actual1[1].filterDesign));
+        expect((actual2[0])).toEqual((actual1[0]));
+        expect((actual2[1])).toEqual((actual1[1]));
         // Layer 2 box filter
-        expect((actual2[2].filterDesign).type).toEqual('and');
-        expect((actual2[2].filterDesign).filters.length).toEqual(4);
-        expect((actual2[2].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
-        expect((actual2[2].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable2);
-        expect((actual2[2].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.Y);
-        expect((actual2[2].filterDesign).filters[0].operator).toEqual('>=');
-        expect((actual2[2].filterDesign).filters[0].value).toBeUndefined();
-        expect((actual2[2].filterDesign).filters[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
-        expect((actual2[2].filterDesign).filters[1].table).toEqual(DashboardServiceMock.TABLES.testTable2);
-        expect((actual2[2].filterDesign).filters[1].field).toEqual(DashboardServiceMock.FIELD_MAP.Y);
-        expect((actual2[2].filterDesign).filters[1].operator).toEqual('<=');
-        expect((actual2[2].filterDesign).filters[1].value).toBeUndefined();
-        expect((actual2[2].filterDesign).filters[2].database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
-        expect((actual2[2].filterDesign).filters[2].table).toEqual(DashboardServiceMock.TABLES.testTable2);
-        expect((actual2[2].filterDesign).filters[2].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
-        expect((actual2[2].filterDesign).filters[2].operator).toEqual('>=');
-        expect((actual2[2].filterDesign).filters[2].value).toBeUndefined();
-        expect((actual2[2].filterDesign).filters[3].database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
-        expect((actual2[2].filterDesign).filters[3].table).toEqual(DashboardServiceMock.TABLES.testTable2);
-        expect((actual2[2].filterDesign).filters[3].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
-        expect((actual2[2].filterDesign).filters[3].operator).toEqual('<=');
-        expect((actual2[2].filterDesign).filters[3].value).toBeUndefined();
-        expect(actual2[2].redrawCallback.toString()).toEqual((component as any).redrawFilterBox.bind(component).toString());
+        expect((actual2[2]).type).toEqual('and');
+        expect((actual2[2]).filters.length).toEqual(4);
+        expect((actual2[2]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
+        expect((actual2[2]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable2);
+        expect((actual2[2]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.Y);
+        expect((actual2[2]).filters[0].operator).toEqual('>=');
+        expect((actual2[2]).filters[0].value).toBeUndefined();
+        expect((actual2[2]).filters[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
+        expect((actual2[2]).filters[1].table).toEqual(DashboardServiceMock.TABLES.testTable2);
+        expect((actual2[2]).filters[1].field).toEqual(DashboardServiceMock.FIELD_MAP.Y);
+        expect((actual2[2]).filters[1].operator).toEqual('<=');
+        expect((actual2[2]).filters[1].value).toBeUndefined();
+        expect((actual2[2]).filters[2].database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
+        expect((actual2[2]).filters[2].table).toEqual(DashboardServiceMock.TABLES.testTable2);
+        expect((actual2[2]).filters[2].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
+        expect((actual2[2]).filters[2].operator).toEqual('>=');
+        expect((actual2[2]).filters[2].value).toBeUndefined();
+        expect((actual2[2]).filters[3].database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
+        expect((actual2[2]).filters[3].table).toEqual(DashboardServiceMock.TABLES.testTable2);
+        expect((actual2[2]).filters[3].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
+        expect((actual2[2]).filters[3].operator).toEqual('<=');
+        expect((actual2[2]).filters[3].value).toBeUndefined();
         // Layer 2 point filter
-        expect((actual2[3].filterDesign).type).toEqual('and');
-        expect((actual2[3].filterDesign).filters.length).toEqual(2);
-        expect((actual2[3].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
-        expect((actual2[3].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable2);
-        expect((actual2[3].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.Y);
-        expect((actual2[3].filterDesign).filters[0].operator).toEqual('=');
-        expect((actual2[3].filterDesign).filters[0].value).toBeUndefined();
-        expect((actual2[3].filterDesign).filters[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
-        expect((actual2[3].filterDesign).filters[1].table).toEqual(DashboardServiceMock.TABLES.testTable2);
-        expect((actual2[3].filterDesign).filters[1].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
-        expect((actual2[3].filterDesign).filters[1].operator).toEqual('=');
-        expect((actual2[3].filterDesign).filters[1].value).toBeUndefined();
-        expect(actual2[3].redrawCallback.toString()).toEqual((component as any).redrawFilterPoint.bind(component).toString());
+        expect((actual2[3]).type).toEqual('and');
+        expect((actual2[3]).filters.length).toEqual(2);
+        expect((actual2[3]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
+        expect((actual2[3]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable2);
+        expect((actual2[3]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.Y);
+        expect((actual2[3]).filters[0].operator).toEqual('=');
+        expect((actual2[3]).filters[0].value).toBeUndefined();
+        expect((actual2[3]).filters[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
+        expect((actual2[3]).filters[1].table).toEqual(DashboardServiceMock.TABLES.testTable2);
+        expect((actual2[3]).filters[1].field).toEqual(DashboardServiceMock.FIELD_MAP.X);
+        expect((actual2[3]).filters[1].operator).toEqual('=');
+        expect((actual2[3]).filters[1].value).toBeUndefined();
 
         component.options.layers[0].filterFields = [DashboardServiceMock.FIELD_MAP.FILTER];
         let actual3 = (component as any).designEachFilterWithNoValues();
         expect(actual3.length).toEqual(5);
-        expect((actual2[0].filterDesign)).toEqual((actual2[0].filterDesign));
-        expect((actual2[1].filterDesign)).toEqual((actual2[1].filterDesign));
-        expect((actual3[3].filterDesign)).toEqual((actual2[2].filterDesign));
-        expect((actual3[4].filterDesign)).toEqual((actual2[3].filterDesign));
+        expect((actual2[0])).toEqual((actual2[0]));
+        expect((actual2[1])).toEqual((actual2[1]));
+        expect((actual3[3])).toEqual((actual2[2]));
+        expect((actual3[4])).toEqual((actual2[3]));
         // Layer 1 filter field
-        expect((actual3[2].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual3[2].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual3[2].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.FILTER);
-        expect((actual3[2].filterDesign).operator).toEqual('=');
-        expect((actual3[2].filterDesign).value).toBeUndefined();
+        expect((actual3[2]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual3[2]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual3[2]).field).toEqual(DashboardServiceMock.FIELD_MAP.FILTER);
+        expect((actual3[2]).operator).toEqual('=');
+        expect((actual3[2]).value).toBeUndefined();
 
         component.options.layers[1].filterFields = [DashboardServiceMock.FIELD_MAP.FILTER,
             DashboardServiceMock.FIELD_MAP.NAME,
             DashboardServiceMock.FIELD_MAP.TYPE];
         let actual4 = (component as any).designEachFilterWithNoValues();
         expect(actual4.length).toEqual(8);
-        expect((actual4[0].filterDesign)).toEqual((actual3[0].filterDesign));
-        expect((actual4[1].filterDesign)).toEqual((actual3[1].filterDesign));
-        expect((actual4[2].filterDesign)).toEqual((actual3[2].filterDesign));
-        expect((actual4[3].filterDesign)).toEqual((actual3[3].filterDesign));
-        expect((actual4[4].filterDesign)).toEqual((actual3[4].filterDesign));
+        expect((actual4[0])).toEqual((actual3[0]));
+        expect((actual4[1])).toEqual((actual3[1]));
+        expect((actual4[2])).toEqual((actual3[2]));
+        expect((actual4[3])).toEqual((actual3[3]));
+        expect((actual4[4])).toEqual((actual3[4]));
         // Layer 2 filter fields
-        expect((actual4[5].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
-        expect((actual4[5].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable2);
-        expect((actual4[5].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.FILTER);
-        expect((actual4[5].filterDesign).operator).toEqual('=');
-        expect((actual4[5].filterDesign).value).toBeUndefined();
-        expect((actual4[6].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
-        expect((actual4[6].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable2);
-        expect((actual4[6].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
-        expect((actual4[6].filterDesign).operator).toEqual('=');
-        expect((actual4[6].filterDesign).value).toBeUndefined();
-        expect((actual4[7].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
-        expect((actual4[7].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable2);
-        expect((actual4[7].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.TYPE);
-        expect((actual4[7].filterDesign).operator).toEqual('=');
-        expect((actual4[7].filterDesign).value).toBeUndefined();
+        expect((actual4[5]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
+        expect((actual4[5]).table).toEqual(DashboardServiceMock.TABLES.testTable2);
+        expect((actual4[5]).field).toEqual(DashboardServiceMock.FIELD_MAP.FILTER);
+        expect((actual4[5]).operator).toEqual('=');
+        expect((actual4[5]).value).toBeUndefined();
+        expect((actual4[6]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
+        expect((actual4[6]).table).toEqual(DashboardServiceMock.TABLES.testTable2);
+        expect((actual4[6]).field).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
+        expect((actual4[6]).operator).toEqual('=');
+        expect((actual4[6]).value).toBeUndefined();
+        expect((actual4[7]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase2);
+        expect((actual4[7]).table).toEqual(DashboardServiceMock.TABLES.testTable2);
+        expect((actual4[7]).field).toEqual(DashboardServiceMock.FIELD_MAP.TYPE);
+        expect((actual4[7]).operator).toEqual('=');
+        expect((actual4[7]).value).toBeUndefined();
     });
 
     it('filterByLocation does call exchangeFilters with filters on each layer', () => {
@@ -1076,7 +1072,7 @@ describe('Component: Map', () => {
         // TODO
     });
 
-    it('redrawFilterBox with filter arguments does draw one new filter box', () => {
+    it('redrawFilters with box filter arguments does draw one new filter box', () => {
         component.assignTestMap();
         let mapSpy = component.spyOnTestMap('drawBoundary');
         const filters = [1, 2, 3, 4].map((val) => ({
@@ -1110,37 +1106,39 @@ describe('Component: Map', () => {
         col.unsharedFilterValue = '';
         component.options.layers[0] = col;
 
-        component['redrawFilterBox']([{
-            root: CompoundFilterType.AND,
-            type: CompoundFilterType.AND,
-            name: 'blah',
-            filters
-        } as CompoundFilterDesign]);
+        let testCollection = new FilterCollection();
+        spyOn(testCollection, 'getCompatibleFilters').and.callFake((design) => design.filters.length === 4 ? [
+            FilterUtil.createFilterFromDesign({
+                root: CompoundFilterType.AND,
+                type: CompoundFilterType.AND,
+                filters
+            } as CompoundFilterDesign)
+        ] : []);
+
+        component['redrawFilters'](testCollection);
         expect(mapSpy.calls.count()).toEqual(1);
     });
 
-    it('redrawFilterBox with no filter arguments does remove old filter box', () => {
+    it('redrawFilters with no box filter arguments does remove old filter box', () => {
         component.assignTestMap();
         let mapSpy = component.spyOnTestMap('removeFilterBox');
-        component['redrawFilterBox']([
-
-        ]);
+        component['redrawFilters'](new FilterCollection());
         expect(mapSpy.calls.count()).toEqual(1);
     });
 
-    it('redrawFilterBox with multiple filter arguments does draw multiple new filter boxes', () => {
+    it('redrawFilters with multiple box filter arguments does draw multiple new filter boxes', () => {
         // TODO THOR-1102
     });
 
-    it('redrawFilterBox with filter arguments does draw new filter boxes and remove old filter boxes', () => {
+    it('redrawFilters with box filter arguments does draw new filter boxes and remove old filter boxes', () => {
         // TODO THOR-1102
     });
 
-    it('redrawFilterPoint with no filter arguments does remove old points', () => {
+    it('redrawFilters with no point filter arguments does remove old points', () => {
         // TODO THOR-1104
     });
 
-    it('redrawFilterPoint with filter arguments does draw new points', () => {
+    it('redrawFilters with point filter arguments does draw new points', () => {
         // TODO THOR-1104
     });
 

--- a/src/app/components/media-viewer/media-viewer.component.spec.ts
+++ b/src/app/components/media-viewer/media-viewer.component.spec.ts
@@ -14,6 +14,7 @@
  */
 import { By } from '@angular/platform-browser';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { FilterCollection } from '../../util/filter.util';
 import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
 import { MediaTypes } from '../../models/types';
 import { Injector } from '@angular/core';
@@ -205,7 +206,7 @@ describe('Component: MediaViewer', () => {
             }]
         }];
 
-        component.transformVisualizationQueryResults(component.options, []);
+        component.transformVisualizationQueryResults(component.options, [], new FilterCollection());
 
         expect(component.tabsAndMedia).toEqual([]);
     }));
@@ -226,7 +227,7 @@ describe('Component: MediaViewer', () => {
             testLinkField: 'testLinkValue',
             testNameField: 'testNameValue',
             testTypeField: 'testTypeValue'
-        }]);
+        }], new FilterCollection());
 
         expect((component as any).errorMessage).toBe('No Data');
         expect(component.options.id).toBe('_id');
@@ -257,7 +258,7 @@ describe('Component: MediaViewer', () => {
         component.options.clearMedia = false;
         (component as any).isFiltered = () => true;
 
-        component.transformVisualizationQueryResults(component.options, []);
+        component.transformVisualizationQueryResults(component.options, [], new FilterCollection());
 
         expect(component.tabsAndMedia).toEqual([]);
     }));
@@ -277,7 +278,7 @@ describe('Component: MediaViewer', () => {
             testLinkField: 'testLinkValue',
             testNameField: 'testNameValue',
             testTypeField: 'testTypeValue'
-        }]);
+        }], new FilterCollection());
 
         expect(component.tabsAndMedia).toEqual([{
             loaded: false,
@@ -333,7 +334,7 @@ describe('Component: MediaViewer', () => {
             testLinkField: 'testLinkValue2',
             testNameField: 'testNameValue2',
             testTypeField: 'testTypeValue2'
-        }]);
+        }], new FilterCollection());
 
         expect(component.tabsAndMedia).toEqual([{
             loaded: false,
@@ -370,7 +371,7 @@ describe('Component: MediaViewer', () => {
             testLinkField: ['testLinkValue1', 'testLinkValue2'],
             testNameField: 'testNameValue',
             testTypeField: 'testTypeValue'
-        }]);
+        }], new FilterCollection());
 
         expect(component.tabsAndMedia).toEqual([{
             loaded: false,
@@ -424,7 +425,7 @@ describe('Component: MediaViewer', () => {
             testLinkField: ['testLinkValue1', 'testLinkValue2'],
             testNameField: ['testNameValue1', 'testNameValue2'],
             testTypeField: ['testTypeValue1', 'testTypeValue2']
-        }]);
+        }], new FilterCollection());
 
         expect(component.tabsAndMedia).toEqual([{
             loaded: false,
@@ -474,7 +475,7 @@ describe('Component: MediaViewer', () => {
         component.transformVisualizationQueryResults(component.options, [{
             testIdField: 'testIdValue',
             testLinkField: ''
-        }]);
+        }], new FilterCollection());
 
         expect(component.tabsAndMedia).toEqual([]);
     });
@@ -491,7 +492,7 @@ describe('Component: MediaViewer', () => {
         component.transformVisualizationQueryResults(component.options, [{
             testIdField: 'testIdValue',
             testLinkField: 'testLinkValue'
-        }]);
+        }], new FilterCollection());
 
         expect(component.tabsAndMedia).toEqual([{
             loaded: false,
@@ -525,7 +526,7 @@ describe('Component: MediaViewer', () => {
         component.transformVisualizationQueryResults(component.options, [{
             testIdField: 'testIdValue',
             testLinkField: 'testLinkValue'
-        }]);
+        }], new FilterCollection());
 
         expect(component.tabsAndMedia).toEqual([{
             loaded: false,
@@ -556,7 +557,7 @@ describe('Component: MediaViewer', () => {
         component.transformVisualizationQueryResults(component.options, [{
             testIdField: 'testIdValue',
             testLinkField: 'linkPrefix/testLinkValue'
-        }]);
+        }], new FilterCollection());
 
         expect(component.tabsAndMedia).toEqual([{
             loaded: false,
@@ -586,7 +587,7 @@ describe('Component: MediaViewer', () => {
         component.transformVisualizationQueryResults(component.options, [{
             testIdField: 'testIdValue',
             testLinkField: 'prefix/testLinkValue'
-        }]);
+        }], new FilterCollection());
 
         expect(component.tabsAndMedia).toEqual([{
             loaded: false,
@@ -625,7 +626,7 @@ describe('Component: MediaViewer', () => {
         component.transformVisualizationQueryResults(component.options, [{
             testIdField: 'testIdValue',
             testLinkField: ['video.avi', 'image.jpg', 'alpha.txt', 'audio.wav', 'other.xyz']
-        }]);
+        }], new FilterCollection());
 
         expect((component as any).errorMessage).toBe('');
         expect(component.tabsAndMedia).toEqual([{

--- a/src/app/components/media-viewer/media-viewer.component.ts
+++ b/src/app/components/media-viewer/media-viewer.component.ts
@@ -28,7 +28,7 @@ import { DomSanitizer } from '@angular/platform-browser';
 
 import { AbstractSearchService, FilterClause, QueryPayload, SortOrder } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterBehavior } from '../../util/filter.util';
+import { FilterCollection, FilterDesign } from '../../util/filter.util';
 import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
@@ -215,13 +215,13 @@ export class MediaViewerComponent extends BaseNeonComponent implements OnInit, O
     }
 
     /**
-     * Returns each type of filter made by this visualization as an object containing 1) a filter design with undefined values and 2) a
-     * callback to redraw the filter.  This visualization will automatically update with compatible filters that were set externally.
+     * Returns the design for each type of filter made by this visualization.  This visualization will automatically update itself with all
+     * compatible filters that were set internally or externally whenever it runs a visualization query.
      *
-     * @return {FilterBehavior[]}
+     * @return {FilterDesign[]}
      * @override
      */
-    protected designEachFilterWithNoValues(): FilterBehavior[] {
+    protected designEachFilterWithNoValues(): FilterDesign[] {
         // This visualization does not filter.
         return [];
     }
@@ -475,16 +475,17 @@ export class MediaViewerComponent extends BaseNeonComponent implements OnInit, O
      *
      * @arg {any} options A WidgetOptionCollection object.
      * @arg {any[]} results
+     * @arg {FilterCollection} filters
      * @return {number}
      * @override
      */
-    transformVisualizationQueryResults(options: any, results: any[]): number {
+    transformVisualizationQueryResults(options: any, results: any[], filters: FilterCollection): number {
         this.noDataId = options.id;
         this.tabsAndMedia = [];
         this.selectedTabIndex = 0;
         this.queryItems = [];
 
-        if (options.clearMedia && !this.isFiltered()) {
+        if (options.clearMedia && !filters.getFilters().length) {
             this.errorMessage = 'No Data';
             options.id = '_id';
             return 0;

--- a/src/app/components/network-graph/network-graph.component.spec.ts
+++ b/src/app/components/network-graph/network-graph.component.spec.ts
@@ -20,6 +20,7 @@ import { NeonFieldMetaData } from '../../models/dataset';
 import { InjectableFilterService } from '../../services/injectable.filter.service';
 import { AbstractSearchService } from '../../services/abstract.search.service';
 import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
+import { FilterCollection } from '../../util/filter.util';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 import { By } from '@angular/platform-browser';
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
@@ -158,7 +159,7 @@ describe('Component: NetworkGraph', () => {
             predicate: 'testPredicate3',
             provenance: 'testProvenance4',
             subject: ['testSubject4']
-        }]);
+        }], new FilterCollection());
 
         expect(component.totalNodes).toEqual(8); // Total based on allowed limit
         expect(component.displayGraph).toEqual(true);
@@ -219,7 +220,7 @@ describe('Component: NetworkGraph', () => {
             testEdgeColorField: '#5f9365',
             testXPositionField: 191,
             testYPositionField: -525
-        }]);
+        }], new FilterCollection());
 
         expect(component.totalNodes).toEqual(3); // Total based on allowed limit
         expect(component.displayGraph).toEqual(true);
@@ -287,7 +288,7 @@ describe('Component: NetworkGraph', () => {
             testNodeColorField: 'Entity',
             testNodeXPositionField: 191,
             testNodeYPositionField: -525
-        }]);
+        }], new FilterCollection());
 
         let edgesData = [{
             testEdgeNameField: 'edgeName1',
@@ -310,7 +311,7 @@ describe('Component: NetworkGraph', () => {
             testEdgeDestinationIdField: 'nodeId1'
         }];
 
-        component.transformVisualizationQueryResults(options.layers[1], edgesData);
+        component.transformVisualizationQueryResults(options.layers[1], edgesData, new FilterCollection());
 
         expect(component.totalNodes).toEqual(component.options.limit); // Total based on allowed limit
         expect(component.displayGraph).toEqual(true);
@@ -387,7 +388,7 @@ describe('Component: NetworkGraph', () => {
             testEdgeColorField: '#5f9365',
             testXPositionField: -858,
             testYPositionField: 495
-        }]);
+        }], new FilterCollection());
 
         let spy = spyOn((component as any), 'toggleFilters');
 
@@ -479,7 +480,7 @@ describe('Component: NetworkGraph', () => {
             testEdgeColorField: '#5f9365',
             testXPositionField: -858,
             testYPositionField: 495
-        }]);
+        }], new FilterCollection());
 
         let spy = spyOn((component as any), 'toggleFilters');
 
@@ -543,7 +544,7 @@ describe('Component: NetworkGraph', () => {
             testEdgeColorField: '#5f9365',
             testXPositionField: -858,
             testYPositionField: 495
-        }]);
+        }], new FilterCollection());
 
         let spy = spyOn((component as any), 'toggleFilters');
 
@@ -624,7 +625,7 @@ describe('Component: NetworkGraph', () => {
             testEdgeColorField: '#5f9365',
             testXPositionField: -858,
             testYPositionField: 495
-        }]);
+        }], new FilterCollection());
 
         let spy = spyOn((component as any), 'toggleFilters');
 
@@ -707,7 +708,7 @@ describe('Component: NetworkGraph', () => {
             testEdgeColorField: '#5f9365',
             testXPositionField: -858,
             testYPositionField: 495
-        }]);
+        }], new FilterCollection());
 
         let spy = spyOn((component as any), 'toggleFilters');
 
@@ -756,153 +757,135 @@ describe('Component: NetworkGraph', () => {
         component.options.edgeColorField = DashboardServiceMock.FIELD_MAP.TYPE;
         let actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(1);
-        expect((actual[0].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[0].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[0].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.TYPE);
-        expect((actual[0].filterDesign).operator).toEqual('!=');
-        expect((actual[0].filterDesign).value).toBeUndefined();
-        expect(actual[0].redrawCallback.toString()).toEqual((component as any).redrawLegend.bind(component).toString());
+        expect((actual[0]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[0]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[0]).field).toEqual(DashboardServiceMock.FIELD_MAP.TYPE);
+        expect((actual[0]).operator).toEqual('!=');
+        expect((actual[0]).value).toBeUndefined();
         component.options.edgeColorField = NeonFieldMetaData.get();
 
         component.options.nodeField = DashboardServiceMock.FIELD_MAP.NAME;
         actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(2);
-        expect((actual[0].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[0].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[0].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
-        expect((actual[0].filterDesign).operator).toEqual('=');
-        expect((actual[0].filterDesign).value).toBeUndefined();
-        expect(actual[0].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
-        expect((actual[1].filterDesign).type).toEqual('or');
-        expect((actual[1].filterDesign).filters.length).toEqual(1);
-        expect((actual[1].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[1].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[1].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
-        expect((actual[1].filterDesign).filters[0].operator).toEqual('=');
-        expect((actual[1].filterDesign).filters[0].value).toBeUndefined();
-        expect(actual[1].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
+        expect((actual[0]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[0]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[0]).field).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
+        expect((actual[0]).operator).toEqual('=');
+        expect((actual[0]).value).toBeUndefined();
+        expect((actual[1]).type).toEqual('or');
+        expect((actual[1]).filters.length).toEqual(1);
+        expect((actual[1]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[1]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[1]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
+        expect((actual[1]).filters[0].operator).toEqual('=');
+        expect((actual[1]).filters[0].value).toBeUndefined();
         component.options.nodeField = NeonFieldMetaData.get();
 
         component.options.filterFields = [DashboardServiceMock.FIELD_MAP.CATEGORY];
         actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(2);
-        expect((actual[0].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[0].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[0].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[0].filterDesign).operator).toEqual('=');
-        expect((actual[0].filterDesign).value).toBeUndefined();
-        expect(actual[0].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
-        expect((actual[1].filterDesign).type).toEqual('or');
-        expect((actual[1].filterDesign).filters.length).toEqual(1);
-        expect((actual[1].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[1].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[1].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[1].filterDesign).filters[0].operator).toEqual('=');
-        expect((actual[1].filterDesign).filters[0].value).toBeUndefined();
-        expect(actual[1].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
+        expect((actual[0]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[0]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[0]).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[0]).operator).toEqual('=');
+        expect((actual[0]).value).toBeUndefined();
+        expect((actual[1]).type).toEqual('or');
+        expect((actual[1]).filters.length).toEqual(1);
+        expect((actual[1]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[1]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[1]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[1]).filters[0].operator).toEqual('=');
+        expect((actual[1]).filters[0].value).toBeUndefined();
 
         component.options.multiFilterOperator = 'and';
         actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(2);
-        expect((actual[0].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[0].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[0].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[0].filterDesign).operator).toEqual('=');
-        expect((actual[0].filterDesign).value).toBeUndefined();
-        expect(actual[0].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
-        expect((actual[1].filterDesign).type).toEqual('and');
-        expect((actual[1].filterDesign).filters.length).toEqual(1);
-        expect((actual[1].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[1].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[1].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[1].filterDesign).filters[0].operator).toEqual('=');
-        expect((actual[1].filterDesign).filters[0].value).toBeUndefined();
-        expect(actual[1].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
+        expect((actual[0]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[0]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[0]).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[0]).operator).toEqual('=');
+        expect((actual[0]).value).toBeUndefined();
+        expect((actual[1]).type).toEqual('and');
+        expect((actual[1]).filters.length).toEqual(1);
+        expect((actual[1]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[1]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[1]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[1]).filters[0].operator).toEqual('=');
+        expect((actual[1]).filters[0].value).toBeUndefined();
 
         component.options.filterFields = [DashboardServiceMock.FIELD_MAP.CATEGORY, DashboardServiceMock.FIELD_MAP.TEXT];
         actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(4);
-        expect((actual[0].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[0].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[0].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[0].filterDesign).operator).toEqual('=');
-        expect((actual[0].filterDesign).value).toBeUndefined();
-        expect(actual[0].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
-        expect((actual[1].filterDesign).type).toEqual('and');
-        expect((actual[1].filterDesign).filters.length).toEqual(1);
-        expect((actual[1].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[1].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[1].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[1].filterDesign).filters[0].operator).toEqual('=');
-        expect((actual[1].filterDesign).filters[0].value).toBeUndefined();
-        expect(actual[1].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
-        expect((actual[2].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[2].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[2].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
-        expect((actual[2].filterDesign).operator).toEqual('=');
-        expect((actual[2].filterDesign).value).toBeUndefined();
-        expect(actual[2].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
-        expect((actual[3].filterDesign).type).toEqual('and');
-        expect((actual[3].filterDesign).filters.length).toEqual(1);
-        expect((actual[3].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[3].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[3].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
-        expect((actual[3].filterDesign).filters[0].operator).toEqual('=');
-        expect((actual[3].filterDesign).filters[0].value).toBeUndefined();
-        expect(actual[3].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
+        expect((actual[0]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[0]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[0]).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[0]).operator).toEqual('=');
+        expect((actual[0]).value).toBeUndefined();
+        expect((actual[1]).type).toEqual('and');
+        expect((actual[1]).filters.length).toEqual(1);
+        expect((actual[1]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[1]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[1]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[1]).filters[0].operator).toEqual('=');
+        expect((actual[1]).filters[0].value).toBeUndefined();
+        expect((actual[2]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[2]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[2]).field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
+        expect((actual[2]).operator).toEqual('=');
+        expect((actual[2]).value).toBeUndefined();
+        expect((actual[3]).type).toEqual('and');
+        expect((actual[3]).filters.length).toEqual(1);
+        expect((actual[3]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[3]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[3]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
+        expect((actual[3]).filters[0].operator).toEqual('=');
+        expect((actual[3]).filters[0].value).toBeUndefined();
 
         component.options.edgeColorField = DashboardServiceMock.FIELD_MAP.TYPE;
         component.options.nodeField = DashboardServiceMock.FIELD_MAP.NAME;
         actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(7);
-        expect((actual[0].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[0].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[0].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.TYPE);
-        expect((actual[0].filterDesign).operator).toEqual('!=');
-        expect((actual[0].filterDesign).value).toBeUndefined();
-        expect(actual[0].redrawCallback.toString()).toEqual((component as any).redrawLegend.bind(component).toString());
-        expect((actual[1].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[1].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[1].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
-        expect((actual[1].filterDesign).operator).toEqual('=');
-        expect((actual[1].filterDesign).value).toBeUndefined();
-        expect(actual[1].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
-        expect((actual[2].filterDesign).type).toEqual('and');
-        expect((actual[2].filterDesign).filters.length).toEqual(1);
-        expect((actual[2].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[2].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[2].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
-        expect((actual[2].filterDesign).filters[0].operator).toEqual('=');
-        expect((actual[2].filterDesign).filters[0].value).toBeUndefined();
-        expect(actual[2].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
-        expect((actual[3].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[3].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[3].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[3].filterDesign).operator).toEqual('=');
-        expect((actual[3].filterDesign).value).toBeUndefined();
-        expect(actual[3].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
-        expect((actual[4].filterDesign).type).toEqual('and');
-        expect((actual[4].filterDesign).filters.length).toEqual(1);
-        expect((actual[4].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[4].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[4].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[4].filterDesign).filters[0].operator).toEqual('=');
-        expect((actual[4].filterDesign).filters[0].value).toBeUndefined();
-        expect(actual[4].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
-        expect((actual[5].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[5].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[5].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
-        expect((actual[5].filterDesign).operator).toEqual('=');
-        expect((actual[5].filterDesign).value).toBeUndefined();
-        expect(actual[5].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
-        expect((actual[6].filterDesign).type).toEqual('and');
-        expect((actual[6].filterDesign).filters.length).toEqual(1);
-        expect((actual[6].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[6].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[6].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
-        expect((actual[6].filterDesign).filters[0].operator).toEqual('=');
-        expect((actual[6].filterDesign).filters[0].value).toBeUndefined();
-        expect(actual[6].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
+        expect((actual[0]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[0]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[0]).field).toEqual(DashboardServiceMock.FIELD_MAP.TYPE);
+        expect((actual[0]).operator).toEqual('!=');
+        expect((actual[0]).value).toBeUndefined();
+        expect((actual[1]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[1]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[1]).field).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
+        expect((actual[1]).operator).toEqual('=');
+        expect((actual[1]).value).toBeUndefined();
+        expect((actual[2]).type).toEqual('and');
+        expect((actual[2]).filters.length).toEqual(1);
+        expect((actual[2]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[2]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[2]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
+        expect((actual[2]).filters[0].operator).toEqual('=');
+        expect((actual[2]).filters[0].value).toBeUndefined();
+        expect((actual[3]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[3]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[3]).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[3]).operator).toEqual('=');
+        expect((actual[3]).value).toBeUndefined();
+        expect((actual[4]).type).toEqual('and');
+        expect((actual[4]).filters.length).toEqual(1);
+        expect((actual[4]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[4]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[4]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[4]).filters[0].operator).toEqual('=');
+        expect((actual[4]).filters[0].value).toBeUndefined();
+        expect((actual[5]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[5]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[5]).field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
+        expect((actual[5]).operator).toEqual('=');
+        expect((actual[5]).value).toBeUndefined();
+        expect((actual[6]).type).toEqual('and');
+        expect((actual[6]).filters.length).toEqual(1);
+        expect((actual[6]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[6]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[6]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
+        expect((actual[6]).filters[0].operator).toEqual('=');
+        expect((actual[6]).filters[0].value).toBeUndefined();
     });
 
     it('designEachFilterWithNoValues with layers does return expected object', () => {
@@ -914,53 +897,46 @@ describe('Component: NetworkGraph', () => {
 
         let actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(7);
-        expect((actual[0].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[0].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[0].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.TYPE);
-        expect((actual[0].filterDesign).operator).toEqual('!=');
-        expect((actual[0].filterDesign).value).toBeUndefined();
-        expect(actual[0].redrawCallback.toString()).toEqual((component as any).redrawLegend.bind(component).toString());
-        expect((actual[1].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[1].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[1].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
-        expect((actual[1].filterDesign).operator).toEqual('=');
-        expect((actual[1].filterDesign).value).toBeUndefined();
-        expect(actual[1].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
-        expect((actual[2].filterDesign).type).toEqual('or');
-        expect((actual[2].filterDesign).filters.length).toEqual(1);
-        expect((actual[2].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[2].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[2].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
-        expect((actual[2].filterDesign).filters[0].operator).toEqual('=');
-        expect((actual[2].filterDesign).filters[0].value).toBeUndefined();
-        expect(actual[2].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
-        expect((actual[3].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[3].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[3].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[3].filterDesign).operator).toEqual('=');
-        expect((actual[3].filterDesign).value).toBeUndefined();
-        expect(actual[3].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
-        expect((actual[4].filterDesign).type).toEqual('or');
-        expect((actual[4].filterDesign).filters.length).toEqual(1);
-        expect((actual[4].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[4].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[4].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[4].filterDesign).filters[0].operator).toEqual('=');
-        expect((actual[4].filterDesign).filters[0].value).toBeUndefined();
-        expect(actual[4].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
-        expect((actual[5].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[5].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[5].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
-        expect((actual[5].filterDesign).operator).toEqual('=');
-        expect((actual[5].filterDesign).value).toBeUndefined();
-        expect(actual[5].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
-        expect((actual[6].filterDesign).type).toEqual('or');
-        expect((actual[6].filterDesign).filters.length).toEqual(1);
-        expect((actual[6].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[6].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[6].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
-        expect((actual[6].filterDesign).filters[0].operator).toEqual('=');
-        expect((actual[6].filterDesign).filters[0].value).toBeUndefined();
-        expect(actual[6].redrawCallback.toString()).toEqual((component as any).redrawFilteredNodes.bind(component).toString());
+        expect((actual[0]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[0]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[0]).field).toEqual(DashboardServiceMock.FIELD_MAP.TYPE);
+        expect((actual[0]).operator).toEqual('!=');
+        expect((actual[0]).value).toBeUndefined();
+        expect((actual[1]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[1]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[1]).field).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
+        expect((actual[1]).operator).toEqual('=');
+        expect((actual[1]).value).toBeUndefined();
+        expect((actual[2]).type).toEqual('or');
+        expect((actual[2]).filters.length).toEqual(1);
+        expect((actual[2]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[2]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[2]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
+        expect((actual[2]).filters[0].operator).toEqual('=');
+        expect((actual[2]).filters[0].value).toBeUndefined();
+        expect((actual[3]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[3]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[3]).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[3]).operator).toEqual('=');
+        expect((actual[3]).value).toBeUndefined();
+        expect((actual[4]).type).toEqual('or');
+        expect((actual[4]).filters.length).toEqual(1);
+        expect((actual[4]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[4]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[4]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[4]).filters[0].operator).toEqual('=');
+        expect((actual[4]).filters[0].value).toBeUndefined();
+        expect((actual[5]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[5]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[5]).field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
+        expect((actual[5]).operator).toEqual('=');
+        expect((actual[5]).value).toBeUndefined();
+        expect((actual[6]).type).toEqual('or');
+        expect((actual[6]).filters.length).toEqual(1);
+        expect((actual[6]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[6]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[6]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
+        expect((actual[6]).filters[0].operator).toEqual('=');
+        expect((actual[6]).filters[0].value).toBeUndefined();
     });
 });

--- a/src/app/components/network-graph/network-graph.component.ts
+++ b/src/app/components/network-graph/network-graph.component.ts
@@ -34,7 +34,7 @@ import {
 } from '../../services/abstract.search.service';
 import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { CompoundFilterDesign, FilterBehavior, FilterDesign, SimpleFilterDesign } from '../../util/filter.util';
+import { CompoundFilterDesign, FilterCollection, FilterDesign, SimpleFilterDesign } from '../../util/filter.util';
 import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
@@ -364,22 +364,13 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
     }
 
     /**
-     * Returns each type of filter made by this visualization as an object containing 1) a filter design with undefined values and 2) a
-     * callback to redraw the filter.  This visualization will automatically update with compatible filters that were set externally.
+     * Returns the design for each type of filter made by this visualization.  This visualization will automatically update itself with all
+     * compatible filters that were set internally or externally whenever it runs a visualization query.
      *
-     * @return {FilterBehavior[]}
+     * @return {FilterDesign[]}
      * @override
      */
-    protected designEachFilterWithNoValues(): FilterBehavior[] {
-        let behaviors: FilterBehavior[] = [];
-
-        if (this.options.edgeColorField.columnName) {
-            behaviors.push({
-                filterDesign: this.createFilterDesignOnLegend(),
-                redrawCallback: this.redrawLegend.bind(this)
-            } as FilterBehavior);
-        }
-
+    protected designEachFilterWithNoValues(): FilterDesign[] {
         let filterFields: NeonFieldMetaData[] = [this.options.nodeField].concat(this.options.filterFields);
         if (this.options.layers.length) {
             this.options.layers.forEach((layer) => {
@@ -389,23 +380,15 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
             });
         }
 
-        filterFields.forEach((filterField) => {
+        return filterFields.reduce((designs, filterField) => {
             if (filterField.columnName) {
-                behaviors.push({
-                    // Match a single EQUALS filter on the specified filter field.
-                    filterDesign: this.createFilterDesignOnNodeDataItem(filterField),
-                    redrawCallback: this.redrawFilteredNodes.bind(this)
-                } as FilterBehavior);
-
-                behaviors.push({
-                    // Match a compound filter with one or more EQUALS filters on the specified filter field.
-                    filterDesign: this.createFilterDesignOnList([this.createFilterDesignOnNodeDataItem(filterField)]),
-                    redrawCallback: this.redrawFilteredNodes.bind(this)
-                } as FilterBehavior);
+                // Match a single EQUALS filter on the specified filter field.
+                designs.push(this.createFilterDesignOnNodeDataItem(filterField));
+                // Match a compound filter with one or more EQUALS filters on the specified filter field.
+                designs.push(this.createFilterDesignOnList([this.createFilterDesignOnNodeDataItem(filterField)]));
             }
-        });
-
-        return behaviors;
+            return designs;
+        }, this.options.edgeColorField.columnName ? [this.createFilterDesignOnLegend()] : [] as FilterDesign[]);
     }
 
     /**
@@ -559,6 +542,16 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
         }
     }
 
+    /**
+     * Redraws this visualization with the given compatible filters.
+     *
+     * @override
+     */
+    protected redrawFilters(__filters: FilterCollection): void {
+        // TODO AIDA-751 Update the visualization's legend using the given filters.
+        // TODO AIDA-752 Update the visualization's selected (filtered) nodes using the given filters.
+    }
+
     refreshVisualization() {
         //
     }
@@ -669,24 +662,17 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
         return cleanLabel;
     }
 
-    private redrawFilteredNodes(__filters: FilterDesign[]): void {
-        // TODO AIDA-752
-    }
-
-    private redrawLegend(__filters: FilterDesign[]): void {
-        // TODO AIDA-751
-    }
-
     /**
      * Transforms the given array of query results using the given options into an array of objects to be shown in the visualization.
      * Returns the count of elements shown in the visualization.
      *
      * @arg {any} options A WidgetOptionCollection object.
      * @arg {any[]} results
+     * @arg {FilterCollection} filters
      * @return {number}
      * @override
      */
-    transformVisualizationQueryResults(options: any, results: any[]): number {
+    transformVisualizationQueryResults(options: any, results: any[], filters: FilterCollection): number {
         this.disabledSet = [];
 
         if (this.options.layers.length) {
@@ -694,6 +680,8 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
             this.responseData.push({ options: options, results: results });
         } else {
             this.responseData = results;
+
+            // TODO AIDA-752 Use the given filters to show the selected (filtered) nodes.
 
             this.responseData.forEach((result) => {
                 for (let field of options.fields) {
@@ -730,7 +718,13 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
         }
 
         this.existingNodeNames = [];
+
+        this.displayGraph = (this.options.hideUnfiltered && !!filters.getFilters().length) || !this.options.hideUnfiltered;
+
         this.resetGraphData();
+
+        this.redrawFilters(filters);
+
         this.updateLegend();
 
         return this.graphData.nodes.getIds().length;
@@ -748,12 +742,9 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
                 array.findIndex((object) => object.id === value.id) === index).length;
 
             this.graphData.clear();
-            if (this.options.hideUnfiltered && this.isFiltered() || !this.options.hideUnfiltered) {
+            if (this.displayGraph) {
                 this.restartPhysics();
-                this.displayGraph = true;
                 this.graphData.update(graphProperties);
-            } else {
-                this.displayGraph = false;
             }
         }
 

--- a/src/app/components/news-feed/news-feed.component.spec.ts
+++ b/src/app/components/news-feed/news-feed.component.spec.ts
@@ -20,6 +20,7 @@ import { } from 'jasmine-core';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
+import { FilterCollection } from '../../util/filter.util';
 import { InjectableFilterService } from '../../services/injectable.filter.service';
 import { initializeTestBed } from '../../../testUtils/initializeTestBed';
 import { NewsFeedComponent } from './news-feed.component';
@@ -94,11 +95,11 @@ describe('Component: NewsFeed', () => {
         component.options.filterField = DashboardServiceMock.FIELD_MAP.FILTER;
         let actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(1);
-        expect((actual[0].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[0].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        // Expect((actual[0].FIELD_MAP.filterDesign).field).toEqual(DashboardServiceMock.FILTER); // TODO: Verify
-        expect((actual[0].filterDesign).operator).toEqual('=');
-        expect((actual[0].filterDesign).value).toBeUndefined();
+        expect((actual[0]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[0]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[0]).field).toEqual(DashboardServiceMock.FIELD_MAP.FILTER);
+        expect((actual[0]).operator).toEqual('=');
+        expect((actual[0]).value).toBeUndefined();
     });
 
     it('finalizeVisualizationQuery does return expected query', (() => {
@@ -175,15 +176,17 @@ describe('Component: NewsFeed', () => {
             testNameField: 'name2',
             testSizeField: 0.2,
             testTypeField: 'type2'
-        }]);
+        }], new FilterCollection());
 
         expect(component.newsFeedData).toEqual([{
+            _filtered: false,
             _id: 'id1',
             testLinkField: 'link1',
             testNameField: 'name1',
             testSizeField: 0.1,
             testTypeField: 'type1'
         }, {
+            _filtered: false,
             _id: 'id2',
             testLinkField: 'link2',
             testNameField: 'name2',
@@ -196,7 +199,7 @@ describe('Component: NewsFeed', () => {
     it('transformVisualizationQueryResults with empty aggregation query data does return expected data', () => {
         component.options.fields = DashboardServiceMock.FIELDS;
 
-        let actual = component.transformVisualizationQueryResults(component.options, []);
+        let actual = component.transformVisualizationQueryResults(component.options, [], new FilterCollection());
 
         expect(component.newsFeedData).toEqual([]);
         expect(actual).toEqual(0);
@@ -218,15 +221,17 @@ describe('Component: NewsFeed', () => {
             testNameField: 'name2',
             testSizeField: 0.2,
             testTypeField: 'type2'
-        }]);
+        }], new FilterCollection());
 
         expect(component.newsFeedData).toEqual([{
+            _filtered: false,
             _id: 'id1',
             testLinkField: 'link1',
             testNameField: 'name1',
             testSizeField: 0.1,
             testTypeField: 'type1'
         }, {
+            _filtered: false,
             _id: 'id2',
             testLinkField: 'link2',
             testNameField: 'name2',
@@ -251,30 +256,24 @@ describe('Component: NewsFeed', () => {
             testNameField: 'name2',
             testSizeField: 0.2,
             testTypeField: 'type2'
-        }]);
+        }], new FilterCollection());
 
         expect(actual).toEqual(2);
         expect(component.newsFeedData).toEqual([{
+            _filtered: false,
             _id: 'id1',
             testLinkField: 'link1',
             testNameField: 'name1',
             testSizeField: 0.1,
             testTypeField: 'type1'
         }, {
+            _filtered: false,
             _id: 'id2',
             testLinkField: 'link2',
             testNameField: 'name2',
             testSizeField: 0.2,
             testTypeField: 'type2'
         }]);
-    });
-
-    // For refreshVisualization method
-    it('refreshVisualization does call changeDetection.detectChanges', () => {
-        let spy = spyOn(component.changeDetection, 'detectChanges');
-
-        component.refreshVisualization();
-        expect(spy.calls.count()).toEqual(1);
     });
 
     // Private get array values method test?

--- a/src/app/components/news-feed/news-feed.component.ts
+++ b/src/app/components/news-feed/news-feed.component.ts
@@ -26,7 +26,7 @@ import {
 
 import { AbstractSearchService, FilterClause, QueryPayload, SortOrder } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterBehavior, FilterDesign, SimpleFilterDesign } from '../../util/filter.util';
+import { FilterCollection, FilterDesign, SimpleFilterDesign } from '../../util/filter.util';
 import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
@@ -139,24 +139,14 @@ export class NewsFeedComponent extends BaseNeonComponent implements OnInit, OnDe
     }
 
     /**
-     * Returns each type of filter made by this visualization as an object containing 1) a filter design with undefined values and 2) a
-     * callback to redraw the filter.  This visualization will automatically update with compatible filters that were set externally.
+     * Returns the design for each type of filter made by this visualization.  This visualization will automatically update itself with all
+     * compatible filters that were set internally or externally whenever it runs a visualization query.
      *
-     * @return {FilterBehavior[]}
+     * @return {FilterDesign[]}
      * @override
      */
-    protected designEachFilterWithNoValues(): FilterBehavior[] {
-        let behaviors: FilterBehavior[] = [];
-
-        if (this.options.filterField.columnName) {
-            behaviors.push({
-                filterDesign: this.createFilterDesignOnText(),
-                // No redraw callback:  The filtered text will automatically be styled with isSelected as called by the HTML.
-                redrawCallback: () => { /* Do nothing */ }
-            });
-        }
-
-        return behaviors;
+    protected designEachFilterWithNoValues(): FilterDesign[] {
+        return this.options.filterField.columnName ? [this.createFilterDesignOnText()] : [];
     }
 
     /**
@@ -249,12 +239,19 @@ export class NewsFeedComponent extends BaseNeonComponent implements OnInit, OnDe
      *
      * @arg {any} options A WidgetOptionCollection object.
      * @arg {any[]} results
+     * @arg {FilterCollection} filters
      * @return {number}
      * @override
      */
-    transformVisualizationQueryResults(options: any, results: any[]): number {
+    transformVisualizationQueryResults(options: any, results: any[], filters: FilterCollection): number {
         this.newsFeedData = results.map((result) => {
-            let item = {};
+            let item = {
+                _filtered: !!(this.options.filterField.columnName && filters.isFiltered(this.createFilterDesignOnText(
+                    result[this.options.filterField.columnName]
+                )))
+            };
+
+            // TODO THOR-1335 Wrap all of the field properties in the data item to avoid any overlap with the _filtered property.
             for (let field of options.fields) {
                 if (field.type || field.columnName === '_id') {
                     let value = neonUtilities.deepFind(result, field.columnName);
@@ -291,12 +288,25 @@ export class NewsFeedComponent extends BaseNeonComponent implements OnInit, OnDe
     }
 
     /**
+     * Redraws this visualization with the given compatible filters.
+     *
+     * @override
+     */
+    protected redrawFilters(filters: FilterCollection): void {
+        this.newsFeedData.forEach((item) => {
+            item._filtered = this.options.filterField.columnName && filters.isFiltered(this.createFilterDesignOnText(
+                item[this.options.filterField.columnName]
+            ));
+        });
+    }
+
+    /**
      * Updates and redraws the elements and properties for the visualization.
      *
      * @override
      */
     refreshVisualization() {
-        this.changeDetection.detectChanges();
+        // Do nothing.
     }
 
     onResize() {
@@ -344,8 +354,6 @@ export class NewsFeedComponent extends BaseNeonComponent implements OnInit, OnDe
      * @return {boolean}
      */
     isSelected(item) {
-        return (!!this.options.filterField.columnName && this.isFiltered(this.createFilterDesignOnText(
-            item[this.options.filterField.columnName]
-        )));
+        return item._filtered;
     }
 }

--- a/src/app/components/query-bar/query-bar.component.ts
+++ b/src/app/components/query-bar/query-bar.component.ts
@@ -20,7 +20,7 @@ import { map, startWith } from 'rxjs/operators';
 import { AbstractSearchService, CompoundFilterType, FilterClause, QueryPayload } from '../../services/abstract.search.service';
 import { InjectableColorThemeService } from '../../services/injectable.color-theme.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { CompoundFilterDesign, FilterBehavior, FilterDesign, SimpleFilterDesign } from '../../util/filter.util';
+import { CompoundFilterDesign, FilterCollection, FilterDesign, SimpleFilterDesign } from '../../util/filter.util';
 import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
@@ -135,42 +135,29 @@ export class QueryBarComponent extends BaseNeonComponent {
     }
 
     /**
-     * Returns each type of filter made by this visualization as an object containing 1) a filter design with undefined values and 2) a
-     * callback to redraw the filter.  This visualization will automatically update with compatible filters that were set externally.
+     * Returns the design for each type of filter made by this visualization.  This visualization will automatically update itself with all
+     * compatible filters that were set internally or externally whenever it runs a visualization query.
      *
-     * @return {FilterBehavior[]}
+     * @return {FilterDesign[]}
      * @override
      */
-    protected designEachFilterWithNoValues(): FilterBehavior[] {
-        let behaviors: FilterBehavior[] = [];
-
-        if (this.options.filterField.columnName) {
-            behaviors.push({
-                // Match a single EQUALS filter on the filter field.
-                filterDesign: this.createFilterDesignOnText(),
-                redrawCallback: this.updateQueryBarText.bind(this)
-            });
-        }
+    protected designEachFilterWithNoValues(): FilterDesign[] {
+        // Match a single EQUALS filter on the filter field.
+        let designs: FilterDesign[] = this.options.filterField.columnName ? [this.createFilterDesignOnText()] : [];
 
         if (this.options.extendedFilter) {
             this.options.extensionFields.forEach((extensionField) => {
-                behaviors.push({
-                    // Match a single EQUALS filter on the extension database/table/field.
-                    filterDesign: this.createFilterDesignOnExtensionField(extensionField.database, extensionField.table,
-                        extensionField.idField),
-                    redrawCallback: () => { /* Do nothing */ }
-                });
+                // Match a single EQUALS filter on the extension database/table/field.
+                designs.push(this.createFilterDesignOnExtensionField(extensionField.database, extensionField.table,
+                    extensionField.idField));
 
-                behaviors.push({
-                    // Match a compound OR filter with one or more EQUALS filters on the extension database/table/field.
-                    filterDesign: this.createFilterDesignOnList([this.createFilterDesignOnExtensionField(extensionField.database,
-                        extensionField.table, extensionField.idField)]),
-                    redrawCallback: () => { /* Do nothing */ }
-                });
+                // Match a compound OR filter with one or more EQUALS filters on the extension database/table/field.
+                designs.push(this.createFilterDesignOnList([this.createFilterDesignOnExtensionField(extensionField.database,
+                    extensionField.table, extensionField.idField)]));
             });
         }
 
-        return behaviors;
+        return designs;
     }
 
     /**
@@ -226,10 +213,11 @@ export class QueryBarComponent extends BaseNeonComponent {
      *
      * @arg {any} options A WidgetOptionCollection object.
      * @arg {any[]} results
+     * @arg {FilterCollection} filters
      * @return {number}
      * @override
      */
-    transformVisualizationQueryResults(options: any, results: any[]): number {
+    transformVisualizationQueryResults(options: any, results: any[], filters: FilterCollection): number {
         this.queryArray = [];
 
         let setValues = true;
@@ -258,6 +246,8 @@ export class QueryBarComponent extends BaseNeonComponent {
         }
 
         this.queryBarSetup();
+
+        this.redrawFilters(filters);
 
         return this.queryValues.length;
     }
@@ -428,7 +418,12 @@ export class QueryBarComponent extends BaseNeonComponent {
         return false;
     }
 
-    private updateQueryBarText(__filters: FilterDesign[]) {
-        // TODO AIDA-754
+    /**
+     * Redraws this visualization with the given compatible filters.
+     *
+     * @override
+     */
+    protected redrawFilters(__filters: FilterCollection): void {
+        // TODO AIDA-754 Update the query bar active text using the given filters.
     }
 }

--- a/src/app/components/sample/sample.component.spec.ts
+++ b/src/app/components/sample/sample.component.spec.ts
@@ -26,6 +26,7 @@ import { AbstractSearchService } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
 import { InjectableFilterService } from '../../services/injectable.filter.service';
 
+import { FilterCollection } from '../../util/filter.util';
 import { NeonFieldMetaData } from '../../models/dataset';
 
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
@@ -175,11 +176,11 @@ describe('Component: Sample', () => {
         component.options.sampleRequiredField = DashboardServiceMock.FIELD_MAP.FILTER;
         let actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(1);
-        expect((actual[0].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[0].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[0].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.FILTER);
-        expect((actual[0].filterDesign).operator).toEqual('=');
-        expect((actual[0].filterDesign).value).toBeUndefined();
+        expect((actual[0]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[0]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[0]).field).toEqual(DashboardServiceMock.FIELD_MAP.FILTER);
+        expect((actual[0]).operator).toEqual('=');
+        expect((actual[0]).value).toBeUndefined();
     });
 
     it('finalizeVisualizationQuery does return expected query', () => {
@@ -378,7 +379,7 @@ describe('Component: Sample', () => {
         }, {
             _aggregation: 1,
             testRequiredField1: 'z'
-        }]);
+        }], new FilterCollection());
         expect(component.visualizationData).toEqual([{
             count: 2,
             field: component.options.sampleRequiredField,
@@ -399,7 +400,7 @@ describe('Component: Sample', () => {
             prettyName: 'Test Required Field 1'
         });
 
-        let actual = component.transformVisualizationQueryResults(component.options, []);
+        let actual = component.transformVisualizationQueryResults(component.options, [], new FilterCollection());
         expect(component.visualizationData).toEqual([]);
         expect(actual).toEqual(0);
     });
@@ -422,7 +423,7 @@ describe('Component: Sample', () => {
             _aggregation: 1,
             testOptionalField1: 'omega',
             testRequiredField1: 'z'
-        }]);
+        }], new FilterCollection());
         expect(component.visualizationData).toEqual([{
             count: 2,
             field: component.options.sampleRequiredField,

--- a/src/app/components/sample/sample.component.ts
+++ b/src/app/components/sample/sample.component.ts
@@ -31,7 +31,7 @@ import {
     SortOrder
 } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterBehavior, FilterDesign, SimpleFilterDesign } from '../../util/filter.util';
+import { FilterCollection, FilterDesign, SimpleFilterDesign } from '../../util/filter.util';
 import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { AbstractSubcomponent } from './subcomponent.abstract';
@@ -140,25 +140,15 @@ export class SampleComponent extends BaseNeonComponent implements OnInit, OnDest
     }
 
     /**
-     * Returns each type of filter made by this visualization as an object containing 1) a filter design with undefined values and 2) a
-     * callback to redraw the filter.  This visualization will automatically update with compatible filters that were set externally.
+     * Returns the design for each type of filter made by this visualization.  This visualization will automatically update itself with all
+     * compatible filters that were set internally or externally whenever it runs a visualization query.
      *
-     * @return {FilterBehavior[]}
+     * @return {FilterDesign[]}
      * @override
      */
-    protected designEachFilterWithNoValues(): FilterBehavior[] {
-        let behaviors: FilterBehavior[] = [];
-
+    protected designEachFilterWithNoValues(): FilterDesign[] {
         // Add a filter design callback on each specific filter field.
-        if (this.options.sampleRequiredField.columnName) {
-            behaviors.push({
-                filterDesign: this.createFilterDesign(this.options.sampleRequiredField),
-                // No redraw callback:  The filtered text does not have its own HTML styles.
-                redrawCallback: () => { /* Do nothing */ }
-            });
-        }
-
-        return behaviors;
+        return this.options.sampleRequiredField.columnName ? [this.createFilterDesign(this.options.sampleRequiredField)] : [];
     }
 
     /**
@@ -322,10 +312,11 @@ export class SampleComponent extends BaseNeonComponent implements OnInit, OnDest
      *
      * @arg {any} options A WidgetOptionCollection object.
      * @arg {any[]} results
+     * @arg {FilterCollection} filters
      * @return {number}
      * @override
      */
-    transformVisualizationQueryResults(options: any, results: any[]): number {
+    transformVisualizationQueryResults(options: any, results: any[], __filters: FilterCollection): number {
         // TODO Change this behavior as needed to handle your query results:  update and/or redraw and properties and/or subcomponents.
 
         // The aggregation query response data will have an _aggregation field and all visualization fields.

--- a/src/app/components/taxonomy-viewer/taxonomy-viewer.component.spec.ts
+++ b/src/app/components/taxonomy-viewer/taxonomy-viewer.component.spec.ts
@@ -18,7 +18,7 @@ import { Injector } from '@angular/core';
 import { } from 'jasmine-core';
 
 import { AbstractSearchService } from '../../services/abstract.search.service';
-import { CompoundFilterDesign, SimpleFilterDesign } from '../../util/filter.util';
+import { CompoundFilterDesign, FilterCollection, SimpleFilterDesign } from '../../util/filter.util';
 import { InjectableFilterService } from '../../services/injectable.filter.service';
 import { DashboardService } from '../../services/dashboard.service';
 
@@ -249,7 +249,7 @@ describe('Component: TaxonomyViewer', () => {
         component.options.table = DashboardServiceMock.TABLES.testTable1;
         component.options.ascending = true;
 
-        component.transformVisualizationQueryResults(component.options, responseData);
+        component.transformVisualizationQueryResults(component.options, responseData, new FilterCollection());
 
         expect(component.taxonomyGroups.length).toEqual(4);
         expect(component.taxonomyGroups[0].name).toEqual('testCategoryI');
@@ -269,7 +269,7 @@ describe('Component: TaxonomyViewer', () => {
         component.options.subTypeField = NeonFieldMetaData.get({ columnName: 'testSubTypeField' });
         component.options.filterFields = ['testFilter1', 'testFilter2'];
 
-        component.transformVisualizationQueryResults(component.options, responseData);
+        component.transformVisualizationQueryResults(component.options, responseData, new FilterCollection());
 
         fixture.detectChanges();
 
@@ -292,7 +292,7 @@ describe('Component: TaxonomyViewer', () => {
         component.options.subTypeField = NeonFieldMetaData.get({ columnName: 'testSubTypeField' });
         component.options.filterFields = ['testFilter1', 'testFilter2'];
 
-        component.transformVisualizationQueryResults(component.options, responseData);
+        component.transformVisualizationQueryResults(component.options, responseData, new FilterCollection());
 
         fixture.detectChanges();
 
@@ -317,7 +317,7 @@ describe('Component: TaxonomyViewer', () => {
         component.options.subTypeField = NeonFieldMetaData.get({ columnName: 'testSubTypeField' });
         component.options.filterFields = ['testFilter1', 'testFilter2'];
 
-        component.transformVisualizationQueryResults(component.options, responseData);
+        component.transformVisualizationQueryResults(component.options, responseData, new FilterCollection());
 
         fixture.detectChanges();
 
@@ -341,7 +341,7 @@ describe('Component: TaxonomyViewer', () => {
         component.options.subTypeField = NeonFieldMetaData.get({ columnName: 'testSubTypeField' });
         component.options.filterFields = ['testFilter1', 'testFilter2'];
 
-        component.transformVisualizationQueryResults(component.options, responseData);
+        component.transformVisualizationQueryResults(component.options, responseData, new FilterCollection());
 
         fixture.detectChanges();
 
@@ -360,7 +360,7 @@ describe('Component: TaxonomyViewer', () => {
         component.options.subTypeField = NeonFieldMetaData.get({ columnName: 'testSubTypeField' });
         component.options.filterFields = ['testFilter1', 'testFilter2'];
 
-        component.transformVisualizationQueryResults(component.options, responseData);
+        component.transformVisualizationQueryResults(component.options, responseData, new FilterCollection());
 
         fixture.detectChanges();
 
@@ -379,7 +379,7 @@ describe('Component: TaxonomyViewer', () => {
         component.options.subTypeField = NeonFieldMetaData.get({ columnName: 'testSubTypeField' });
         component.options.valueField = NeonFieldMetaData.get({ columnName: 'testValueField' });
 
-        component.transformVisualizationQueryResults(component.options, responseData);
+        component.transformVisualizationQueryResults(component.options, responseData, new FilterCollection());
 
         fixture.detectChanges();
 
@@ -416,7 +416,7 @@ describe('Component: TaxonomyViewer', () => {
         component.options.subTypeField = NeonFieldMetaData.get({ columnName: 'testSubTypeField' });
         component.options.valueField = NeonFieldMetaData.get({ columnName: 'testValueField' });
 
-        component.transformVisualizationQueryResults(component.options, responseData);
+        component.transformVisualizationQueryResults(component.options, responseData, new FilterCollection());
 
         fixture.detectChanges();
 
@@ -488,98 +488,86 @@ describe('Component: TaxonomyViewer', () => {
         component.options.categoryField = DashboardServiceMock.FIELD_MAP.CATEGORY;
         let actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(2);
-        expect((actual[0].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[0].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[0].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[0].filterDesign).operator).toEqual('!=');
-        expect((actual[0].filterDesign).value).toBeUndefined();
-        expect(actual[0].redrawCallback.toString()).toEqual((component as any).redrawTaxonomy.bind(component).toString());
-        expect((actual[1].filterDesign).type).toEqual('and');
-        expect((actual[1].filterDesign).filters.length).toEqual(1);
-        expect((actual[1].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[1].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[1].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[1].filterDesign).filters[0].operator).toEqual('!=');
-        expect((actual[1].filterDesign).filters[0].value).toBeUndefined();
-        expect(actual[1].redrawCallback.toString()).toEqual((component as any).redrawTaxonomy.bind(component).toString());
+        expect((actual[0]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[0]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[0]).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[0]).operator).toEqual('!=');
+        expect((actual[0]).value).toBeUndefined();
+        expect((actual[1]).type).toEqual('and');
+        expect((actual[1]).filters.length).toEqual(1);
+        expect((actual[1]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[1]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[1]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[1]).filters[0].operator).toEqual('!=');
+        expect((actual[1]).filters[0].value).toBeUndefined();
 
         component.options.typeField = DashboardServiceMock.FIELD_MAP.TYPE;
         actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(4);
-        expect((actual[0].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[0].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[0].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[0].filterDesign).operator).toEqual('!=');
-        expect((actual[0].filterDesign).value).toBeUndefined();
-        expect(actual[0].redrawCallback.toString()).toEqual((component as any).redrawTaxonomy.bind(component).toString());
-        expect((actual[1].filterDesign).type).toEqual('and');
-        expect((actual[1].filterDesign).filters.length).toEqual(1);
-        expect((actual[1].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[1].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[1].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[1].filterDesign).filters[0].operator).toEqual('!=');
-        expect((actual[1].filterDesign).filters[0].value).toBeUndefined();
-        expect(actual[1].redrawCallback.toString()).toEqual((component as any).redrawTaxonomy.bind(component).toString());
-        expect((actual[2].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[2].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[2].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.TYPE);
-        expect((actual[2].filterDesign).operator).toEqual('!=');
-        expect((actual[2].filterDesign).value).toBeUndefined();
-        expect(actual[2].redrawCallback.toString()).toEqual((component as any).redrawTaxonomy.bind(component).toString());
-        expect((actual[3].filterDesign).type).toEqual('and');
-        expect((actual[3].filterDesign).filters.length).toEqual(1);
-        expect((actual[3].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[3].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[3].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TYPE);
-        expect((actual[3].filterDesign).filters[0].operator).toEqual('!=');
-        expect((actual[3].filterDesign).filters[0].value).toBeUndefined();
-        expect(actual[3].redrawCallback.toString()).toEqual((component as any).redrawTaxonomy.bind(component).toString());
+        expect((actual[0]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[0]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[0]).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[0]).operator).toEqual('!=');
+        expect((actual[0]).value).toBeUndefined();
+        expect((actual[1]).type).toEqual('and');
+        expect((actual[1]).filters.length).toEqual(1);
+        expect((actual[1]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[1]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[1]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[1]).filters[0].operator).toEqual('!=');
+        expect((actual[1]).filters[0].value).toBeUndefined();
+        expect((actual[2]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[2]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[2]).field).toEqual(DashboardServiceMock.FIELD_MAP.TYPE);
+        expect((actual[2]).operator).toEqual('!=');
+        expect((actual[2]).value).toBeUndefined();
+        expect((actual[3]).type).toEqual('and');
+        expect((actual[3]).filters.length).toEqual(1);
+        expect((actual[3]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[3]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[3]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TYPE);
+        expect((actual[3]).filters[0].operator).toEqual('!=');
+        expect((actual[3]).filters[0].value).toBeUndefined();
 
         component.options.subTypeField = DashboardServiceMock.FIELD_MAP.NAME;
         actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(6);
-        expect((actual[0].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[0].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[0].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[0].filterDesign).operator).toEqual('!=');
-        expect((actual[0].filterDesign).value).toBeUndefined();
-        expect(actual[0].redrawCallback.toString()).toEqual((component as any).redrawTaxonomy.bind(component).toString());
-        expect((actual[1].filterDesign).type).toEqual('and');
-        expect((actual[1].filterDesign).filters.length).toEqual(1);
-        expect((actual[1].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[1].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[1].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
-        expect((actual[1].filterDesign).filters[0].operator).toEqual('!=');
-        expect((actual[1].filterDesign).filters[0].value).toBeUndefined();
-        expect(actual[1].redrawCallback.toString()).toEqual((component as any).redrawTaxonomy.bind(component).toString());
-        expect((actual[2].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[2].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[2].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.TYPE);
-        expect((actual[2].filterDesign).operator).toEqual('!=');
-        expect((actual[2].filterDesign).value).toBeUndefined();
-        expect(actual[2].redrawCallback.toString()).toEqual((component as any).redrawTaxonomy.bind(component).toString());
-        expect((actual[3].filterDesign).type).toEqual('and');
-        expect((actual[3].filterDesign).filters.length).toEqual(1);
-        expect((actual[3].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[3].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[3].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TYPE);
-        expect((actual[3].filterDesign).filters[0].operator).toEqual('!=');
-        expect((actual[3].filterDesign).filters[0].value).toBeUndefined();
-        expect(actual[3].redrawCallback.toString()).toEqual((component as any).redrawTaxonomy.bind(component).toString());
-        expect((actual[4].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[4].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[4].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
-        expect((actual[4].filterDesign).operator).toEqual('!=');
-        expect((actual[4].filterDesign).value).toBeUndefined();
-        expect(actual[4].redrawCallback.toString()).toEqual((component as any).redrawTaxonomy.bind(component).toString());
-        expect((actual[5].filterDesign).type).toEqual('and');
-        expect((actual[5].filterDesign).filters.length).toEqual(1);
-        expect((actual[5].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[5].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[5].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
-        expect((actual[5].filterDesign).filters[0].operator).toEqual('!=');
-        expect((actual[5].filterDesign).filters[0].value).toBeUndefined();
-        expect(actual[5].redrawCallback.toString()).toEqual((component as any).redrawTaxonomy.bind(component).toString());
+        expect((actual[0]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[0]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[0]).field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[0]).operator).toEqual('!=');
+        expect((actual[0]).value).toBeUndefined();
+        expect((actual[1]).type).toEqual('and');
+        expect((actual[1]).filters.length).toEqual(1);
+        expect((actual[1]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[1]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[1]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.CATEGORY);
+        expect((actual[1]).filters[0].operator).toEqual('!=');
+        expect((actual[1]).filters[0].value).toBeUndefined();
+        expect((actual[2]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[2]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[2]).field).toEqual(DashboardServiceMock.FIELD_MAP.TYPE);
+        expect((actual[2]).operator).toEqual('!=');
+        expect((actual[2]).value).toBeUndefined();
+        expect((actual[3]).type).toEqual('and');
+        expect((actual[3]).filters.length).toEqual(1);
+        expect((actual[3]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[3]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[3]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TYPE);
+        expect((actual[3]).filters[0].operator).toEqual('!=');
+        expect((actual[3]).filters[0].value).toBeUndefined();
+        expect((actual[4]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[4]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[4]).field).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
+        expect((actual[4]).operator).toEqual('!=');
+        expect((actual[4]).value).toBeUndefined();
+        expect((actual[5]).type).toEqual('and');
+        expect((actual[5]).filters.length).toEqual(1);
+        expect((actual[5]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[5]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[5]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.NAME);
+        expect((actual[5]).filters[0].operator).toEqual('!=');
+        expect((actual[5]).filters[0].value).toBeUndefined();
     });
 
     it('checkRelatedNodes to deselect a category does call exchangeFilters with category / type / subtype filters', () => {

--- a/src/app/components/text-cloud/text-cloud.component.scss
+++ b/src/app/components/text-cloud/text-cloud.component.scss
@@ -16,7 +16,6 @@
 @import '../base-neon-component/base-neon.component';
 
 :host {
-
     .text-cloud {
         overflow-wrap: break-word;
         display: inline-block;
@@ -33,6 +32,8 @@
         }
 
         .filter {
+            font-weight: 900;
+
             &:not(:hover) {
                 color: var(--color-data-item-selectable-contrast, dimgrey) !important;
             }

--- a/src/app/components/text-cloud/text-cloud.component.spec.ts
+++ b/src/app/components/text-cloud/text-cloud.component.spec.ts
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FilterCollection } from '../../util/filter.util';
 import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../../models/dataset';
 
 import { Injector } from '@angular/core';
@@ -127,12 +128,11 @@ describe('Component: TextCloud', () => {
         component.options.dataField = DashboardServiceMock.FIELD_MAP.TEXT;
         let actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(1);
-        expect((actual[0].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[0].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[0].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
-        expect((actual[0].filterDesign).operator).toEqual('=');
-        expect((actual[0].filterDesign).value).toBeUndefined();
-        expect(actual[0].redrawCallback.toString()).toEqual((component as any).redrawText.bind(component).toString());
+        expect((actual[0]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[0]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[0]).field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
+        expect((actual[0]).operator).toEqual('=');
+        expect((actual[0]).value).toBeUndefined();
     });
 
     it('onClick does call toggleFilters with expected object', () => {
@@ -174,7 +174,7 @@ describe('Component: TextCloud', () => {
         }]]);
     });
 
-    it('redrawText does update textCloudData if no text is selected', () => {
+    it('redrawFilters does update textCloudData if no text is selected', () => {
         component.textCloudData = [{
             color: 'color1',
             fontSize: 'fontSize1',
@@ -191,9 +191,7 @@ describe('Component: TextCloud', () => {
             value: 'value2'
         }];
 
-        spyOn((component as any), 'isFiltered').and.returnValue(false);
-
-        (component as any).redrawText();
+        (component as any).redrawFilters(new FilterCollection());
 
         expect(component.textCloudData).toEqual([{
             color: 'color1',
@@ -212,7 +210,7 @@ describe('Component: TextCloud', () => {
         }]);
     });
 
-    it('redrawText does update textCloudData if some text is selected', () => {
+    it('redrawFilters does update textCloudData if some text is selected', () => {
         component.textCloudData = [{
             color: 'color1',
             fontSize: 'fontSize1',
@@ -229,9 +227,10 @@ describe('Component: TextCloud', () => {
             value: 'value2'
         }];
 
-        spyOn((component as any), 'isFiltered').and.callFake((filterDesign) => filterDesign.value === 'key2');
+        let testCollection = new FilterCollection();
+        spyOn(testCollection, 'isFiltered').and.callFake((design) => design.value === 'key2');
 
-        (component as any).redrawText();
+        (component as any).redrawFilters(testCollection);
 
         expect(component.textCloudData).toEqual([{
             color: 'color1',
@@ -253,14 +252,14 @@ describe('Component: TextCloud', () => {
     it('transformVisualizationQueryResults with no data does return expected data', () => {
         component.options.dataField = NeonFieldMetaData.get({ columnName: 'testTextField', prettyName: 'Test Text Field' });
 
-        let actual1 = component.transformVisualizationQueryResults(component.options, []);
+        let actual1 = component.transformVisualizationQueryResults(component.options, [], new FilterCollection());
 
         expect(component.textCloudData).toEqual([]);
         expect(actual1).toEqual(0);
 
         component.options.sizeField = NeonFieldMetaData.get({ columnName: 'testSizeField', prettyName: 'Test Size Field' });
 
-        let actual2 = component.transformVisualizationQueryResults(component.options, []);
+        let actual2 = component.transformVisualizationQueryResults(component.options, [], new FilterCollection());
 
         expect(component.textCloudData).toEqual([]);
         expect(actual2).toEqual(0);
@@ -279,7 +278,7 @@ describe('Component: TextCloud', () => {
             testTextField: 'Third'
         }];
 
-        let actual1 = component.transformVisualizationQueryResults(component.options, data);
+        let actual1 = component.transformVisualizationQueryResults(component.options, data, new FilterCollection());
 
         expect(component.textCloudData).toEqual([{
             fontSize: '140%',

--- a/src/app/components/thumbnail-grid/thumbnail-grid.component.spec.ts
+++ b/src/app/components/thumbnail-grid/thumbnail-grid.component.spec.ts
@@ -14,6 +14,7 @@
  */
 import { By } from '@angular/platform-browser';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { FilterCollection } from '../../util/filter.util';
 import { NeonFieldMetaData } from '../../models/dataset';
 import { Injector } from '@angular/core';
 
@@ -508,18 +509,18 @@ describe('Component: ThumbnailGrid', () => {
         component.options.filterFields = [DashboardServiceMock.FIELD_MAP.FILTER];
         let actual = (component as any).designEachFilterWithNoValues();
         expect(actual.length).toEqual(2);
-        expect((actual[0].filterDesign).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[0].filterDesign).table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[0].filterDesign).field).toEqual(DashboardServiceMock.FIELD_MAP.FILTER);
-        expect((actual[0].filterDesign).operator).toEqual('=');
-        expect((actual[0].filterDesign).value).toBeUndefined();
-        expect((actual[1].filterDesign).type).toEqual(CompoundFilterType.OR);
-        expect((actual[1].filterDesign).filters.length).toEqual(1);
-        expect((actual[1].filterDesign).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect((actual[1].filterDesign).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect((actual[1].filterDesign).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.FILTER);
-        expect((actual[1].filterDesign).filters[0].operator).toEqual('=');
-        expect((actual[1].filterDesign).filters[0].value).toBeUndefined();
+        expect((actual[0]).database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[0]).table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[0]).field).toEqual(DashboardServiceMock.FIELD_MAP.FILTER);
+        expect((actual[0]).operator).toEqual('=');
+        expect((actual[0]).value).toBeUndefined();
+        expect((actual[1]).type).toEqual(CompoundFilterType.OR);
+        expect((actual[1]).filters.length).toEqual(1);
+        expect((actual[1]).filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
+        expect((actual[1]).filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
+        expect((actual[1]).filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.FILTER);
+        expect((actual[1]).filters[0].operator).toEqual('=');
+        expect((actual[1]).filters[0].value).toBeUndefined();
     });
 
     it('isSelectable does return expected boolean', () => {
@@ -535,39 +536,15 @@ describe('Component: ThumbnailGrid', () => {
     });
 
     it('isSelected does return expected boolean', () => {
-        expect(component.isSelected({})).toEqual(false);
-
         expect(component.isSelected({
+            _filtered: false,
             testFilterField: 'testFilterValue1'
         })).toEqual(false);
 
-        component.options.filterFields = [DashboardServiceMock.FIELD_MAP.FILTER];
-
         expect(component.isSelected({
-            testFilterField: 'testFilterValue1'
-        })).toEqual(false);
-
-        spyOn((component as any), 'isFiltered').and.callFake((filterDesign) => filterDesign.database === component.options.database &&
-            filterDesign.table === component.options.table && filterDesign.field === component.options.filterFields[0] &&
-            filterDesign.operator === '=' && filterDesign.value === 'testFilterValue1');
-
-        expect(component.isSelected({
+            _filtered: true,
             testFilterField: 'testFilterValue1'
         })).toEqual(true);
-
-        expect(component.isSelected({
-            testFilterField: 'testFilterValue2'
-        })).toEqual(false);
-
-        expect(component.isSelected({
-            testNotAFilterField: 'testFilterValue1'
-        })).toEqual(false);
-
-        component.options.filterFields = [];
-
-        expect(component.isSelected({
-            testFilterField: 'testFilterValue1'
-        })).toEqual(false);
     });
 
     it('validateVisualizationQuery does return expected boolean', () => {
@@ -659,9 +636,10 @@ describe('Component: ThumbnailGrid', () => {
             testPredictedNameField: 'predictedName2',
             testSortField: 'sort2',
             testTypeField: 'type2'
-        }]);
+        }], new FilterCollection());
 
         expect(component.gridArray).toEqual([{
+            _filtered: false,
             _id: 'id1',
             testCategoryField: 'category1',
             testCompareField: 'compare1',
@@ -675,6 +653,7 @@ describe('Component: ThumbnailGrid', () => {
             testSortField: 'sort1',
             testTypeField: 'type1'
         }, {
+            _filtered: false,
             _id: 'id2',
             testCategoryField: 'category2',
             testCompareField: 'compare2',
@@ -695,7 +674,7 @@ describe('Component: ThumbnailGrid', () => {
         component.options.fields = DashboardServiceMock.FIELDS;
         component.options.linkField = NeonFieldMetaData.get({ columnName: 'testLinkField', prettyName: 'Test Link Field' });
 
-        let actual = component.transformVisualizationQueryResults(component.options, []);
+        let actual = component.transformVisualizationQueryResults(component.options, [], new FilterCollection());
 
         expect(component.gridArray).toEqual([]);
         expect(actual).toEqual(0);
@@ -722,15 +701,17 @@ describe('Component: ThumbnailGrid', () => {
             testNameField: 'name2',
             testSizeField: 0.2,
             testTypeField: 'type2'
-        }]);
+        }], new FilterCollection());
 
         expect(component.gridArray).toEqual([{
+            _filtered: false,
             _id: 'id1',
             testLinkField: 'prefix/link1',
             testNameField: 'name1',
             testSizeField: 0.1,
             testTypeField: 'type1'
         }, {
+            _filtered: false,
             _id: 'id2',
             testLinkField: 'prefix/link2',
             testNameField: 'name2',

--- a/src/app/components/timeline/timeline.component.spec.ts
+++ b/src/app/components/timeline/timeline.component.spec.ts
@@ -28,6 +28,7 @@ import { SearchServiceMock } from '../../../testUtils/MockServices/SearchService
 import { DashboardServiceMock } from '../../../testUtils/MockServices/DashboardServiceMock';
 
 import { TimelineModule } from './timeline.module';
+import { FilterCollection } from '../../util/filter.util';
 import { NeonFieldMetaData } from '../../models/dataset';
 
 describe('Component: Timeline', () => {
@@ -437,7 +438,7 @@ describe('Component: Timeline', () => {
             _date: 1515110400000,
             _month: 1,
             _year: 2018
-        }]);
+        }], new FilterCollection());
 
         expect(actual).toEqual(4);
         // Expected date value equals UTCMonth - 1
@@ -473,7 +474,7 @@ describe('Component: Timeline', () => {
             _date: 1515110400000,
             _month: 1,
             _year: 2018
-        }]);
+        }], new FilterCollection());
 
         expect(actual).toEqual(11);
         // Expected date value equals UTCMonth - 1

--- a/src/app/components/wiki-viewer/wiki-viewer.component.spec.ts
+++ b/src/app/components/wiki-viewer/wiki-viewer.component.spec.ts
@@ -117,12 +117,6 @@ describe('Component: WikiViewer', () => {
         expect(component.validateVisualizationQuery(component.options)).toBe(true);
     }));
 
-    it('refreshVisualization does call changeDetection.detectChanges', (() => {
-        let spy = spyOn(component.changeDetection, 'detectChanges');
-        component.refreshVisualization();
-        expect(spy.calls.count()).toBe(1);
-    }));
-
     it('does show toolbar and sidenav', (() => {
         let toolbar = fixture.debugElement.query(By.css('mat-toolbar'));
         expect(toolbar).not.toBeNull();

--- a/src/app/components/wiki-viewer/wiki-viewer.component.ts
+++ b/src/app/components/wiki-viewer/wiki-viewer.component.ts
@@ -29,7 +29,7 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 
 import { AbstractSearchService, FilterClause, QueryPayload } from '../../services/abstract.search.service';
 import { DashboardService } from '../../services/dashboard.service';
-import { FilterBehavior } from '../../util/filter.util';
+import { FilterCollection, FilterDesign } from '../../util/filter.util';
 import { InjectableFilterService } from '../../services/injectable.filter.service';
 
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
@@ -87,13 +87,13 @@ export class WikiViewerComponent extends BaseNeonComponent implements OnInit, On
     }
 
     /**
-     * Returns each type of filter made by this visualization as an object containing 1) a filter design with undefined values and 2) a
-     * callback to redraw the filter.  This visualization will automatically update with compatible filters that were set externally.
+     * Returns the design for each type of filter made by this visualization.  This visualization will automatically update itself with all
+     * compatible filters that were set internally or externally whenever it runs a visualization query.
      *
-     * @return {FilterBehavior[]}
+     * @return {FilterDesign[]}
      * @override
      */
-    protected designEachFilterWithNoValues(): FilterBehavior[] {
+    protected designEachFilterWithNoValues(): FilterDesign[] {
         // This visualization does not filter.
         return [];
     }
@@ -206,10 +206,11 @@ export class WikiViewerComponent extends BaseNeonComponent implements OnInit, On
      *
      * @arg {any} options A WidgetOptionCollection object.
      * @arg {any[]} results
+     * @arg {FilterCollection} filters
      * @return {number}
      * @override
      */
-    transformVisualizationQueryResults(__options: any, __results: any[]): number {
+    transformVisualizationQueryResults(__options: any, __results: any[], __filters: FilterCollection): number {
         // Unused because we override handleTransformVisualizationQueryResults.
         return 0;
     }
@@ -248,7 +249,7 @@ export class WikiViewerComponent extends BaseNeonComponent implements OnInit, On
      * @override
      */
     refreshVisualization() {
-        this.changeDetection.detectChanges();
+        // Do nothing.
     }
 
     /**

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -20,14 +20,11 @@ import { APP_BASE_HREF } from '@angular/common';
 
 import { DashboardComponent } from './dashboard.component';
 
-import { ConfigUtil } from '../util/config.util';
-import { CompoundFilterDesign, SimpleFilterDesign } from '../util/filter.util';
 import { NeonConfig, NeonDashboardLeafConfig, NeonLayoutConfig } from '../models/types';
-import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../models/dataset';
 import { NeonGridItem } from '../models/neon-grid-item';
 import { neonEvents } from '../models/neon-namespaces';
 
-import { AbstractSearchService, CompoundFilterType } from '../services/abstract.search.service';
+import { AbstractSearchService } from '../services/abstract.search.service';
 import { InjectableColorThemeService } from '../services/injectable.color-theme.service';
 import { DashboardService } from '../services/dashboard.service';
 import { InjectableFilterService } from '../services/injectable.filter.service';
@@ -827,48 +824,6 @@ describe('Dashboard', () => {
         let spy = spyOn(component.grid, 'triggerResize');
         component['resizeGrid']();
         expect(spy.calls.count()).toEqual(1);
-    });
-
-    it('getFiltersToSaveInURL should return expected output', () => {
-        expect(component['getFiltersToSaveInURL']()).toEqual(ConfigUtil.translate('[]', ConfigUtil.encodeFiltersMap));
-
-        spyOn(component['filterService'], 'getFilters').and.returnValue([{
-            root: CompoundFilterType.OR,
-            datastore: '',
-            database: NeonDatabaseMetaData.get({ name: 'databaseZ' }),
-            table: NeonTableMetaData.get({ name: 'tableA' }),
-            field: NeonFieldMetaData.get({ columnName: 'field1' }),
-            operator: '=',
-            value: 'value1'
-        } as SimpleFilterDesign, {
-            root: 'and',
-            type: 'and',
-            filters: [{
-                root: CompoundFilterType.OR,
-                datastore: '',
-                database: NeonDatabaseMetaData.get({ name: 'databaseY' }),
-                table: NeonTableMetaData.get({ name: 'tableB' }),
-                field: NeonFieldMetaData.get({ columnName: 'field2' }),
-                operator: '!=',
-                value: ''
-            } as SimpleFilterDesign, {
-                root: CompoundFilterType.OR,
-                datastore: '',
-                database: NeonDatabaseMetaData.get({ name: 'databaseY' }),
-                table: NeonTableMetaData.get({ name: 'tableB' }),
-                field: NeonFieldMetaData.get({ columnName: 'field2' }),
-                operator: '!=',
-                value: null
-            } as SimpleFilterDesign]
-        } as CompoundFilterDesign]);
-
-        expect(component['getFiltersToSaveInURL']()).toEqual(ConfigUtil.translate(JSON.stringify(JSON.parse(`[
-            [".databaseZ.tableA.field1","=","value1","or"],
-            ["and", "and",
-                [".databaseY.tableB.field2", "!=", "", "or"],
-                [".databaseY.tableB.field2", "!=", null, "or"]
-            ]
-        ]`)), ConfigUtil.encodeFiltersMap));
     });
 });
 

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -31,7 +31,7 @@ import { InjectableColorThemeService } from '../services/injectable.color-theme.
 import { BaseNeonComponent } from '../components/base-neon-component/base-neon.component';
 import { DashboardService } from '../services/dashboard.service';
 import { DomSanitizer } from '@angular/platform-browser';
-import { FilterDataSource, FilterDesign, FilterUtil } from '../util/filter.util';
+import { FilterDataSource, FilterDesign } from '../util/filter.util';
 import { InjectableFilterService } from '../services/injectable.filter.service';
 import { MatSnackBar, MatSidenav } from '@angular/material';
 import { MatIconRegistry } from '@angular/material/icon';
@@ -213,7 +213,7 @@ export class DashboardComponent implements AfterViewInit, OnInit, OnDestroy {
      */
     private onDashboardStateChange(state: DashboardState) {
         // Validate url first
-        const currentFilter = this.getFiltersToSaveInURL();
+        const currentFilter = this.dashboardService.getFiltersToSaveInURL();
         const { fullPath, filters, url } = ConfigUtil.getUrlState(window.location, this.baseHref);
         if ((!filters && currentFilter) || url.pathname === '/') {
             this.location.replaceState(`${fullPath}#${currentFilter}`);
@@ -398,7 +398,7 @@ export class DashboardComponent implements AfterViewInit, OnInit, OnDestroy {
         };
         const { pathParts } = ConfigUtil.getUrlState(window.location, this.baseHref);
         this.router.navigate(pathParts, {
-            fragment: this.getFiltersToSaveInURL(),
+            fragment: this.dashboardService.getFiltersToSaveInURL(),
             queryParamsHandling: 'merge',
             relativeTo: this.router.routerState.root
         });
@@ -507,13 +507,5 @@ export class DashboardComponent implements AfterViewInit, OnInit, OnDestroy {
      */
     private updateShowFilterTray(eventMessage: { show: boolean }) {
         this.showFilterTray = eventMessage.show;
-    }
-
-    /**
-     * Returns the filters as string for use in URL
-     */
-    private getFiltersToSaveInURL(): string {
-        let filters: FilterDesign[] = this.filterService.getFilters();
-        return ConfigUtil.translate(JSON.stringify(FilterUtil.toPlainFilterJSON(filters)), ConfigUtil.encodeFiltersMap);
     }
 }

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -31,7 +31,7 @@ import { InjectableColorThemeService } from '../services/injectable.color-theme.
 import { BaseNeonComponent } from '../components/base-neon-component/base-neon.component';
 import { DashboardService } from '../services/dashboard.service';
 import { DomSanitizer } from '@angular/platform-browser';
-import { FilterDataSource, FilterDesign } from '../util/filter.util';
+import { FilterDataSource, FilterDesign, FilterUtil } from '../util/filter.util';
 import { InjectableFilterService } from '../services/injectable.filter.service';
 import { MatSnackBar, MatSidenav } from '@angular/material';
 import { MatIconRegistry } from '@angular/material/icon';
@@ -213,7 +213,7 @@ export class DashboardComponent implements AfterViewInit, OnInit, OnDestroy {
      */
     private onDashboardStateChange(state: DashboardState) {
         // Validate url first
-        const currentFilter = this.filterService.getFiltersToSaveInURL();
+        const currentFilter = this.getFiltersToSaveInURL();
         const { fullPath, filters, url } = ConfigUtil.getUrlState(window.location, this.baseHref);
         if ((!filters && currentFilter) || url.pathname === '/') {
             this.location.replaceState(`${fullPath}#${currentFilter}`);
@@ -398,7 +398,7 @@ export class DashboardComponent implements AfterViewInit, OnInit, OnDestroy {
         };
         const { pathParts } = ConfigUtil.getUrlState(window.location, this.baseHref);
         this.router.navigate(pathParts, {
-            fragment: this.filterService.getFiltersToSaveInURL(),
+            fragment: this.getFiltersToSaveInURL(),
             queryParamsHandling: 'merge',
             relativeTo: this.router.routerState.root
         });
@@ -507,5 +507,13 @@ export class DashboardComponent implements AfterViewInit, OnInit, OnDestroy {
      */
     private updateShowFilterTray(eventMessage: { show: boolean }) {
         this.showFilterTray = eventMessage.show;
+    }
+
+    /**
+     * Returns the filters as string for use in URL
+     */
+    private getFiltersToSaveInURL(): string {
+        let filters: FilterDesign[] = this.filterService.getFilters();
+        return ConfigUtil.translate(JSON.stringify(FilterUtil.toPlainFilterJSON(filters)), ConfigUtil.encodeFiltersMap);
     }
 }

--- a/src/app/services/dashboard.service.spec.ts
+++ b/src/app/services/dashboard.service.spec.ts
@@ -15,7 +15,8 @@
 import { inject } from '@angular/core/testing';
 
 import { NeonConfig, NeonDashboardLeafConfig, FilterConfig } from '../models/types';
-import { NeonDatastoreConfig } from '../models/dataset';
+import { NeonDatabaseMetaData, NeonDatastoreConfig, NeonFieldMetaData, NeonTableMetaData } from '../models/dataset';
+import { CompoundFilterDesign, SimpleFilterDesign } from '../util/filter.util';
 import { DashboardService } from './dashboard.service';
 
 import { initializeTestBed, getConfigService } from '../../testUtils/initializeTestBed';
@@ -84,13 +85,13 @@ describe('Service: DashboardService', () => {
         let spy = spyOn(dashboardService['filterService'], 'setFiltersFromConfig');
 
         dashboardService.setActiveDashboard(NeonDashboardLeafConfig.get({
-            filters: ConfigUtil.translate(JSON.stringify(JSON.parse(`[
+            filters: ConfigUtil.translate(`[
                 [".databaseZ.tableA.field1","=","value1","or"],
                 ["and", "and",
                     [".databaseY.tableB.field2", "!=", "", "or"],
                     [".databaseY.tableB.field2", "!=", null, "or"]
                 ]
-            ]`)), ConfigUtil.encodeFiltersMap)
+            ]`, ConfigUtil.encodeFiltersMap)
         }));
 
         expect(spy.calls.count()).toEqual(1);
@@ -123,6 +124,49 @@ describe('Service: DashboardService', () => {
                 value: null
             }]
         }]);
+    });
+
+    it('getFiltersToSaveInURL should return expected output', () => {
+        expect(dashboardService.getFiltersToSaveInURL()).toEqual(ConfigUtil.translate('[]', ConfigUtil.encodeFiltersMap));
+
+        spyOn(dashboardService['filterService'], 'getFilters').and.returnValue([{
+            root: 'or',
+            datastore: '',
+            database: NeonDatabaseMetaData.get({ name: 'databaseZ' }),
+            table: NeonTableMetaData.get({ name: 'tableA' }),
+            field: NeonFieldMetaData.get({ columnName: 'field1' }),
+            operator: '=',
+            value: 'value1'
+        } as SimpleFilterDesign, {
+            root: 'and',
+            type: 'and',
+            filters: [{
+                root: 'or',
+                datastore: '',
+                database: NeonDatabaseMetaData.get({ name: 'databaseY' }),
+                table: NeonTableMetaData.get({ name: 'tableB' }),
+                field: NeonFieldMetaData.get({ columnName: 'field2' }),
+                operator: '!=',
+                value: ''
+            } as SimpleFilterDesign, {
+                root: 'or',
+                datastore: '',
+                database: NeonDatabaseMetaData.get({ name: 'databaseY' }),
+                table: NeonTableMetaData.get({ name: 'tableB' }),
+                field: NeonFieldMetaData.get({ columnName: 'field2' }),
+                operator: '!=',
+                value: null
+            } as SimpleFilterDesign]
+        } as CompoundFilterDesign]);
+
+        // Use the parse and stringify functions so we don't have to type unicode here.
+        expect(dashboardService.getFiltersToSaveInURL()).toEqual(ConfigUtil.translate(JSON.stringify(JSON.parse(`[
+            [".databaseZ.tableA.field1","=","value1","or"],
+            ["and", "and",
+                [".databaseY.tableB.field2", "!=", "", "or"],
+                [".databaseY.tableB.field2", "!=", null, "or"]
+            ]
+        ]`)), ConfigUtil.encodeFiltersMap));
     });
 });
 

--- a/src/app/services/dashboard.service.spec.ts
+++ b/src/app/services/dashboard.service.spec.ts
@@ -79,6 +79,51 @@ describe('Service: DashboardService', () => {
             databases: {}
         });
     });
+
+    it('setActiveDashboard should translate string filter list', () => {
+        let spy = spyOn(dashboardService['filterService'], 'setFiltersFromConfig');
+
+        dashboardService.setActiveDashboard(NeonDashboardLeafConfig.get({
+            filters: ConfigUtil.translate(JSON.stringify(JSON.parse(`[
+                [".databaseZ.tableA.field1","=","value1","or"],
+                ["and", "and",
+                    [".databaseY.tableB.field2", "!=", "", "or"],
+                    [".databaseY.tableB.field2", "!=", null, "or"]
+                ]
+            ]`)), ConfigUtil.encodeFiltersMap)
+        }));
+
+        expect(spy.calls.count()).toEqual(1);
+        expect(spy.calls.argsFor(0)[0]).toEqual([{
+            root: 'or',
+            datastore: '',
+            database: 'databaseZ',
+            table: 'tableA',
+            field: 'field1',
+            operator: '=',
+            value: 'value1'
+        }, {
+            root: 'and',
+            type: 'and',
+            filters: [{
+                root: 'or',
+                datastore: '',
+                database: 'databaseY',
+                table: 'tableB',
+                field: 'field2',
+                operator: '!=',
+                value: ''
+            }, {
+                root: 'or',
+                datastore: '',
+                database: 'databaseY',
+                table: 'tableB',
+                field: 'field2',
+                operator: '!=',
+                value: null
+            }]
+        }]);
+    });
 });
 
 describe('Service: DashboardService with Mock Data', () => {

--- a/src/app/services/dashboard.service.ts
+++ b/src/app/services/dashboard.service.ts
@@ -27,6 +27,7 @@ import { DashboardUtil } from '../util/dashboard.util';
 import { GridState } from '../models/grid-state';
 import { Observable, from, Subject } from 'rxjs';
 import { map, shareReplay, mergeMap } from 'rxjs/operators';
+import { ConfigUtil } from '../util/config.util';
 import { FilterUtil } from '../util/filter.util';
 import { InjectableFilterService } from './injectable.filter.service';
 
@@ -109,10 +110,13 @@ export class DashboardService {
         this.setActiveDatastore(this.config.datastores[firstName]);
 
         // Load filters
-        const filters = typeof dashboard.filters === 'string' ?
-            FilterUtil.fromSimpleFilterQueryString(dashboard.filters) : dashboard.filters;
+        let filters = dashboard.filters;
+        if (typeof filters === 'string') {
+            const stringFilters = ConfigUtil.translate(dashboard.filters as string, ConfigUtil.decodeFiltersMap);
+            filters = (JSON.parse(stringFilters) as any[]).map((stringFilter) => FilterUtil.fromPlainFilterJSON(stringFilter));
+        }
 
-        this.filterService.setFiltersFromConfig(filters || [], this.state);
+        this.filterService.setFiltersFromConfig(filters || [], this.state.asDataset());
         this.stateSubject.next(this.state);
     }
 

--- a/src/app/services/dashboard.service.ts
+++ b/src/app/services/dashboard.service.ts
@@ -28,7 +28,7 @@ import { GridState } from '../models/grid-state';
 import { Observable, from, Subject } from 'rxjs';
 import { map, shareReplay, mergeMap } from 'rxjs/operators';
 import { ConfigUtil } from '../util/config.util';
-import { FilterUtil } from '../util/filter.util';
+import { FilterDesign, FilterUtil } from '../util/filter.util';
 import { InjectableFilterService } from './injectable.filter.service';
 
 @Injectable({
@@ -110,11 +110,7 @@ export class DashboardService {
         this.setActiveDatastore(this.config.datastores[firstName]);
 
         // Load filters
-        let filters = dashboard.filters;
-        if (typeof filters === 'string') {
-            const stringFilters = ConfigUtil.translate(dashboard.filters as string, ConfigUtil.decodeFiltersMap);
-            filters = (JSON.parse(stringFilters) as any[]).map((stringFilter) => FilterUtil.fromPlainFilterJSON(stringFilter));
-        }
+        let filters = this._translateFilters(dashboard.filters);
 
         this.filterService.setFiltersFromConfig(filters || [], this.state.asDataset());
         this.stateSubject.next(this.state);
@@ -243,5 +239,21 @@ export class DashboardService {
             out.dashboards.options.connectOnLoad = true;
         }
         return out;
+    }
+
+    /**
+     * Returns the filters as string for use in URL
+     */
+    public getFiltersToSaveInURL(): string {
+        let filters: FilterDesign[] = this.filterService.getFilters();
+        return ConfigUtil.translate(JSON.stringify(FilterUtil.toPlainFilterJSON(filters)), ConfigUtil.encodeFiltersMap);
+    }
+
+    private _translateFilters(filters: FilterConfig[] | string): FilterConfig[] {
+        if (typeof filters === 'string') {
+            const stringFilters = ConfigUtil.translate(filters, ConfigUtil.decodeFiltersMap);
+            return (JSON.parse(stringFilters) as any[]).map((stringFilter) => FilterUtil.fromPlainFilterJSON(stringFilter));
+        }
+        return filters;
     }
 }

--- a/src/app/services/filter.service.spec.ts
+++ b/src/app/services/filter.service.spec.ts
@@ -12,10 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { inject } from '@angular/core/testing';
-import { HttpClientModule } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-
 import { CompoundFilterType } from './abstract.search.service';
 import {
     CompoundFilterDesign,
@@ -24,29 +20,16 @@ import {
     FilterUtil,
     SimpleFilterDesign
 } from '../util/filter.util';
-import { DashboardService } from './dashboard.service';
 import { FilterChangeListener, FilterService } from './filter.service';
 
-import { DashboardServiceMock } from '../../testUtils/MockServices/DashboardServiceMock';
-import { initializeTestBed } from '../../testUtils/initializeTestBed';
+import { DATABASES, DATASET, FIELD_MAP, TABLES } from '../../testUtils/mock-dataset';
 
 describe('FilterService with no filters', () => {
     let filterService: FilterService;
 
-    initializeTestBed('Filter Service with no filters', {
-        providers: [
-            { provide: DashboardService, useClass: DashboardServiceMock },
-            { provide: FilterService, useClass: FilterService }
-        ],
-        imports: [
-            HttpClientModule,
-            HttpClientTestingModule
-        ]
+    beforeEach(() => {
+        filterService = new FilterService();
     });
-
-    beforeEach(inject([FilterService], (_filterService) => {
-        filterService = _filterService;
-    }));
 
     it('should have expected properties with no filters', () => {
         expect(filterService['filterCollection']).toBeDefined();
@@ -61,7 +44,6 @@ describe('FilterService with no filters', () => {
 });
 
 describe('FilterService with filters', () => {
-    let datasetService: DashboardService;
     let filterService: FilterService;
     let source1: FilterDataSource[];
     let source2: FilterDataSource[];
@@ -82,71 +64,63 @@ describe('FilterService with filters', () => {
     let relationFilter1: any;
     let relationFilter2: any;
 
-    initializeTestBed('Filter Service with filters', {
-        providers: [
-            { provide: DashboardService, useClass: DashboardServiceMock },
-            { provide: FilterService, useClass: FilterService }
-        ]
-    });
-
-    beforeEach(inject([DashboardService, FilterService], (_datasetService, _filterService) => {
-        datasetService = _datasetService;
-        filterService = _filterService;
+    beforeEach(() => {
+        filterService = new FilterService();
 
         source1 = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.ID.columnName,
             operator: '='
         } as FilterDataSource];
         source2 = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.SIZE.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.SIZE.columnName,
             operator: '>'
         } as FilterDataSource, {
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.SIZE.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.SIZE.columnName,
             operator: '<'
         } as FilterDataSource];
 
         design1A = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.ID,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.ID,
             operator: '=',
             value: 'testId1'
         } as SimpleFilterDesign;
         design1B = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.ID,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.ID,
             operator: '=',
             value: 'testId2'
         } as SimpleFilterDesign;
         design1C = {
             root: CompoundFilterType.OR,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.ID,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.ID,
             operator: '=',
             value: 'testId3'
         } as SimpleFilterDesign;
         design1D = {
             root: CompoundFilterType.OR,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.ID,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.ID,
             operator: '=',
             value: 'testId4'
         } as SimpleFilterDesign;
@@ -156,17 +130,17 @@ describe('FilterService with filters', () => {
             filters: [{
                 root: CompoundFilterType.AND,
                 datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1,
-                table: DashboardServiceMock.TABLES.testTable1,
-                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                database: DATABASES.testDatabase1,
+                table: TABLES.testTable1,
+                field: FIELD_MAP.SIZE,
                 operator: '>',
                 value: 10
             } as SimpleFilterDesign, {
                 root: CompoundFilterType.AND,
                 datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1,
-                table: DashboardServiceMock.TABLES.testTable1,
-                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                database: DATABASES.testDatabase1,
+                table: TABLES.testTable1,
+                field: FIELD_MAP.SIZE,
                 operator: '<',
                 value: 20
             } as SimpleFilterDesign]
@@ -188,7 +162,7 @@ describe('FilterService with filters', () => {
 
         filterService['filterCollection'].setFilters(source1, [filter1A, filter1B, filter1C, filter1D]);
         filterService['filterCollection'].setFilters(source2, [filter2A]);
-    }));
+    });
 
     afterEach(() => {
         // Services are not recreated in each test so we must reset the internal data.
@@ -210,34 +184,34 @@ describe('FilterService with filters', () => {
     let generateRelationFilters = () => {
         relationSource1 = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.RELATION_A.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.RELATION_A.columnName,
             operator: '='
         } as FilterDataSource];
         relationSource2 = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.RELATION_B.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.RELATION_B.columnName,
             operator: '='
         } as FilterDataSource];
 
         relationDesign1 = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.RELATION_A,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.RELATION_A,
             operator: '=',
             value: 'testRelation'
         } as SimpleFilterDesign;
         relationDesign2 = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.RELATION_B,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.RELATION_B,
             operator: '=',
             value: 'testRelation'
         } as SimpleFilterDesign;
@@ -249,23 +223,19 @@ describe('FilterService with filters', () => {
 
         relationDesign1.id = relationFilter1.id;
         relationDesign2.id = relationFilter2.id;
-
-        /* eslint-disable-next-line jasmine/no-unsafe-spy */
-        spyOn(datasetService.state, 'findRelationDataList').and.returnValue([[
-            [{
-                datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1,
-                table: DashboardServiceMock.TABLES.testTable1,
-                field: DashboardServiceMock.FIELD_MAP.RELATION_A
-            }],
-            [{
-                datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1,
-                table: DashboardServiceMock.TABLES.testTable1,
-                field: DashboardServiceMock.FIELD_MAP.RELATION_B
-            }]
-        ]]);
     };
+
+    let findRelationDataList = () => [[[{
+        datastore: '',
+        database: DATABASES.testDatabase1,
+        table: TABLES.testTable1,
+        field: FIELD_MAP.RELATION_A
+    }], [{
+        datastore: '',
+        database: DATABASES.testDatabase1,
+        table: TABLES.testTable1,
+        field: FIELD_MAP.RELATION_B
+    }]]];
 
     it('should have expected properties', () => {
         expect(filterService['filterCollection'].getDataSources()).toEqual([source1, source2]);
@@ -378,9 +348,9 @@ describe('FilterService with filters', () => {
 
         let actual = filterService.deleteFilters('testCaller', [{
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.TEXT,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.TEXT,
             operator: '='
         } as SimpleFilterDesign]);
 
@@ -388,9 +358,9 @@ describe('FilterService with filters', () => {
         let keys = Array.from(actual.keys());
         expect(keys).toEqual([source1, source2, [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.TEXT.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.TEXT.columnName,
             operator: '='
         } as FilterDataSource]]);
         expect(actual.get(keys[0])).toEqual([design1A, design1B, design1C, design1D]);
@@ -406,18 +376,18 @@ describe('FilterService with filters', () => {
         let testDesign = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.TEXT,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.TEXT,
             operator: '=',
             value: 'testText'
         } as SimpleFilterDesign;
 
         let testSource = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.TEXT.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.TEXT.columnName,
             operator: '='
         } as FilterDataSource];
 
@@ -428,9 +398,9 @@ describe('FilterService with filters', () => {
 
         let listComplete = filterService['filterCollection'].getFilters(testSource) as any[]; // TODO: Typings;;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.TEXT);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testText');
 
@@ -453,9 +423,9 @@ describe('FilterService with filters', () => {
         let testDesign = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.ID,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.ID,
             operator: '=',
             value: 'testId5'
         } as SimpleFilterDesign;
@@ -464,9 +434,9 @@ describe('FilterService with filters', () => {
 
         let listComplete = filterService['filterCollection'].getFilters(source1) as any[]; // TODO: Typings;;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.ID);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.ID);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testId5');
 
@@ -490,18 +460,18 @@ describe('FilterService with filters', () => {
         let testDesign = {
             root: CompoundFilterType.OR,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.TEXT,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.TEXT,
             operator: '=',
             value: 'testText'
         } as SimpleFilterDesign;
 
         let testSource = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.TEXT.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.TEXT.columnName,
             operator: '='
         } as FilterDataSource];
 
@@ -512,9 +482,9 @@ describe('FilterService with filters', () => {
 
         let listComplete = filterService['filterCollection'].getFilters(testSource) as any[]; // TODO: Typings
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.TEXT);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testText');
 
@@ -536,16 +506,16 @@ describe('FilterService with filters', () => {
 
         let spy = spyOn(filterService as any, '_notifier');
 
-        let actual = filterService.exchangeFilters('testCaller', [relationDesign1], datasetService.state.findRelationDataList());
+        let actual = filterService.exchangeFilters('testCaller', [relationDesign1], findRelationDataList());
 
         expect(filterService['filterCollection'].getFilters(source1)).toEqual([filter1A, filter1B, filter1C, filter1D]);
         expect(filterService['filterCollection'].getFilters(source2)).toEqual([filter2A]);
 
         let listComplete = filterService['filterCollection'].getFilters(relationSource1) as any[]; // TODO: Typings;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.RELATION_A);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.RELATION_A);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testRelation');
 
@@ -553,9 +523,9 @@ describe('FilterService with filters', () => {
 
         listComplete = filterService['filterCollection'].getFilters(relationSource2) as any[]; // TODO: Typings;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.RELATION_B);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.RELATION_B);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testRelation');
 
@@ -581,23 +551,23 @@ describe('FilterService with filters', () => {
         let testDesign2 = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.RELATION_B,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.RELATION_B,
             operator: '=',
             value: 'testExchangeRelation'
         } as SimpleFilterDesign;
 
-        let actual = filterService.exchangeFilters('testCaller', [testDesign2], datasetService.state.findRelationDataList());
+        let actual = filterService.exchangeFilters('testCaller', [testDesign2], findRelationDataList());
 
         expect(filterService['filterCollection'].getFilters(source1)).toEqual([filter1A, filter1B, filter1C, filter1D]);
         expect(filterService['filterCollection'].getFilters(source2)).toEqual([filter2A]);
 
         let listComplete = filterService['filterCollection'].getFilters(relationSource1) as any[]; // TODO: Typings;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.RELATION_A);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.RELATION_A);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testExchangeRelation');
 
@@ -605,18 +575,18 @@ describe('FilterService with filters', () => {
             id: listComplete[0].id,
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.RELATION_A,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.RELATION_A,
             operator: '=',
             value: 'testExchangeRelation'
         } as SimpleFilterDesign;
 
         listComplete = filterService['filterCollection'].getFilters(relationSource2);
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.RELATION_B);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.RELATION_B);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testExchangeRelation');
 
@@ -697,9 +667,9 @@ describe('FilterService with filters', () => {
         expect(filterService.getFilters(source2)).toEqual([design2A]);
         expect(filterService.getFilters([{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.ID.columnName,
             operator: '!='
         } as FilterDataSource])).toEqual([]);
     });
@@ -708,33 +678,33 @@ describe('FilterService with filters', () => {
         expect(filterService.getFiltersToSaveInConfig()).toEqual([{
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId1'
         }, {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId2'
         }, {
             root: CompoundFilterType.OR,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId3'
         }, {
             root: CompoundFilterType.OR,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId4'
         }, {
@@ -743,17 +713,17 @@ describe('FilterService with filters', () => {
             filters: [{
                 root: CompoundFilterType.AND,
                 datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1.name,
-                table: DashboardServiceMock.TABLES.testTable1.name,
-                field: DashboardServiceMock.FIELD_MAP.SIZE.columnName,
+                database: DATABASES.testDatabase1.name,
+                table: TABLES.testTable1.name,
+                field: FIELD_MAP.SIZE.columnName,
                 operator: '>',
                 value: 10
             }, {
                 root: CompoundFilterType.AND,
                 datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1.name,
-                table: DashboardServiceMock.TABLES.testTable1.name,
-                field: DashboardServiceMock.FIELD_MAP.SIZE.columnName,
+                database: DATABASES.testDatabase1.name,
+                table: TABLES.testTable1.name,
+                field: FIELD_MAP.SIZE.columnName,
                 operator: '<',
                 value: 20
             }]
@@ -907,9 +877,9 @@ describe('FilterService with filters', () => {
             filters: [{
                 root: CompoundFilterType.AND,
                 datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1,
-                table: DashboardServiceMock.TABLES.testTable1,
-                field: DashboardServiceMock.FIELD_MAP.ID,
+                database: DATABASES.testDatabase1,
+                table: TABLES.testTable1,
+                field: FIELD_MAP.ID,
                 operator: '='
             } as SimpleFilterDesign]
         } as CompoundFilterDesign;
@@ -924,17 +894,17 @@ describe('FilterService with filters', () => {
         let testDesign = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.TEXT,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.TEXT,
             operator: '='
         } as SimpleFilterDesign;
 
         let testSource = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.TEXT.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.TEXT.columnName,
             operator: '='
         } as FilterDataSource];
 
@@ -947,24 +917,24 @@ describe('FilterService with filters', () => {
     it('setFiltersFromConfig should change filterCollection', () => {
         let actual;
 
-        filterService.setFiltersFromConfig([], datasetService.state);
+        filterService.setFiltersFromConfig([], DATASET);
         expect(filterService['filterCollection'].getDataSources()).toEqual([]);
 
         filterService.setFiltersFromConfig([{
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId1'
-        }], datasetService.state);
+        }], DATASET);
         expect(filterService['filterCollection'].getDataSources()).toEqual([source1]);
         actual = filterService['filterCollection'].getFilters(source1);
         expect(actual.length).toEqual(1);
-        expect(actual[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[0].field).toEqual(DashboardServiceMock.FIELD_MAP.ID);
+        expect(actual[0].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[0].table).toEqual(TABLES.testTable1);
+        expect(actual[0].field).toEqual(FIELD_MAP.ID);
         expect(actual[0].operator).toEqual('=');
         expect(actual[0].value).toEqual('testId1');
         expect(actual[0].root).toEqual(CompoundFilterType.AND);
@@ -972,60 +942,60 @@ describe('FilterService with filters', () => {
         filterService.setFiltersFromConfig([{
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId1'
         }, {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId2'
         }, {
             root: CompoundFilterType.OR,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId3'
         }, {
             root: CompoundFilterType.OR,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId4'
-        }], datasetService.state);
+        }], DATASET);
         expect(filterService['filterCollection'].getDataSources()).toEqual([source1]);
         actual = filterService['filterCollection'].getFilters(source1);
         expect(actual.length).toEqual(4);
-        expect(actual[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[0].field).toEqual(DashboardServiceMock.FIELD_MAP.ID);
+        expect(actual[0].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[0].table).toEqual(TABLES.testTable1);
+        expect(actual[0].field).toEqual(FIELD_MAP.ID);
         expect(actual[0].operator).toEqual('=');
         expect(actual[0].value).toEqual('testId1');
         expect(actual[0].root).toEqual(CompoundFilterType.AND);
-        expect(actual[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[1].field).toEqual(DashboardServiceMock.FIELD_MAP.ID);
+        expect(actual[1].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[1].table).toEqual(TABLES.testTable1);
+        expect(actual[1].field).toEqual(FIELD_MAP.ID);
         expect(actual[1].operator).toEqual('=');
         expect(actual[1].value).toEqual('testId2');
         expect(actual[1].root).toEqual(CompoundFilterType.AND);
-        expect(actual[2].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[2].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[2].field).toEqual(DashboardServiceMock.FIELD_MAP.ID);
+        expect(actual[2].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[2].table).toEqual(TABLES.testTable1);
+        expect(actual[2].field).toEqual(FIELD_MAP.ID);
         expect(actual[2].operator).toEqual('=');
         expect(actual[2].value).toEqual('testId3');
         expect(actual[2].root).toEqual(CompoundFilterType.OR);
-        expect(actual[3].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[3].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[3].field).toEqual(DashboardServiceMock.FIELD_MAP.ID);
+        expect(actual[3].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[3].table).toEqual(TABLES.testTable1);
+        expect(actual[3].field).toEqual(FIELD_MAP.ID);
         expect(actual[3].operator).toEqual('=');
         expect(actual[3].value).toEqual('testId4');
         expect(actual[3].root).toEqual(CompoundFilterType.OR);
@@ -1036,52 +1006,52 @@ describe('FilterService with filters', () => {
             filters: [{
                 root: CompoundFilterType.AND,
                 datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1.name,
-                table: DashboardServiceMock.TABLES.testTable1.name,
-                field: DashboardServiceMock.FIELD_MAP.SIZE.columnName,
+                database: DATABASES.testDatabase1.name,
+                table: TABLES.testTable1.name,
+                field: FIELD_MAP.SIZE.columnName,
                 operator: '>',
                 value: 10
             }, {
                 root: CompoundFilterType.AND,
                 datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1.name,
-                table: DashboardServiceMock.TABLES.testTable1.name,
-                field: DashboardServiceMock.FIELD_MAP.SIZE.columnName,
+                database: DATABASES.testDatabase1.name,
+                table: TABLES.testTable1.name,
+                field: FIELD_MAP.SIZE.columnName,
                 operator: '<',
                 value: 20
             }]
-        }], datasetService.state);
+        }], DATASET);
         expect(filterService['filterCollection'].getDataSources()).toEqual([source2]);
         actual = filterService['filterCollection'].getFilters(source2);
         expect(actual.length).toEqual(1);
         expect(actual[0].type).toEqual(CompoundFilterType.AND);
         expect(actual[0].root).toEqual(CompoundFilterType.AND);
         expect(actual[0].filters.length).toEqual(2);
-        expect(actual[0].filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[0].filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[0].filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.SIZE);
+        expect(actual[0].filters[0].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[0].filters[0].table).toEqual(TABLES.testTable1);
+        expect(actual[0].filters[0].field).toEqual(FIELD_MAP.SIZE);
         expect(actual[0].filters[0].operator).toEqual('>');
         expect(actual[0].filters[0].value).toEqual(10);
-        expect(actual[0].filters[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[0].filters[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[0].filters[1].field).toEqual(DashboardServiceMock.FIELD_MAP.SIZE);
+        expect(actual[0].filters[1].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[0].filters[1].table).toEqual(TABLES.testTable1);
+        expect(actual[0].filters[1].field).toEqual(FIELD_MAP.SIZE);
         expect(actual[0].filters[1].operator).toEqual('<');
         expect(actual[0].filters[1].value).toEqual(20);
 
         filterService.setFiltersFromConfig([{
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId1'
         }, {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId2'
         }, {
@@ -1090,33 +1060,33 @@ describe('FilterService with filters', () => {
             filters: [{
                 root: CompoundFilterType.AND,
                 datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1.name,
-                table: DashboardServiceMock.TABLES.testTable1.name,
-                field: DashboardServiceMock.FIELD_MAP.SIZE.columnName,
+                database: DATABASES.testDatabase1.name,
+                table: TABLES.testTable1.name,
+                field: FIELD_MAP.SIZE.columnName,
                 operator: '>',
                 value: 10
             }, {
                 root: CompoundFilterType.AND,
                 datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1.name,
-                table: DashboardServiceMock.TABLES.testTable1.name,
-                field: DashboardServiceMock.FIELD_MAP.SIZE.columnName,
+                database: DATABASES.testDatabase1.name,
+                table: TABLES.testTable1.name,
+                field: FIELD_MAP.SIZE.columnName,
                 operator: '<',
                 value: 20
             }]
-        }], datasetService.state);
+        }], DATASET);
         expect(filterService['filterCollection'].getDataSources()).toEqual([source1, source2]);
         actual = filterService['filterCollection'].getFilters(source1);
         expect(actual.length).toEqual(2);
-        expect(actual[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[0].field).toEqual(DashboardServiceMock.FIELD_MAP.ID);
+        expect(actual[0].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[0].table).toEqual(TABLES.testTable1);
+        expect(actual[0].field).toEqual(FIELD_MAP.ID);
         expect(actual[0].operator).toEqual('=');
         expect(actual[0].value).toEqual('testId1');
         expect(actual[0].root).toEqual(CompoundFilterType.AND);
-        expect(actual[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[1].field).toEqual(DashboardServiceMock.FIELD_MAP.ID);
+        expect(actual[1].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[1].table).toEqual(TABLES.testTable1);
+        expect(actual[1].field).toEqual(FIELD_MAP.ID);
         expect(actual[1].operator).toEqual('=');
         expect(actual[1].value).toEqual('testId2');
         expect(actual[1].root).toEqual(CompoundFilterType.AND);
@@ -1125,14 +1095,14 @@ describe('FilterService with filters', () => {
         expect(actual[0].type).toEqual(CompoundFilterType.AND);
         expect(actual[0].root).toEqual(CompoundFilterType.AND);
         expect(actual[0].filters.length).toEqual(2);
-        expect(actual[0].filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[0].filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[0].filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.SIZE);
+        expect(actual[0].filters[0].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[0].filters[0].table).toEqual(TABLES.testTable1);
+        expect(actual[0].filters[0].field).toEqual(FIELD_MAP.SIZE);
         expect(actual[0].filters[0].operator).toEqual('>');
         expect(actual[0].filters[0].value).toEqual(10);
-        expect(actual[0].filters[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[0].filters[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[0].filters[1].field).toEqual(DashboardServiceMock.FIELD_MAP.SIZE);
+        expect(actual[0].filters[1].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[0].filters[1].table).toEqual(TABLES.testTable1);
+        expect(actual[0].filters[1].field).toEqual(FIELD_MAP.SIZE);
         expect(actual[0].filters[1].operator).toEqual('<');
         expect(actual[0].filters[1].value).toEqual(20);
     });
@@ -1143,9 +1113,9 @@ describe('FilterService with filters', () => {
         let testDesign = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.ID,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.ID,
             operator: '=',
             value: 'testId5'
         } as SimpleFilterDesign;
@@ -1158,9 +1128,9 @@ describe('FilterService with filters', () => {
         expect(listComplete[1]).toEqual(filter1B);
         expect(listComplete[2]).toEqual(filter1C);
         expect(listComplete[3]).toEqual(filter1D);
-        expect(listComplete[4].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[4].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[4].field).toEqual(DashboardServiceMock.FIELD_MAP.ID);
+        expect(listComplete[4].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[4].table).toEqual(TABLES.testTable1);
+        expect(listComplete[4].field).toEqual(FIELD_MAP.ID);
         expect(listComplete[4].operator).toEqual('=');
         expect(listComplete[4].value).toEqual('testId5');
 
@@ -1184,18 +1154,18 @@ describe('FilterService with filters', () => {
         let testDesign = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.TEXT,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.TEXT,
             operator: '=',
             value: 'testText'
         } as SimpleFilterDesign;
 
         let testSource = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.TEXT.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.TEXT.columnName,
             operator: '='
         } as FilterDataSource];
 
@@ -1206,9 +1176,9 @@ describe('FilterService with filters', () => {
 
         let listComplete = filterService['filterCollection'].getFilters(testSource) as any[]; // TODO: Typings;;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.TEXT);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testText');
 
@@ -1249,18 +1219,18 @@ describe('FilterService with filters', () => {
         let testDesign = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.TEXT,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.TEXT,
             operator: '=',
             value: 'testText'
         } as SimpleFilterDesign;
 
         let testSource = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.TEXT.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.TEXT.columnName,
             operator: '='
         } as FilterDataSource];
 
@@ -1271,9 +1241,9 @@ describe('FilterService with filters', () => {
 
         let listComplete = filterService['filterCollection'].getFilters(testSource) as any[]; // TODO: Typings;;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.TEXT);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testText');
 
@@ -1296,18 +1266,18 @@ describe('FilterService with filters', () => {
         let testDesign = {
             root: CompoundFilterType.OR,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.TEXT,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.TEXT,
             operator: '=',
             value: 'testText'
         } as SimpleFilterDesign;
 
         let testSource = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.TEXT.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.TEXT.columnName,
             operator: '='
         } as FilterDataSource];
 
@@ -1318,9 +1288,9 @@ describe('FilterService with filters', () => {
 
         let listComplete = filterService['filterCollection'].getFilters(testSource) as any[]; // TODO: Typings;;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.TEXT);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testText');
 
@@ -1342,16 +1312,16 @@ describe('FilterService with filters', () => {
 
         let spy = spyOn(filterService as any, '_notifier');
 
-        let actual = filterService.toggleFilters('testCaller', [relationDesign1], datasetService.state.findRelationDataList());
+        let actual = filterService.toggleFilters('testCaller', [relationDesign1], findRelationDataList());
 
         expect(filterService['filterCollection'].getFilters(source1)).toEqual([filter1A, filter1B, filter1C, filter1D]);
         expect(filterService['filterCollection'].getFilters(source2)).toEqual([filter2A]);
 
         let listComplete = filterService['filterCollection'].getFilters(relationSource1) as any[]; // TODO: Typings;;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.RELATION_A);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.RELATION_A);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testRelation');
 
@@ -1359,9 +1329,9 @@ describe('FilterService with filters', () => {
 
         listComplete = filterService['filterCollection'].getFilters(relationSource2) as any[]; // TODO: Typings;;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.RELATION_B);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.RELATION_B);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testRelation');
 
@@ -1387,14 +1357,14 @@ describe('FilterService with filters', () => {
         let testDesign2 = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.RELATION_B,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.RELATION_B,
             operator: '=',
             value: 'testToggleRelation'
         } as SimpleFilterDesign;
 
-        let actual = filterService.toggleFilters('testCaller', [testDesign2], datasetService.state.findRelationDataList());
+        let actual = filterService.toggleFilters('testCaller', [testDesign2], findRelationDataList());
 
         expect(filterService['filterCollection'].getFilters(source1)).toEqual([filter1A, filter1B, filter1C, filter1D]);
         expect(filterService['filterCollection'].getFilters(source2)).toEqual([filter2A]);
@@ -1402,9 +1372,9 @@ describe('FilterService with filters', () => {
         let listComplete = filterService['filterCollection'].getFilters(relationSource1) as any[]; // TODO: Typings;;
         expect(listComplete.length).toEqual(2);
         expect(listComplete[0]).toEqual(relationFilter1);
-        expect(listComplete[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[1].field).toEqual(DashboardServiceMock.FIELD_MAP.RELATION_A);
+        expect(listComplete[1].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[1].table).toEqual(TABLES.testTable1);
+        expect(listComplete[1].field).toEqual(FIELD_MAP.RELATION_A);
         expect(listComplete[1].operator).toEqual('=');
         expect(listComplete[1].value).toEqual('testToggleRelation');
 
@@ -1412,9 +1382,9 @@ describe('FilterService with filters', () => {
             id: listComplete[1].id,
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.RELATION_A,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.RELATION_A,
             operator: '=',
             value: 'testToggleRelation'
         } as SimpleFilterDesign;
@@ -1422,9 +1392,9 @@ describe('FilterService with filters', () => {
         listComplete = filterService['filterCollection'].getFilters(relationSource2);
         expect(listComplete.length).toEqual(2);
         expect(listComplete[0]).toEqual(relationFilter2);
-        expect(listComplete[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[1].field).toEqual(DashboardServiceMock.FIELD_MAP.RELATION_B);
+        expect(listComplete[1].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[1].table).toEqual(TABLES.testTable1);
+        expect(listComplete[1].field).toEqual(FIELD_MAP.RELATION_B);
         expect(listComplete[1].operator).toEqual('=');
         expect(listComplete[1].value).toEqual('testToggleRelation');
 
@@ -1447,7 +1417,7 @@ describe('FilterService with filters', () => {
 
         let spy = spyOn(filterService as any, '_notifier');
 
-        let actual = filterService.toggleFilters('testCaller', [relationDesign1], datasetService.state.findRelationDataList());
+        let actual = filterService.toggleFilters('testCaller', [relationDesign1], findRelationDataList());
 
         expect(filterService['filterCollection'].getFilters(source1)).toEqual([filter1A, filter1B, filter1C, filter1D]);
         expect(filterService['filterCollection'].getFilters(source2)).toEqual([filter2A]);
@@ -1472,18 +1442,18 @@ describe('FilterService with filters', () => {
         let testDesign1 = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.RELATION_A,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.RELATION_A,
             operator: '=',
             value: 'testToggleRelation'
         } as SimpleFilterDesign;
         let testDesign2 = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.RELATION_B,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.RELATION_B,
             operator: '=',
             value: 'testToggleRelation'
         } as SimpleFilterDesign;
@@ -1501,8 +1471,7 @@ describe('FilterService with filters', () => {
 
         let spy = spyOn(filterService as any, '_notifier');
 
-        let actual = filterService.toggleFilters('testCaller',
-            [relationDesign1], datasetService.state.findRelationDataList());
+        let actual = filterService.toggleFilters('testCaller', [relationDesign1], findRelationDataList());
 
         expect(filterService['filterCollection'].getFilters(source1)).toEqual([filter1A, filter1B, filter1C, filter1D]);
         expect(filterService['filterCollection'].getFilters(source2)).toEqual([filter2A]);

--- a/src/app/services/filter.service.ts
+++ b/src/app/services/filter.service.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 import { CompoundFilterType } from './abstract.search.service';
+import { Dataset, SingleField } from '../models/dataset';
 import { FilterConfig } from '../models/types';
-import { SingleField } from '../models/dataset';
 import {
     AbstractFilter,
     CompoundFilter,
@@ -23,8 +23,6 @@ import {
     FilterDesign,
     FilterUtil
 } from '../util/filter.util';
-
-import { DashboardState } from '../models/dashboard-state';
 
 export type FilterChangeListener = (callerId: string, changeCollection: Map<FilterDataSource[], FilterDesign[]>) => void;
 
@@ -276,13 +274,6 @@ export class FilterService {
     }
 
     /**
-     * Returns the filters as string for use in URL
-     */
-    public getFiltersToSaveInURL(): string {
-        return FilterUtil.toSimpleFilterQueryString(this.getFilters());
-    }
-
-    /**
      * Returns all the filters to search on the given datastore/database/table (ignoring filters from the given data sources).
      *
      * @arg {string} datastoreName
@@ -379,10 +370,10 @@ export class FilterService {
     /**
      * Sets the filters in the FilterService to the given filter JSON objects from a config file.
      */
-    public setFiltersFromConfig(filtersFromConfig: FilterConfig[], dashboardState: DashboardState) {
+    public setFiltersFromConfig(filtersFromConfig: FilterConfig[], dataset: Dataset) {
         let collection: FilterCollection = new FilterCollection();
         for (const filterFromConfig of filtersFromConfig) {
-            const filterDesign: FilterDesign = FilterUtil.createFilterDesignFromJsonObject(filterFromConfig, dashboardState);
+            const filterDesign: FilterDesign = FilterUtil.createFilterDesignFromJsonObject(filterFromConfig, dataset);
             if (filterDesign) {
                 const filterDataSourceList = collection.findFilterDataSources(filterDesign);
                 const filter = FilterUtil.createFilterFromDesign(filterDesign);

--- a/src/app/util/filter.util.spec.ts
+++ b/src/app/util/filter.util.spec.ts
@@ -747,7 +747,7 @@ describe('FilterCollection', () => {
     let filter1B: any;
     let filter2A: any;
 
-    initializeTestBed('Single List Filter Collection', {
+    initializeTestBed('Filter Collection', {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock }
         ],
@@ -817,6 +817,14 @@ describe('FilterCollection', () => {
                 value: 20
             } as SimpleFilterDesign]
         } as CompoundFilterDesign);
+
+        // TODO THOR-1078 Remove these lines
+        (filter1A as SimpleFilter).datastore = 'testDatastore1';
+        (filter1B as SimpleFilter).datastore = 'testDatastore1';
+        filter2A.filters.forEach((filter) => {
+            (filter as SimpleFilter).datastore = 'testDatastore1';
+        });
+
         filterCollection = new FilterCollection();
         (filterCollection as any).data.set(source1, [filter1A, filter1B]);
         (filterCollection as any).data.set(source2, [filter2A]);
@@ -1003,6 +1011,503 @@ describe('FilterCollection', () => {
 
         expect((filterCollection as any).data.has(testDataSource1)).toEqual(false);
         expect((filterCollection as any).data.has(testDataSource2)).toEqual(false);
+    });
+
+    it('isFiltererd should return expected boolean', () => {
+        let testCollection = new FilterCollection();
+        expect(testCollection.isFiltered()).toEqual(false);
+
+        testCollection.setFilters(source1, []);
+        expect(testCollection.isFiltered()).toEqual(false);
+
+        let design1A = filter1A.toDesign();
+        design1A.value = undefined;
+        // TODO THOR-1078 Remove this line
+        design1A.datastore = 'testDatastore1';
+
+        let design2A = filter2A.toDesign();
+        design2A.filters[0].value = undefined;
+        design2A.filters[1].value = undefined;
+        // TODO THOR-1078 Remove these two lines
+        design2A.filters[0].datastore = 'testDatastore1';
+        design2A.filters[1].datastore = 'testDatastore1';
+
+        testCollection.setFilters(source1, [filter1A]);
+        expect(testCollection.isFiltered()).toEqual(true);
+        expect(testCollection.isFiltered(design1A)).toEqual(true);
+        expect(testCollection.isFiltered(design2A)).toEqual(false);
+
+        testCollection.setFilters(source2, [filter2A]);
+        expect(testCollection.isFiltered()).toEqual(true);
+        expect(testCollection.isFiltered(design1A)).toEqual(true);
+        expect(testCollection.isFiltered(design2A)).toEqual(true);
+        expect(testCollection.isFiltered({
+            datastore: '',
+            database: DashboardServiceMock.DATABASES.testDatabase1,
+            table: DashboardServiceMock.TABLES.testTable1,
+            field: DashboardServiceMock.FIELD_MAP.ID,
+            operator: '!='
+        } as SimpleFilterDesign)).toEqual(false);
+    });
+
+    it('isFiltered with compound filter designs that have a single data source should return expected boolean', () => {
+        let testDesign = {
+            type: 'or',
+            root: CompoundFilterType.AND,
+            filters: [{
+                root: CompoundFilterType.AND,
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '=',
+                value: 10
+            } as SimpleFilterDesign, {
+                root: CompoundFilterType.AND,
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '=',
+                value: 20
+            } as SimpleFilterDesign]
+        } as CompoundFilterDesign;
+
+        let testFilter = FilterUtil.createFilterFromDesign(testDesign);
+
+        let testSource = [{
+            datastoreName: '',
+            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
+            tableName: DashboardServiceMock.TABLES.testTable1.name,
+            fieldName: DashboardServiceMock.FIELD_MAP.SIZE.columnName,
+            operator: '='
+        } as FilterDataSource];
+
+        let testCollection = new FilterCollection();
+        testCollection.setFilters(testSource, [testFilter]);
+
+        // Same design (should return true)
+        expect(testCollection.isFiltered({
+            type: 'or',
+            filters: [{
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '='
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '='
+            } as SimpleFilterDesign]
+        } as CompoundFilterDesign)).toEqual(true);
+
+        // Same data source but too few nested filters (should return true)
+        expect(testCollection.isFiltered({
+            type: 'or',
+            filters: [{
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '='
+            } as SimpleFilterDesign]
+        } as CompoundFilterDesign)).toEqual(true);
+
+        // Same data source but too many nested filters (should return true)
+        expect(testCollection.isFiltered({
+            type: 'or',
+            filters: [{
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '='
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '='
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '='
+            } as SimpleFilterDesign]
+        } as CompoundFilterDesign)).toEqual(true);
+
+        // With correct values (should return true)
+        expect(testCollection.isFiltered({
+            type: 'or',
+            filters: [{
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '=',
+                value: 10
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '=',
+                value: 20
+            } as SimpleFilterDesign]
+        } as CompoundFilterDesign)).toEqual(true);
+
+        // With correct values in different order (should return true)
+        expect(testCollection.isFiltered({
+            type: 'or',
+            filters: [{
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '=',
+                value: 20
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '=',
+                value: 10
+            } as SimpleFilterDesign]
+        } as CompoundFilterDesign)).toEqual(true);
+
+        // With incorrect values (should return false)
+        expect(testCollection.isFiltered({
+            type: 'or',
+            filters: [{
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '=',
+                value: 1
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '=',
+                value: 20
+            } as SimpleFilterDesign]
+        } as CompoundFilterDesign)).toEqual(false);
+    });
+
+    it('isFiltered with compound filter designs that have multiple data sources should return expected boolean', () => {
+        let testDesign = {
+            type: 'or',
+            root: CompoundFilterType.AND,
+            filters: [{
+                root: CompoundFilterType.AND,
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '=',
+                value: 10
+            } as SimpleFilterDesign, {
+                root: CompoundFilterType.AND,
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '=',
+                value: 20
+            } as SimpleFilterDesign, {
+                root: CompoundFilterType.AND,
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '!=',
+                value: 30
+            } as SimpleFilterDesign, {
+                root: CompoundFilterType.AND,
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '!=',
+                value: 40
+            } as SimpleFilterDesign]
+        } as CompoundFilterDesign;
+
+        let testFilter = FilterUtil.createFilterFromDesign(testDesign);
+
+        let testSource = [{
+            datastoreName: '',
+            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
+            tableName: DashboardServiceMock.TABLES.testTable1.name,
+            fieldName: DashboardServiceMock.FIELD_MAP.SIZE.columnName,
+            operator: '='
+        } as FilterDataSource, {
+            datastoreName: '',
+            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
+            tableName: DashboardServiceMock.TABLES.testTable1.name,
+            fieldName: DashboardServiceMock.FIELD_MAP.SIZE.columnName,
+            operator: '!='
+        } as FilterDataSource];
+
+        let testCollection = new FilterCollection();
+        testCollection.setFilters(testSource, [testFilter]);
+
+        // Same design (should return true)
+        expect(testCollection.isFiltered({
+            type: 'or',
+            filters: [{
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '='
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '='
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '!='
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '!='
+            } as SimpleFilterDesign]
+        } as CompoundFilterDesign)).toEqual(true);
+
+        // Same design in different order (should return true)
+        expect(testCollection.isFiltered({
+            type: 'or',
+            filters: [{
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '!='
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '!='
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '='
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '='
+            } as SimpleFilterDesign]
+        } as CompoundFilterDesign)).toEqual(true);
+
+        // Same data source but too few nested filters (should return false)
+        expect(testCollection.isFiltered({
+            type: 'or',
+            filters: [{
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '='
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '!='
+            } as SimpleFilterDesign]
+        } as CompoundFilterDesign)).toEqual(false);
+
+        // Same data source but too many nested filters (should return false)
+        expect(testCollection.isFiltered({
+            type: 'or',
+            filters: [{
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '='
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '='
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '!='
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '!='
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '!='
+            } as SimpleFilterDesign]
+        } as CompoundFilterDesign)).toEqual(false);
+
+        // With correct values (should return true)
+        expect(testCollection.isFiltered({
+            type: 'or',
+            filters: [{
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '=',
+                value: 10
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '=',
+                value: 20
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '!=',
+                value: 30
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '!=',
+                value: 40
+            } as SimpleFilterDesign]
+        } as CompoundFilterDesign)).toEqual(true);
+
+        // With correct values in different order (should return true)
+        expect(testCollection.isFiltered({
+            type: 'or',
+            filters: [{
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '=',
+                value: 20
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '=',
+                value: 10
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '!=',
+                value: 40
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '!=',
+                value: 30
+            } as SimpleFilterDesign]
+        } as CompoundFilterDesign)).toEqual(true);
+
+        // Same design in different order With correct values (should return true)
+        expect(testCollection.isFiltered({
+            type: 'or',
+            filters: [{
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '=',
+                value: 10
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '!=',
+                value: 30
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '=',
+                value: 20
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '!=',
+                value: 40
+            } as SimpleFilterDesign]
+        } as CompoundFilterDesign)).toEqual(true);
+
+        // With incorrect values (should return false)
+        expect(testCollection.isFiltered({
+            type: 'or',
+            filters: [{
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '=',
+                value: 10
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '=',
+                value: 20
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '!=',
+                value: 30
+            } as SimpleFilterDesign, {
+                datastore: '',
+                database: DashboardServiceMock.DATABASES.testDatabase1,
+                table: DashboardServiceMock.TABLES.testTable1,
+                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                operator: '!=',
+                value: 50
+            } as SimpleFilterDesign]
+        } as CompoundFilterDesign)).toEqual(false);
     });
 
     it('setFilters should save filters with input data source if it is not in collection', () => {
@@ -3418,3 +3923,4 @@ describe('Filter Labels', () => {
         expect(domainFilter.getLabelForValue()).toEqual('between -100 and 100');
     });
 });
+

--- a/src/app/util/filter.util.spec.ts
+++ b/src/app/util/filter.util.spec.ts
@@ -31,7 +31,6 @@ import { NeonFieldMetaData, NeonDatabaseMetaData, NeonTableMetaData } from '../m
 
 import { DashboardServiceMock } from '../../testUtils/MockServices/DashboardServiceMock';
 import { initializeTestBed } from '../../testUtils/initializeTestBed';
-import { ConfigUtil } from '../util/config.util';
 
 describe('FilterUtil', () => {
     beforeAll(() => {
@@ -607,19 +606,6 @@ describe('FilterUtil', () => {
     });
 
     describe('simpleFiltering', () => {
-        const queryString = `[
-            [".databaseZ.tableA.field1","=","value1","or"],
-            ["and", "and",
-                [".databaseY.tableB.field2", "!=", "", "or"],
-                [".databaseY.tableB.field2", "!=", null, "or"]
-            ]
-        ]`;
-
-        const queryStringCompact = ConfigUtil.translate(
-            JSON.stringify(JSON.parse(queryString)),
-            ConfigUtil.encodeFiltersMap
-        );
-
         const filtersSimple = [
             {
                 root: 'or',
@@ -701,8 +687,6 @@ describe('FilterUtil', () => {
                 ['.databaseY.tableB.field2', '!=', null, 'or']]
         ];
 
-        const empty = ConfigUtil.translate('[]', ConfigUtil.encodeFiltersMap);
-
         it('toPlainFilterJSON should return expected output', () => {
             expect(FilterUtil.toPlainFilterJSON(filterDesigns)).toEqual(expected);
             expect(FilterUtil.toPlainFilterJSON([])).toEqual([]);
@@ -725,16 +709,6 @@ describe('FilterUtil', () => {
                 type: 'and',
                 filters: []
             });
-        });
-
-        it('toSimpleFilterQueryString should return expected output', () => {
-            expect(FilterUtil.toSimpleFilterQueryString(filterDesigns)).toEqual(queryStringCompact);
-            expect(FilterUtil.toSimpleFilterQueryString([])).toEqual(empty);
-        });
-
-        it('fromSimpleFilterQueryString should return expected output', () => {
-            expect(FilterUtil.fromSimpleFilterQueryString(queryStringCompact)).toEqual(filtersSimple);
-            expect(FilterUtil.fromSimpleFilterQueryString(empty)).toEqual([]);
         });
     });
 });

--- a/src/app/util/filter.util.ts
+++ b/src/app/util/filter.util.ts
@@ -152,13 +152,13 @@ export class FilterUtil {
             let datastore: NeonDatastoreConfig = dataset.datastores[0];
             let database: NeonDatabaseMetaData = datastore.databases[filterObject.database];
             let table: NeonTableMetaData = database.tables[filterObject.table];
-            let fields: NeonFieldMetaData[] = table.fields.filter((field) => field.columnName === filterObject.field);
+            let field: NeonFieldMetaData = table.fields.filter((field) => field.columnName === filterObject.field)[0];
             return {
                 root: filterObject.root || '',
                 datastore: filterObject.datastore || '',
                 database,
                 table,
-                field: fields[0],
+                field,
                 operator: filterObject.operator,
                 value: filterObject.value
             } as SimpleFilterDesign;


### PR DESCRIPTION
Goals:  Widgets should be passed new filters whenever the filters are changed, rather than it maintaining a collection of "cached" filters and knowing when to update that collection itself.

Accomplishments:
- Removed cachedFilters and updateCollectionWithGlobalCompatibleFilters from BaseNeonComponent.  Filters are now passed into transformVisualizationQueryResults and the new redrawFilters function (called if the filters are changed but the widget won't requery).
- Removed FilterBehavior; the designEachFilterWithNoValues function now returns a list of FilterDesign objects.