### PR TITLE
THOR-1331 Removed ConfigUtil and DashboardState from FilterService

### DIFF
--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -20,14 +20,11 @@ import { APP_BASE_HREF } from '@angular/common';
 
 import { DashboardComponent } from './dashboard.component';
 
-import { ConfigUtil } from '../util/config.util';
-import { CompoundFilterDesign, SimpleFilterDesign } from '../util/filter.util';
 import { NeonConfig, NeonDashboardLeafConfig, NeonLayoutConfig } from '../models/types';
-import { NeonDatabaseMetaData, NeonFieldMetaData, NeonTableMetaData } from '../models/dataset';
 import { NeonGridItem } from '../models/neon-grid-item';
 import { neonEvents } from '../models/neon-namespaces';
 
-import { AbstractSearchService, CompoundFilterType } from '../services/abstract.search.service';
+import { AbstractSearchService } from '../services/abstract.search.service';
 import { InjectableColorThemeService } from '../services/injectable.color-theme.service';
 import { DashboardService } from '../services/dashboard.service';
 import { InjectableFilterService } from '../services/injectable.filter.service';
@@ -827,48 +824,6 @@ describe('Dashboard', () => {
         let spy = spyOn(component.grid, 'triggerResize');
         component['resizeGrid']();
         expect(spy.calls.count()).toEqual(1);
-    });
-
-    it('getFiltersToSaveInURL should return expected output', () => {
-        expect(component['getFiltersToSaveInURL']()).toEqual(ConfigUtil.translate('[]', ConfigUtil.encodeFiltersMap));
-
-        spyOn(component['filterService'], 'getFilters').and.returnValue([{
-            root: CompoundFilterType.OR,
-            datastore: '',
-            database: NeonDatabaseMetaData.get({ name: 'databaseZ' }),
-            table: NeonTableMetaData.get({ name: 'tableA' }),
-            field: NeonFieldMetaData.get({ columnName: 'field1' }),
-            operator: '=',
-            value: 'value1'
-        } as SimpleFilterDesign, {
-            root: 'and',
-            type: 'and',
-            filters: [{
-                root: CompoundFilterType.OR,
-                datastore: '',
-                database: NeonDatabaseMetaData.get({ name: 'databaseY' }),
-                table: NeonTableMetaData.get({ name: 'tableB' }),
-                field: NeonFieldMetaData.get({ columnName: 'field2' }),
-                operator: '!=',
-                value: ''
-            } as SimpleFilterDesign, {
-                root: CompoundFilterType.OR,
-                datastore: '',
-                database: NeonDatabaseMetaData.get({ name: 'databaseY' }),
-                table: NeonTableMetaData.get({ name: 'tableB' }),
-                field: NeonFieldMetaData.get({ columnName: 'field2' }),
-                operator: '!=',
-                value: null
-            } as SimpleFilterDesign]
-        } as CompoundFilterDesign]);
-
-        expect(component['getFiltersToSaveInURL']()).toEqual(ConfigUtil.translate(JSON.stringify(JSON.parse(`[
-            [".databaseZ.tableA.field1","=","value1","or"],
-            ["and", "and",
-                [".databaseY.tableB.field2", "!=", "", "or"],
-                [".databaseY.tableB.field2", "!=", null, "or"]
-            ]
-        ]`)), ConfigUtil.encodeFiltersMap));
     });
 });
 

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -31,7 +31,7 @@ import { InjectableColorThemeService } from '../services/injectable.color-theme.
 import { BaseNeonComponent } from '../components/base-neon-component/base-neon.component';
 import { DashboardService } from '../services/dashboard.service';
 import { DomSanitizer } from '@angular/platform-browser';
-import { FilterDataSource, FilterDesign, FilterUtil } from '../util/filter.util';
+import { FilterDataSource, FilterDesign } from '../util/filter.util';
 import { InjectableFilterService } from '../services/injectable.filter.service';
 import { MatSnackBar, MatSidenav } from '@angular/material';
 import { MatIconRegistry } from '@angular/material/icon';
@@ -213,7 +213,7 @@ export class DashboardComponent implements AfterViewInit, OnInit, OnDestroy {
      */
     private onDashboardStateChange(state: DashboardState) {
         // Validate url first
-        const currentFilter = this.getFiltersToSaveInURL();
+        const currentFilter = this.dashboardService.getFiltersToSaveInURL();
         const { fullPath, filters, url } = ConfigUtil.getUrlState(window.location, this.baseHref);
         if ((!filters && currentFilter) || url.pathname === '/') {
             this.location.replaceState(`${fullPath}#${currentFilter}`);
@@ -398,7 +398,7 @@ export class DashboardComponent implements AfterViewInit, OnInit, OnDestroy {
         };
         const { pathParts } = ConfigUtil.getUrlState(window.location, this.baseHref);
         this.router.navigate(pathParts, {
-            fragment: this.getFiltersToSaveInURL(),
+            fragment: this.dashboardService.getFiltersToSaveInURL(),
             queryParamsHandling: 'merge',
             relativeTo: this.router.routerState.root
         });
@@ -507,13 +507,5 @@ export class DashboardComponent implements AfterViewInit, OnInit, OnDestroy {
      */
     private updateShowFilterTray(eventMessage: { show: boolean }) {
         this.showFilterTray = eventMessage.show;
-    }
-
-    /**
-     * Returns the filters as string for use in URL
-     */
-    private getFiltersToSaveInURL(): string {
-        let filters: FilterDesign[] = this.filterService.getFilters();
-        return ConfigUtil.translate(JSON.stringify(FilterUtil.toPlainFilterJSON(filters)), ConfigUtil.encodeFiltersMap);
     }
 }

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -31,7 +31,7 @@ import { InjectableColorThemeService } from '../services/injectable.color-theme.
 import { BaseNeonComponent } from '../components/base-neon-component/base-neon.component';
 import { DashboardService } from '../services/dashboard.service';
 import { DomSanitizer } from '@angular/platform-browser';
-import { FilterDataSource, FilterDesign } from '../util/filter.util';
+import { FilterDataSource, FilterDesign, FilterUtil } from '../util/filter.util';
 import { InjectableFilterService } from '../services/injectable.filter.service';
 import { MatSnackBar, MatSidenav } from '@angular/material';
 import { MatIconRegistry } from '@angular/material/icon';
@@ -213,7 +213,7 @@ export class DashboardComponent implements AfterViewInit, OnInit, OnDestroy {
      */
     private onDashboardStateChange(state: DashboardState) {
         // Validate url first
-        const currentFilter = this.filterService.getFiltersToSaveInURL();
+        const currentFilter = this.getFiltersToSaveInURL();
         const { fullPath, filters, url } = ConfigUtil.getUrlState(window.location, this.baseHref);
         if ((!filters && currentFilter) || url.pathname === '/') {
             this.location.replaceState(`${fullPath}#${currentFilter}`);
@@ -398,7 +398,7 @@ export class DashboardComponent implements AfterViewInit, OnInit, OnDestroy {
         };
         const { pathParts } = ConfigUtil.getUrlState(window.location, this.baseHref);
         this.router.navigate(pathParts, {
-            fragment: this.filterService.getFiltersToSaveInURL(),
+            fragment: this.getFiltersToSaveInURL(),
             queryParamsHandling: 'merge',
             relativeTo: this.router.routerState.root
         });
@@ -507,5 +507,13 @@ export class DashboardComponent implements AfterViewInit, OnInit, OnDestroy {
      */
     private updateShowFilterTray(eventMessage: { show: boolean }) {
         this.showFilterTray = eventMessage.show;
+    }
+
+    /**
+     * Returns the filters as string for use in URL
+     */
+    private getFiltersToSaveInURL(): string {
+        let filters: FilterDesign[] = this.filterService.getFilters();
+        return ConfigUtil.translate(JSON.stringify(FilterUtil.toPlainFilterJSON(filters)), ConfigUtil.encodeFiltersMap);
     }
 }

--- a/src/app/services/dashboard.service.spec.ts
+++ b/src/app/services/dashboard.service.spec.ts
@@ -15,7 +15,8 @@
 import { inject } from '@angular/core/testing';
 
 import { NeonConfig, NeonDashboardLeafConfig, FilterConfig } from '../models/types';
-import { NeonDatastoreConfig } from '../models/dataset';
+import { NeonDatabaseMetaData, NeonDatastoreConfig, NeonFieldMetaData, NeonTableMetaData } from '../models/dataset';
+import { CompoundFilterDesign, SimpleFilterDesign } from '../util/filter.util';
 import { DashboardService } from './dashboard.service';
 
 import { initializeTestBed, getConfigService } from '../../testUtils/initializeTestBed';
@@ -84,13 +85,13 @@ describe('Service: DashboardService', () => {
         let spy = spyOn(dashboardService['filterService'], 'setFiltersFromConfig');
 
         dashboardService.setActiveDashboard(NeonDashboardLeafConfig.get({
-            filters: ConfigUtil.translate(JSON.stringify(JSON.parse(`[
+            filters: ConfigUtil.translate(`[
                 [".databaseZ.tableA.field1","=","value1","or"],
                 ["and", "and",
                     [".databaseY.tableB.field2", "!=", "", "or"],
                     [".databaseY.tableB.field2", "!=", null, "or"]
                 ]
-            ]`)), ConfigUtil.encodeFiltersMap)
+            ]`, ConfigUtil.encodeFiltersMap)
         }));
 
         expect(spy.calls.count()).toEqual(1);
@@ -123,6 +124,49 @@ describe('Service: DashboardService', () => {
                 value: null
             }]
         }]);
+    });
+
+    it('getFiltersToSaveInURL should return expected output', () => {
+        expect(dashboardService.getFiltersToSaveInURL()).toEqual(ConfigUtil.translate('[]', ConfigUtil.encodeFiltersMap));
+
+        spyOn(dashboardService['filterService'], 'getFilters').and.returnValue([{
+            root: 'or',
+            datastore: '',
+            database: NeonDatabaseMetaData.get({ name: 'databaseZ' }),
+            table: NeonTableMetaData.get({ name: 'tableA' }),
+            field: NeonFieldMetaData.get({ columnName: 'field1' }),
+            operator: '=',
+            value: 'value1'
+        } as SimpleFilterDesign, {
+            root: 'and',
+            type: 'and',
+            filters: [{
+                root: 'or',
+                datastore: '',
+                database: NeonDatabaseMetaData.get({ name: 'databaseY' }),
+                table: NeonTableMetaData.get({ name: 'tableB' }),
+                field: NeonFieldMetaData.get({ columnName: 'field2' }),
+                operator: '!=',
+                value: ''
+            } as SimpleFilterDesign, {
+                root: 'or',
+                datastore: '',
+                database: NeonDatabaseMetaData.get({ name: 'databaseY' }),
+                table: NeonTableMetaData.get({ name: 'tableB' }),
+                field: NeonFieldMetaData.get({ columnName: 'field2' }),
+                operator: '!=',
+                value: null
+            } as SimpleFilterDesign]
+        } as CompoundFilterDesign]);
+
+        // Use the parse and stringify functions so we don't have to type unicode here.
+        expect(dashboardService.getFiltersToSaveInURL()).toEqual(ConfigUtil.translate(JSON.stringify(JSON.parse(`[
+            [".databaseZ.tableA.field1","=","value1","or"],
+            ["and", "and",
+                [".databaseY.tableB.field2", "!=", "", "or"],
+                [".databaseY.tableB.field2", "!=", null, "or"]
+            ]
+        ]`)), ConfigUtil.encodeFiltersMap));
     });
 });
 

--- a/src/app/services/dashboard.service.spec.ts
+++ b/src/app/services/dashboard.service.spec.ts
@@ -79,6 +79,51 @@ describe('Service: DashboardService', () => {
             databases: {}
         });
     });
+
+    it('setActiveDashboard should translate string filter list', () => {
+        let spy = spyOn(dashboardService['filterService'], 'setFiltersFromConfig');
+
+        dashboardService.setActiveDashboard(NeonDashboardLeafConfig.get({
+            filters: ConfigUtil.translate(JSON.stringify(JSON.parse(`[
+                [".databaseZ.tableA.field1","=","value1","or"],
+                ["and", "and",
+                    [".databaseY.tableB.field2", "!=", "", "or"],
+                    [".databaseY.tableB.field2", "!=", null, "or"]
+                ]
+            ]`)), ConfigUtil.encodeFiltersMap)
+        }));
+
+        expect(spy.calls.count()).toEqual(1);
+        expect(spy.calls.argsFor(0)[0]).toEqual([{
+            root: 'or',
+            datastore: '',
+            database: 'databaseZ',
+            table: 'tableA',
+            field: 'field1',
+            operator: '=',
+            value: 'value1'
+        }, {
+            root: 'and',
+            type: 'and',
+            filters: [{
+                root: 'or',
+                datastore: '',
+                database: 'databaseY',
+                table: 'tableB',
+                field: 'field2',
+                operator: '!=',
+                value: ''
+            }, {
+                root: 'or',
+                datastore: '',
+                database: 'databaseY',
+                table: 'tableB',
+                field: 'field2',
+                operator: '!=',
+                value: null
+            }]
+        }]);
+    });
 });
 
 describe('Service: DashboardService with Mock Data', () => {

--- a/src/app/services/dashboard.service.ts
+++ b/src/app/services/dashboard.service.ts
@@ -27,6 +27,7 @@ import { DashboardUtil } from '../util/dashboard.util';
 import { GridState } from '../models/grid-state';
 import { Observable, from, Subject } from 'rxjs';
 import { map, shareReplay, mergeMap } from 'rxjs/operators';
+import { ConfigUtil } from '../util/config.util';
 import { FilterUtil } from '../util/filter.util';
 import { InjectableFilterService } from './injectable.filter.service';
 
@@ -109,10 +110,13 @@ export class DashboardService {
         this.setActiveDatastore(this.config.datastores[firstName]);
 
         // Load filters
-        const filters = typeof dashboard.filters === 'string' ?
-            FilterUtil.fromSimpleFilterQueryString(dashboard.filters) : dashboard.filters;
+        let filters = dashboard.filters;
+        if (typeof filters === 'string') {
+            const stringFilters = ConfigUtil.translate(dashboard.filters as string, ConfigUtil.decodeFiltersMap);
+            filters = (JSON.parse(stringFilters) as any[]).map((stringFilter) => FilterUtil.fromPlainFilterJSON(stringFilter));
+        }
 
-        this.filterService.setFiltersFromConfig(filters || [], this.state);
+        this.filterService.setFiltersFromConfig(filters || [], this.state.asDataset());
         this.stateSubject.next(this.state);
     }
 

--- a/src/app/services/dashboard.service.ts
+++ b/src/app/services/dashboard.service.ts
@@ -28,7 +28,7 @@ import { GridState } from '../models/grid-state';
 import { Observable, from, Subject } from 'rxjs';
 import { map, shareReplay, mergeMap } from 'rxjs/operators';
 import { ConfigUtil } from '../util/config.util';
-import { FilterUtil } from '../util/filter.util';
+import { FilterDesign, FilterUtil } from '../util/filter.util';
 import { InjectableFilterService } from './injectable.filter.service';
 
 @Injectable({
@@ -110,11 +110,7 @@ export class DashboardService {
         this.setActiveDatastore(this.config.datastores[firstName]);
 
         // Load filters
-        let filters = dashboard.filters;
-        if (typeof filters === 'string') {
-            const stringFilters = ConfigUtil.translate(dashboard.filters as string, ConfigUtil.decodeFiltersMap);
-            filters = (JSON.parse(stringFilters) as any[]).map((stringFilter) => FilterUtil.fromPlainFilterJSON(stringFilter));
-        }
+        let filters = this._translateFilters(dashboard.filters);
 
         this.filterService.setFiltersFromConfig(filters || [], this.state.asDataset());
         this.stateSubject.next(this.state);
@@ -243,5 +239,21 @@ export class DashboardService {
             out.dashboards.options.connectOnLoad = true;
         }
         return out;
+    }
+
+    /**
+     * Returns the filters as string for use in URL
+     */
+    public getFiltersToSaveInURL(): string {
+        let filters: FilterDesign[] = this.filterService.getFilters();
+        return ConfigUtil.translate(JSON.stringify(FilterUtil.toPlainFilterJSON(filters)), ConfigUtil.encodeFiltersMap);
+    }
+
+    private _translateFilters(filters: FilterConfig[] | string): FilterConfig[] {
+        if (typeof filters === 'string') {
+            const stringFilters = ConfigUtil.translate(filters, ConfigUtil.decodeFiltersMap);
+            return (JSON.parse(stringFilters) as any[]).map((stringFilter) => FilterUtil.fromPlainFilterJSON(stringFilter));
+        }
+        return filters;
     }
 }

--- a/src/app/services/filter.service.spec.ts
+++ b/src/app/services/filter.service.spec.ts
@@ -12,10 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { inject } from '@angular/core/testing';
-import { HttpClientModule } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-
 import { CompoundFilterType } from './abstract.search.service';
 import {
     CompoundFilterDesign,
@@ -24,29 +20,16 @@ import {
     FilterUtil,
     SimpleFilterDesign
 } from '../util/filter.util';
-import { DashboardService } from './dashboard.service';
 import { FilterChangeListener, FilterService } from './filter.service';
 
-import { DashboardServiceMock } from '../../testUtils/MockServices/DashboardServiceMock';
-import { initializeTestBed } from '../../testUtils/initializeTestBed';
+import { DATABASES, DATASET, FIELD_MAP, TABLES } from '../../testUtils/mock-dataset';
 
 describe('FilterService with no filters', () => {
     let filterService: FilterService;
 
-    initializeTestBed('Filter Service with no filters', {
-        providers: [
-            { provide: DashboardService, useClass: DashboardServiceMock },
-            { provide: FilterService, useClass: FilterService }
-        ],
-        imports: [
-            HttpClientModule,
-            HttpClientTestingModule
-        ]
+    beforeEach(() => {
+        filterService = new FilterService();
     });
-
-    beforeEach(inject([FilterService], (_filterService) => {
-        filterService = _filterService;
-    }));
 
     it('should have expected properties with no filters', () => {
         expect(filterService['filterCollection']).toBeDefined();
@@ -61,7 +44,6 @@ describe('FilterService with no filters', () => {
 });
 
 describe('FilterService with filters', () => {
-    let datasetService: DashboardService;
     let filterService: FilterService;
     let source1: FilterDataSource[];
     let source2: FilterDataSource[];
@@ -82,71 +64,63 @@ describe('FilterService with filters', () => {
     let relationFilter1: any;
     let relationFilter2: any;
 
-    initializeTestBed('Filter Service with filters', {
-        providers: [
-            { provide: DashboardService, useClass: DashboardServiceMock },
-            { provide: FilterService, useClass: FilterService }
-        ]
-    });
-
-    beforeEach(inject([DashboardService, FilterService], (_datasetService, _filterService) => {
-        datasetService = _datasetService;
-        filterService = _filterService;
+    beforeEach(() => {
+        filterService = new FilterService();
 
         source1 = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.ID.columnName,
             operator: '='
         } as FilterDataSource];
         source2 = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.SIZE.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.SIZE.columnName,
             operator: '>'
         } as FilterDataSource, {
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.SIZE.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.SIZE.columnName,
             operator: '<'
         } as FilterDataSource];
 
         design1A = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.ID,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.ID,
             operator: '=',
             value: 'testId1'
         } as SimpleFilterDesign;
         design1B = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.ID,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.ID,
             operator: '=',
             value: 'testId2'
         } as SimpleFilterDesign;
         design1C = {
             root: CompoundFilterType.OR,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.ID,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.ID,
             operator: '=',
             value: 'testId3'
         } as SimpleFilterDesign;
         design1D = {
             root: CompoundFilterType.OR,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.ID,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.ID,
             operator: '=',
             value: 'testId4'
         } as SimpleFilterDesign;
@@ -156,17 +130,17 @@ describe('FilterService with filters', () => {
             filters: [{
                 root: CompoundFilterType.AND,
                 datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1,
-                table: DashboardServiceMock.TABLES.testTable1,
-                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                database: DATABASES.testDatabase1,
+                table: TABLES.testTable1,
+                field: FIELD_MAP.SIZE,
                 operator: '>',
                 value: 10
             } as SimpleFilterDesign, {
                 root: CompoundFilterType.AND,
                 datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1,
-                table: DashboardServiceMock.TABLES.testTable1,
-                field: DashboardServiceMock.FIELD_MAP.SIZE,
+                database: DATABASES.testDatabase1,
+                table: TABLES.testTable1,
+                field: FIELD_MAP.SIZE,
                 operator: '<',
                 value: 20
             } as SimpleFilterDesign]
@@ -188,7 +162,7 @@ describe('FilterService with filters', () => {
 
         filterService['filterCollection'].setFilters(source1, [filter1A, filter1B, filter1C, filter1D]);
         filterService['filterCollection'].setFilters(source2, [filter2A]);
-    }));
+    });
 
     afterEach(() => {
         // Services are not recreated in each test so we must reset the internal data.
@@ -210,34 +184,34 @@ describe('FilterService with filters', () => {
     let generateRelationFilters = () => {
         relationSource1 = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.RELATION_A.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.RELATION_A.columnName,
             operator: '='
         } as FilterDataSource];
         relationSource2 = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.RELATION_B.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.RELATION_B.columnName,
             operator: '='
         } as FilterDataSource];
 
         relationDesign1 = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.RELATION_A,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.RELATION_A,
             operator: '=',
             value: 'testRelation'
         } as SimpleFilterDesign;
         relationDesign2 = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.RELATION_B,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.RELATION_B,
             operator: '=',
             value: 'testRelation'
         } as SimpleFilterDesign;
@@ -249,23 +223,19 @@ describe('FilterService with filters', () => {
 
         relationDesign1.id = relationFilter1.id;
         relationDesign2.id = relationFilter2.id;
-
-        /* eslint-disable-next-line jasmine/no-unsafe-spy */
-        spyOn(datasetService.state, 'findRelationDataList').and.returnValue([[
-            [{
-                datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1,
-                table: DashboardServiceMock.TABLES.testTable1,
-                field: DashboardServiceMock.FIELD_MAP.RELATION_A
-            }],
-            [{
-                datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1,
-                table: DashboardServiceMock.TABLES.testTable1,
-                field: DashboardServiceMock.FIELD_MAP.RELATION_B
-            }]
-        ]]);
     };
+
+    let findRelationDataList = () => [[[{
+        datastore: '',
+        database: DATABASES.testDatabase1,
+        table: TABLES.testTable1,
+        field: FIELD_MAP.RELATION_A
+    }], [{
+        datastore: '',
+        database: DATABASES.testDatabase1,
+        table: TABLES.testTable1,
+        field: FIELD_MAP.RELATION_B
+    }]]];
 
     it('should have expected properties', () => {
         expect(filterService['filterCollection'].getDataSources()).toEqual([source1, source2]);
@@ -378,9 +348,9 @@ describe('FilterService with filters', () => {
 
         let actual = filterService.deleteFilters('testCaller', [{
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.TEXT,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.TEXT,
             operator: '='
         } as SimpleFilterDesign]);
 
@@ -388,9 +358,9 @@ describe('FilterService with filters', () => {
         let keys = Array.from(actual.keys());
         expect(keys).toEqual([source1, source2, [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.TEXT.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.TEXT.columnName,
             operator: '='
         } as FilterDataSource]]);
         expect(actual.get(keys[0])).toEqual([design1A, design1B, design1C, design1D]);
@@ -406,18 +376,18 @@ describe('FilterService with filters', () => {
         let testDesign = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.TEXT,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.TEXT,
             operator: '=',
             value: 'testText'
         } as SimpleFilterDesign;
 
         let testSource = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.TEXT.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.TEXT.columnName,
             operator: '='
         } as FilterDataSource];
 
@@ -428,9 +398,9 @@ describe('FilterService with filters', () => {
 
         let listComplete = filterService['filterCollection'].getFilters(testSource) as any[]; // TODO: Typings;;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.TEXT);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testText');
 
@@ -453,9 +423,9 @@ describe('FilterService with filters', () => {
         let testDesign = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.ID,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.ID,
             operator: '=',
             value: 'testId5'
         } as SimpleFilterDesign;
@@ -464,9 +434,9 @@ describe('FilterService with filters', () => {
 
         let listComplete = filterService['filterCollection'].getFilters(source1) as any[]; // TODO: Typings;;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.ID);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.ID);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testId5');
 
@@ -490,18 +460,18 @@ describe('FilterService with filters', () => {
         let testDesign = {
             root: CompoundFilterType.OR,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.TEXT,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.TEXT,
             operator: '=',
             value: 'testText'
         } as SimpleFilterDesign;
 
         let testSource = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.TEXT.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.TEXT.columnName,
             operator: '='
         } as FilterDataSource];
 
@@ -512,9 +482,9 @@ describe('FilterService with filters', () => {
 
         let listComplete = filterService['filterCollection'].getFilters(testSource) as any[]; // TODO: Typings
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.TEXT);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testText');
 
@@ -536,16 +506,16 @@ describe('FilterService with filters', () => {
 
         let spy = spyOn(filterService as any, '_notifier');
 
-        let actual = filterService.exchangeFilters('testCaller', [relationDesign1], datasetService.state.findRelationDataList());
+        let actual = filterService.exchangeFilters('testCaller', [relationDesign1], findRelationDataList());
 
         expect(filterService['filterCollection'].getFilters(source1)).toEqual([filter1A, filter1B, filter1C, filter1D]);
         expect(filterService['filterCollection'].getFilters(source2)).toEqual([filter2A]);
 
         let listComplete = filterService['filterCollection'].getFilters(relationSource1) as any[]; // TODO: Typings;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.RELATION_A);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.RELATION_A);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testRelation');
 
@@ -553,9 +523,9 @@ describe('FilterService with filters', () => {
 
         listComplete = filterService['filterCollection'].getFilters(relationSource2) as any[]; // TODO: Typings;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.RELATION_B);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.RELATION_B);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testRelation');
 
@@ -581,23 +551,23 @@ describe('FilterService with filters', () => {
         let testDesign2 = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.RELATION_B,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.RELATION_B,
             operator: '=',
             value: 'testExchangeRelation'
         } as SimpleFilterDesign;
 
-        let actual = filterService.exchangeFilters('testCaller', [testDesign2], datasetService.state.findRelationDataList());
+        let actual = filterService.exchangeFilters('testCaller', [testDesign2], findRelationDataList());
 
         expect(filterService['filterCollection'].getFilters(source1)).toEqual([filter1A, filter1B, filter1C, filter1D]);
         expect(filterService['filterCollection'].getFilters(source2)).toEqual([filter2A]);
 
         let listComplete = filterService['filterCollection'].getFilters(relationSource1) as any[]; // TODO: Typings;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.RELATION_A);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.RELATION_A);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testExchangeRelation');
 
@@ -605,18 +575,18 @@ describe('FilterService with filters', () => {
             id: listComplete[0].id,
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.RELATION_A,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.RELATION_A,
             operator: '=',
             value: 'testExchangeRelation'
         } as SimpleFilterDesign;
 
         listComplete = filterService['filterCollection'].getFilters(relationSource2);
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.RELATION_B);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.RELATION_B);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testExchangeRelation');
 
@@ -697,9 +667,9 @@ describe('FilterService with filters', () => {
         expect(filterService.getFilters(source2)).toEqual([design2A]);
         expect(filterService.getFilters([{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.ID.columnName,
             operator: '!='
         } as FilterDataSource])).toEqual([]);
     });
@@ -708,33 +678,33 @@ describe('FilterService with filters', () => {
         expect(filterService.getFiltersToSaveInConfig()).toEqual([{
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId1'
         }, {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId2'
         }, {
             root: CompoundFilterType.OR,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId3'
         }, {
             root: CompoundFilterType.OR,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId4'
         }, {
@@ -743,17 +713,17 @@ describe('FilterService with filters', () => {
             filters: [{
                 root: CompoundFilterType.AND,
                 datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1.name,
-                table: DashboardServiceMock.TABLES.testTable1.name,
-                field: DashboardServiceMock.FIELD_MAP.SIZE.columnName,
+                database: DATABASES.testDatabase1.name,
+                table: TABLES.testTable1.name,
+                field: FIELD_MAP.SIZE.columnName,
                 operator: '>',
                 value: 10
             }, {
                 root: CompoundFilterType.AND,
                 datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1.name,
-                table: DashboardServiceMock.TABLES.testTable1.name,
-                field: DashboardServiceMock.FIELD_MAP.SIZE.columnName,
+                database: DATABASES.testDatabase1.name,
+                table: TABLES.testTable1.name,
+                field: FIELD_MAP.SIZE.columnName,
                 operator: '<',
                 value: 20
             }]
@@ -907,9 +877,9 @@ describe('FilterService with filters', () => {
             filters: [{
                 root: CompoundFilterType.AND,
                 datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1,
-                table: DashboardServiceMock.TABLES.testTable1,
-                field: DashboardServiceMock.FIELD_MAP.ID,
+                database: DATABASES.testDatabase1,
+                table: TABLES.testTable1,
+                field: FIELD_MAP.ID,
                 operator: '='
             } as SimpleFilterDesign]
         } as CompoundFilterDesign;
@@ -924,17 +894,17 @@ describe('FilterService with filters', () => {
         let testDesign = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.TEXT,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.TEXT,
             operator: '='
         } as SimpleFilterDesign;
 
         let testSource = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.TEXT.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.TEXT.columnName,
             operator: '='
         } as FilterDataSource];
 
@@ -947,24 +917,24 @@ describe('FilterService with filters', () => {
     it('setFiltersFromConfig should change filterCollection', () => {
         let actual;
 
-        filterService.setFiltersFromConfig([], datasetService.state);
+        filterService.setFiltersFromConfig([], DATASET);
         expect(filterService['filterCollection'].getDataSources()).toEqual([]);
 
         filterService.setFiltersFromConfig([{
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId1'
-        }], datasetService.state);
+        }], DATASET);
         expect(filterService['filterCollection'].getDataSources()).toEqual([source1]);
         actual = filterService['filterCollection'].getFilters(source1);
         expect(actual.length).toEqual(1);
-        expect(actual[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[0].field).toEqual(DashboardServiceMock.FIELD_MAP.ID);
+        expect(actual[0].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[0].table).toEqual(TABLES.testTable1);
+        expect(actual[0].field).toEqual(FIELD_MAP.ID);
         expect(actual[0].operator).toEqual('=');
         expect(actual[0].value).toEqual('testId1');
         expect(actual[0].root).toEqual(CompoundFilterType.AND);
@@ -972,60 +942,60 @@ describe('FilterService with filters', () => {
         filterService.setFiltersFromConfig([{
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId1'
         }, {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId2'
         }, {
             root: CompoundFilterType.OR,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId3'
         }, {
             root: CompoundFilterType.OR,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId4'
-        }], datasetService.state);
+        }], DATASET);
         expect(filterService['filterCollection'].getDataSources()).toEqual([source1]);
         actual = filterService['filterCollection'].getFilters(source1);
         expect(actual.length).toEqual(4);
-        expect(actual[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[0].field).toEqual(DashboardServiceMock.FIELD_MAP.ID);
+        expect(actual[0].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[0].table).toEqual(TABLES.testTable1);
+        expect(actual[0].field).toEqual(FIELD_MAP.ID);
         expect(actual[0].operator).toEqual('=');
         expect(actual[0].value).toEqual('testId1');
         expect(actual[0].root).toEqual(CompoundFilterType.AND);
-        expect(actual[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[1].field).toEqual(DashboardServiceMock.FIELD_MAP.ID);
+        expect(actual[1].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[1].table).toEqual(TABLES.testTable1);
+        expect(actual[1].field).toEqual(FIELD_MAP.ID);
         expect(actual[1].operator).toEqual('=');
         expect(actual[1].value).toEqual('testId2');
         expect(actual[1].root).toEqual(CompoundFilterType.AND);
-        expect(actual[2].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[2].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[2].field).toEqual(DashboardServiceMock.FIELD_MAP.ID);
+        expect(actual[2].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[2].table).toEqual(TABLES.testTable1);
+        expect(actual[2].field).toEqual(FIELD_MAP.ID);
         expect(actual[2].operator).toEqual('=');
         expect(actual[2].value).toEqual('testId3');
         expect(actual[2].root).toEqual(CompoundFilterType.OR);
-        expect(actual[3].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[3].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[3].field).toEqual(DashboardServiceMock.FIELD_MAP.ID);
+        expect(actual[3].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[3].table).toEqual(TABLES.testTable1);
+        expect(actual[3].field).toEqual(FIELD_MAP.ID);
         expect(actual[3].operator).toEqual('=');
         expect(actual[3].value).toEqual('testId4');
         expect(actual[3].root).toEqual(CompoundFilterType.OR);
@@ -1036,52 +1006,52 @@ describe('FilterService with filters', () => {
             filters: [{
                 root: CompoundFilterType.AND,
                 datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1.name,
-                table: DashboardServiceMock.TABLES.testTable1.name,
-                field: DashboardServiceMock.FIELD_MAP.SIZE.columnName,
+                database: DATABASES.testDatabase1.name,
+                table: TABLES.testTable1.name,
+                field: FIELD_MAP.SIZE.columnName,
                 operator: '>',
                 value: 10
             }, {
                 root: CompoundFilterType.AND,
                 datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1.name,
-                table: DashboardServiceMock.TABLES.testTable1.name,
-                field: DashboardServiceMock.FIELD_MAP.SIZE.columnName,
+                database: DATABASES.testDatabase1.name,
+                table: TABLES.testTable1.name,
+                field: FIELD_MAP.SIZE.columnName,
                 operator: '<',
                 value: 20
             }]
-        }], datasetService.state);
+        }], DATASET);
         expect(filterService['filterCollection'].getDataSources()).toEqual([source2]);
         actual = filterService['filterCollection'].getFilters(source2);
         expect(actual.length).toEqual(1);
         expect(actual[0].type).toEqual(CompoundFilterType.AND);
         expect(actual[0].root).toEqual(CompoundFilterType.AND);
         expect(actual[0].filters.length).toEqual(2);
-        expect(actual[0].filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[0].filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[0].filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.SIZE);
+        expect(actual[0].filters[0].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[0].filters[0].table).toEqual(TABLES.testTable1);
+        expect(actual[0].filters[0].field).toEqual(FIELD_MAP.SIZE);
         expect(actual[0].filters[0].operator).toEqual('>');
         expect(actual[0].filters[0].value).toEqual(10);
-        expect(actual[0].filters[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[0].filters[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[0].filters[1].field).toEqual(DashboardServiceMock.FIELD_MAP.SIZE);
+        expect(actual[0].filters[1].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[0].filters[1].table).toEqual(TABLES.testTable1);
+        expect(actual[0].filters[1].field).toEqual(FIELD_MAP.SIZE);
         expect(actual[0].filters[1].operator).toEqual('<');
         expect(actual[0].filters[1].value).toEqual(20);
 
         filterService.setFiltersFromConfig([{
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId1'
         }, {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1.name,
-            table: DashboardServiceMock.TABLES.testTable1.name,
-            field: DashboardServiceMock.FIELD_MAP.ID.columnName,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.ID.columnName,
             operator: '=',
             value: 'testId2'
         }, {
@@ -1090,33 +1060,33 @@ describe('FilterService with filters', () => {
             filters: [{
                 root: CompoundFilterType.AND,
                 datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1.name,
-                table: DashboardServiceMock.TABLES.testTable1.name,
-                field: DashboardServiceMock.FIELD_MAP.SIZE.columnName,
+                database: DATABASES.testDatabase1.name,
+                table: TABLES.testTable1.name,
+                field: FIELD_MAP.SIZE.columnName,
                 operator: '>',
                 value: 10
             }, {
                 root: CompoundFilterType.AND,
                 datastore: '',
-                database: DashboardServiceMock.DATABASES.testDatabase1.name,
-                table: DashboardServiceMock.TABLES.testTable1.name,
-                field: DashboardServiceMock.FIELD_MAP.SIZE.columnName,
+                database: DATABASES.testDatabase1.name,
+                table: TABLES.testTable1.name,
+                field: FIELD_MAP.SIZE.columnName,
                 operator: '<',
                 value: 20
             }]
-        }], datasetService.state);
+        }], DATASET);
         expect(filterService['filterCollection'].getDataSources()).toEqual([source1, source2]);
         actual = filterService['filterCollection'].getFilters(source1);
         expect(actual.length).toEqual(2);
-        expect(actual[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[0].field).toEqual(DashboardServiceMock.FIELD_MAP.ID);
+        expect(actual[0].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[0].table).toEqual(TABLES.testTable1);
+        expect(actual[0].field).toEqual(FIELD_MAP.ID);
         expect(actual[0].operator).toEqual('=');
         expect(actual[0].value).toEqual('testId1');
         expect(actual[0].root).toEqual(CompoundFilterType.AND);
-        expect(actual[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[1].field).toEqual(DashboardServiceMock.FIELD_MAP.ID);
+        expect(actual[1].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[1].table).toEqual(TABLES.testTable1);
+        expect(actual[1].field).toEqual(FIELD_MAP.ID);
         expect(actual[1].operator).toEqual('=');
         expect(actual[1].value).toEqual('testId2');
         expect(actual[1].root).toEqual(CompoundFilterType.AND);
@@ -1125,14 +1095,14 @@ describe('FilterService with filters', () => {
         expect(actual[0].type).toEqual(CompoundFilterType.AND);
         expect(actual[0].root).toEqual(CompoundFilterType.AND);
         expect(actual[0].filters.length).toEqual(2);
-        expect(actual[0].filters[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[0].filters[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[0].filters[0].field).toEqual(DashboardServiceMock.FIELD_MAP.SIZE);
+        expect(actual[0].filters[0].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[0].filters[0].table).toEqual(TABLES.testTable1);
+        expect(actual[0].filters[0].field).toEqual(FIELD_MAP.SIZE);
         expect(actual[0].filters[0].operator).toEqual('>');
         expect(actual[0].filters[0].value).toEqual(10);
-        expect(actual[0].filters[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(actual[0].filters[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(actual[0].filters[1].field).toEqual(DashboardServiceMock.FIELD_MAP.SIZE);
+        expect(actual[0].filters[1].database).toEqual(DATABASES.testDatabase1);
+        expect(actual[0].filters[1].table).toEqual(TABLES.testTable1);
+        expect(actual[0].filters[1].field).toEqual(FIELD_MAP.SIZE);
         expect(actual[0].filters[1].operator).toEqual('<');
         expect(actual[0].filters[1].value).toEqual(20);
     });
@@ -1143,9 +1113,9 @@ describe('FilterService with filters', () => {
         let testDesign = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.ID,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.ID,
             operator: '=',
             value: 'testId5'
         } as SimpleFilterDesign;
@@ -1158,9 +1128,9 @@ describe('FilterService with filters', () => {
         expect(listComplete[1]).toEqual(filter1B);
         expect(listComplete[2]).toEqual(filter1C);
         expect(listComplete[3]).toEqual(filter1D);
-        expect(listComplete[4].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[4].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[4].field).toEqual(DashboardServiceMock.FIELD_MAP.ID);
+        expect(listComplete[4].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[4].table).toEqual(TABLES.testTable1);
+        expect(listComplete[4].field).toEqual(FIELD_MAP.ID);
         expect(listComplete[4].operator).toEqual('=');
         expect(listComplete[4].value).toEqual('testId5');
 
@@ -1184,18 +1154,18 @@ describe('FilterService with filters', () => {
         let testDesign = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.TEXT,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.TEXT,
             operator: '=',
             value: 'testText'
         } as SimpleFilterDesign;
 
         let testSource = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.TEXT.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.TEXT.columnName,
             operator: '='
         } as FilterDataSource];
 
@@ -1206,9 +1176,9 @@ describe('FilterService with filters', () => {
 
         let listComplete = filterService['filterCollection'].getFilters(testSource) as any[]; // TODO: Typings;;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.TEXT);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testText');
 
@@ -1249,18 +1219,18 @@ describe('FilterService with filters', () => {
         let testDesign = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.TEXT,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.TEXT,
             operator: '=',
             value: 'testText'
         } as SimpleFilterDesign;
 
         let testSource = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.TEXT.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.TEXT.columnName,
             operator: '='
         } as FilterDataSource];
 
@@ -1271,9 +1241,9 @@ describe('FilterService with filters', () => {
 
         let listComplete = filterService['filterCollection'].getFilters(testSource) as any[]; // TODO: Typings;;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.TEXT);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testText');
 
@@ -1296,18 +1266,18 @@ describe('FilterService with filters', () => {
         let testDesign = {
             root: CompoundFilterType.OR,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.TEXT,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.TEXT,
             operator: '=',
             value: 'testText'
         } as SimpleFilterDesign;
 
         let testSource = [{
             datastoreName: '',
-            databaseName: DashboardServiceMock.DATABASES.testDatabase1.name,
-            tableName: DashboardServiceMock.TABLES.testTable1.name,
-            fieldName: DashboardServiceMock.FIELD_MAP.TEXT.columnName,
+            databaseName: DATABASES.testDatabase1.name,
+            tableName: TABLES.testTable1.name,
+            fieldName: FIELD_MAP.TEXT.columnName,
             operator: '='
         } as FilterDataSource];
 
@@ -1318,9 +1288,9 @@ describe('FilterService with filters', () => {
 
         let listComplete = filterService['filterCollection'].getFilters(testSource) as any[]; // TODO: Typings;;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.TEXT);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.TEXT);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testText');
 
@@ -1342,16 +1312,16 @@ describe('FilterService with filters', () => {
 
         let spy = spyOn(filterService as any, '_notifier');
 
-        let actual = filterService.toggleFilters('testCaller', [relationDesign1], datasetService.state.findRelationDataList());
+        let actual = filterService.toggleFilters('testCaller', [relationDesign1], findRelationDataList());
 
         expect(filterService['filterCollection'].getFilters(source1)).toEqual([filter1A, filter1B, filter1C, filter1D]);
         expect(filterService['filterCollection'].getFilters(source2)).toEqual([filter2A]);
 
         let listComplete = filterService['filterCollection'].getFilters(relationSource1) as any[]; // TODO: Typings;;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.RELATION_A);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.RELATION_A);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testRelation');
 
@@ -1359,9 +1329,9 @@ describe('FilterService with filters', () => {
 
         listComplete = filterService['filterCollection'].getFilters(relationSource2) as any[]; // TODO: Typings;;
         expect(listComplete.length).toEqual(1);
-        expect(listComplete[0].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[0].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[0].field).toEqual(DashboardServiceMock.FIELD_MAP.RELATION_B);
+        expect(listComplete[0].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[0].table).toEqual(TABLES.testTable1);
+        expect(listComplete[0].field).toEqual(FIELD_MAP.RELATION_B);
         expect(listComplete[0].operator).toEqual('=');
         expect(listComplete[0].value).toEqual('testRelation');
 
@@ -1387,14 +1357,14 @@ describe('FilterService with filters', () => {
         let testDesign2 = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.RELATION_B,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.RELATION_B,
             operator: '=',
             value: 'testToggleRelation'
         } as SimpleFilterDesign;
 
-        let actual = filterService.toggleFilters('testCaller', [testDesign2], datasetService.state.findRelationDataList());
+        let actual = filterService.toggleFilters('testCaller', [testDesign2], findRelationDataList());
 
         expect(filterService['filterCollection'].getFilters(source1)).toEqual([filter1A, filter1B, filter1C, filter1D]);
         expect(filterService['filterCollection'].getFilters(source2)).toEqual([filter2A]);
@@ -1402,9 +1372,9 @@ describe('FilterService with filters', () => {
         let listComplete = filterService['filterCollection'].getFilters(relationSource1) as any[]; // TODO: Typings;;
         expect(listComplete.length).toEqual(2);
         expect(listComplete[0]).toEqual(relationFilter1);
-        expect(listComplete[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[1].field).toEqual(DashboardServiceMock.FIELD_MAP.RELATION_A);
+        expect(listComplete[1].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[1].table).toEqual(TABLES.testTable1);
+        expect(listComplete[1].field).toEqual(FIELD_MAP.RELATION_A);
         expect(listComplete[1].operator).toEqual('=');
         expect(listComplete[1].value).toEqual('testToggleRelation');
 
@@ -1412,9 +1382,9 @@ describe('FilterService with filters', () => {
             id: listComplete[1].id,
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.RELATION_A,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.RELATION_A,
             operator: '=',
             value: 'testToggleRelation'
         } as SimpleFilterDesign;
@@ -1422,9 +1392,9 @@ describe('FilterService with filters', () => {
         listComplete = filterService['filterCollection'].getFilters(relationSource2);
         expect(listComplete.length).toEqual(2);
         expect(listComplete[0]).toEqual(relationFilter2);
-        expect(listComplete[1].database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
-        expect(listComplete[1].table).toEqual(DashboardServiceMock.TABLES.testTable1);
-        expect(listComplete[1].field).toEqual(DashboardServiceMock.FIELD_MAP.RELATION_B);
+        expect(listComplete[1].database).toEqual(DATABASES.testDatabase1);
+        expect(listComplete[1].table).toEqual(TABLES.testTable1);
+        expect(listComplete[1].field).toEqual(FIELD_MAP.RELATION_B);
         expect(listComplete[1].operator).toEqual('=');
         expect(listComplete[1].value).toEqual('testToggleRelation');
 
@@ -1447,7 +1417,7 @@ describe('FilterService with filters', () => {
 
         let spy = spyOn(filterService as any, '_notifier');
 
-        let actual = filterService.toggleFilters('testCaller', [relationDesign1], datasetService.state.findRelationDataList());
+        let actual = filterService.toggleFilters('testCaller', [relationDesign1], findRelationDataList());
 
         expect(filterService['filterCollection'].getFilters(source1)).toEqual([filter1A, filter1B, filter1C, filter1D]);
         expect(filterService['filterCollection'].getFilters(source2)).toEqual([filter2A]);
@@ -1472,18 +1442,18 @@ describe('FilterService with filters', () => {
         let testDesign1 = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.RELATION_A,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.RELATION_A,
             operator: '=',
             value: 'testToggleRelation'
         } as SimpleFilterDesign;
         let testDesign2 = {
             root: CompoundFilterType.AND,
             datastore: '',
-            database: DashboardServiceMock.DATABASES.testDatabase1,
-            table: DashboardServiceMock.TABLES.testTable1,
-            field: DashboardServiceMock.FIELD_MAP.RELATION_B,
+            database: DATABASES.testDatabase1,
+            table: TABLES.testTable1,
+            field: FIELD_MAP.RELATION_B,
             operator: '=',
             value: 'testToggleRelation'
         } as SimpleFilterDesign;
@@ -1501,8 +1471,7 @@ describe('FilterService with filters', () => {
 
         let spy = spyOn(filterService as any, '_notifier');
 
-        let actual = filterService.toggleFilters('testCaller',
-            [relationDesign1], datasetService.state.findRelationDataList());
+        let actual = filterService.toggleFilters('testCaller', [relationDesign1], findRelationDataList());
 
         expect(filterService['filterCollection'].getFilters(source1)).toEqual([filter1A, filter1B, filter1C, filter1D]);
         expect(filterService['filterCollection'].getFilters(source2)).toEqual([filter2A]);

--- a/src/app/services/filter.service.ts
+++ b/src/app/services/filter.service.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 import { CompoundFilterType } from './abstract.search.service';
+import { Dataset, SingleField } from '../models/dataset';
 import { FilterConfig } from '../models/types';
-import { SingleField } from '../models/dataset';
 import {
     AbstractFilter,
     CompoundFilter,
@@ -23,8 +23,6 @@ import {
     FilterDesign,
     FilterUtil
 } from '../util/filter.util';
-
-import { DashboardState } from '../models/dashboard-state';
 
 export type FilterChangeListener = (callerId: string, changeCollection: Map<FilterDataSource[], FilterDesign[]>) => void;
 
@@ -276,13 +274,6 @@ export class FilterService {
     }
 
     /**
-     * Returns the filters as string for use in URL
-     */
-    public getFiltersToSaveInURL(): string {
-        return FilterUtil.toSimpleFilterQueryString(this.getFilters());
-    }
-
-    /**
      * Returns all the filters to search on the given datastore/database/table (ignoring filters from the given data sources).
      *
      * @arg {string} datastoreName
@@ -379,10 +370,10 @@ export class FilterService {
     /**
      * Sets the filters in the FilterService to the given filter JSON objects from a config file.
      */
-    public setFiltersFromConfig(filtersFromConfig: FilterConfig[], dashboardState: DashboardState) {
+    public setFiltersFromConfig(filtersFromConfig: FilterConfig[], dataset: Dataset) {
         let collection: FilterCollection = new FilterCollection();
         for (const filterFromConfig of filtersFromConfig) {
-            const filterDesign: FilterDesign = FilterUtil.createFilterDesignFromJsonObject(filterFromConfig, dashboardState);
+            const filterDesign: FilterDesign = FilterUtil.createFilterDesignFromJsonObject(filterFromConfig, dataset);
             if (filterDesign) {
                 const filterDataSourceList = collection.findFilterDataSources(filterDesign);
                 const filter = FilterUtil.createFilterFromDesign(filterDesign);

--- a/src/app/util/filter.util.spec.ts
+++ b/src/app/util/filter.util.spec.ts
@@ -31,7 +31,6 @@ import { NeonFieldMetaData, NeonDatabaseMetaData, NeonTableMetaData } from '../m
 
 import { DashboardServiceMock } from '../../testUtils/MockServices/DashboardServiceMock';
 import { initializeTestBed } from '../../testUtils/initializeTestBed';
-import { ConfigUtil } from '../util/config.util';
 
 describe('FilterUtil', () => {
     beforeAll(() => {
@@ -607,19 +606,6 @@ describe('FilterUtil', () => {
     });
 
     describe('simpleFiltering', () => {
-        const queryString = `[
-            [".databaseZ.tableA.field1","=","value1","or"],
-            ["and", "and",
-                [".databaseY.tableB.field2", "!=", "", "or"],
-                [".databaseY.tableB.field2", "!=", null, "or"]
-            ]
-        ]`;
-
-        const queryStringCompact = ConfigUtil.translate(
-            JSON.stringify(JSON.parse(queryString)),
-            ConfigUtil.encodeFiltersMap
-        );
-
         const filtersSimple = [
             {
                 root: 'or',
@@ -701,8 +687,6 @@ describe('FilterUtil', () => {
                 ['.databaseY.tableB.field2', '!=', null, 'or']]
         ];
 
-        const empty = ConfigUtil.translate('[]', ConfigUtil.encodeFiltersMap);
-
         it('toPlainFilterJSON should return expected output', () => {
             expect(FilterUtil.toPlainFilterJSON(filterDesigns)).toEqual(expected);
             expect(FilterUtil.toPlainFilterJSON([])).toEqual([]);
@@ -725,16 +709,6 @@ describe('FilterUtil', () => {
                 type: 'and',
                 filters: []
             });
-        });
-
-        it('toSimpleFilterQueryString should return expected output', () => {
-            expect(FilterUtil.toSimpleFilterQueryString(filterDesigns)).toEqual(queryStringCompact);
-            expect(FilterUtil.toSimpleFilterQueryString([])).toEqual(empty);
-        });
-
-        it('fromSimpleFilterQueryString should return expected output', () => {
-            expect(FilterUtil.fromSimpleFilterQueryString(queryStringCompact)).toEqual(filtersSimple);
-            expect(FilterUtil.fromSimpleFilterQueryString(empty)).toEqual([]);
         });
     });
 });

--- a/src/app/util/filter.util.ts
+++ b/src/app/util/filter.util.ts
@@ -152,13 +152,13 @@ export class FilterUtil {
             let datastore: NeonDatastoreConfig = dataset.datastores[0];
             let database: NeonDatabaseMetaData = datastore.databases[filterObject.database];
             let table: NeonTableMetaData = database.tables[filterObject.table];
-            let fields: NeonFieldMetaData[] = table.fields.filter((field) => field.columnName === filterObject.field);
+            let field: NeonFieldMetaData = table.fields.filter((field) => field.columnName === filterObject.field)[0];
             return {
                 root: filterObject.root || '',
                 datastore: filterObject.datastore || '',
                 database,
                 table,
-                field: fields[0],
+                field,
                 operator: filterObject.operator,
                 value: filterObject.value
             } as SimpleFilterDesign;


### PR DESCRIPTION
Goals:  Remove the dependencies on ConfigUtil and DashboardState from the FilterService.

Accomplishments:
- Moved filter-to-string conversion from FilterService/FilterUtil to DashboardComponent.
- Moved string-to-filter conversion from FilterUtil to DashboardService.