### PR TITLE
THOR-1384 Move Current Dashboard State to URL Query Parameters

### DIFF
--- a/src/app/components/dashboard-selector/dashboard-selector.component.spec.ts
+++ b/src/app/components/dashboard-selector/dashboard-selector.component.spec.ts
@@ -97,8 +97,10 @@ describe('Component: Dashboard Selector', () => {
         component.updateDashboardState(dashboards.choices.dash1);
         expect(spy.calls.count()).toEqual(1);
         const [path, params] = spy.calls.argsFor(0);
-        expect(path).toEqual(['-', 'dash1']);
-        expect(params.queryParams).toBeUndefined();
+        expect(path).toEqual(['/']);
+        expect(params.queryParams).toEqual({
+            dashboard: '-/dash1'
+        });
     }));
 
     it('selectDashboard() should set dashboardChoice if no more choices exists', (() => {

--- a/src/app/components/dashboard-selector/dashboard-selector.component.ts
+++ b/src/app/components/dashboard-selector/dashboard-selector.component.ts
@@ -130,15 +130,13 @@ export class DashboardSelectorComponent implements OnInit, OnDestroy {
     public updateDashboardState(dashboard: NeonDashboardConfig) {
         if (dashboard && 'tables' in dashboard) {
             this.dashboardChoice = dashboard;
-            this.router.navigate(
-                [
-                    this.dashboardService.config.fileName,
-                    ...this.computeNamePath()
-                ],
-                {
-                    relativeTo: this.router.routerState.root
-                }
-            );
+            this.router.navigate(['/'], {
+                fragment: '',
+                queryParams: {
+                    dashboard: [this.dashboardService.config.fileName, ...this.computeNamePath()].join('/')
+                },
+                relativeTo: this.router.routerState.root
+            });
         }
     }
 

--- a/src/app/components/save-state/save-state.component.ts
+++ b/src/app/components/save-state/save-state.component.ts
@@ -117,8 +117,13 @@ export class SaveStateComponent implements OnInit {
     public loadState(name: string): void {
         this.configService.load(name)
             .subscribe((config) => {
-                this.router.navigate([config.fileName], { relativeTo: this.router.routerState.root });
-                this.openNotification(name, 'loaded');
+                this.router.navigate(['/'], {
+                    fragment: '',
+                    queryParams: {
+                        dashboard: config.fileName
+                    },
+                    relativeTo: this.router.routerState.root
+                });
                 this.closeSidenav();
             }, this.handleStateFailure.bind(this, name));
     }

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -34,6 +34,7 @@ import { SearchServiceMock } from '../../testUtils/MockServices/SearchServiceMoc
 import { initializeTestBed } from '../../testUtils/initializeTestBed';
 
 import { ConfigService } from '../services/config.service';
+import { ConfigUtil } from '../util/config.util';
 import { GearModule } from '../components/gear/gear.module';
 
 const Modules = {
@@ -123,8 +124,10 @@ describe('Dashboard', () => {
         component.onFiltersChanged('testCaller', null);
         expect(spyOnRouter.calls.count()).toEqual(1);
         const [path, params] = spyOnRouter.calls.argsFor(0);
-        expect(path).toEqual(['context.html']);
-        expect(params.queryParamsHandling).toEqual('merge');
+        expect(path).toEqual(['/']);
+        expect(params.queryParams).toEqual({
+            dashboard: ConfigUtil.DEFAULT_CONFIG_NAME
+        });
         expect(params.fragment).toBeTruthy();
     });
 

--- a/src/app/models/types.ts
+++ b/src/app/models/types.ts
@@ -162,7 +162,7 @@ export interface NeonConfig {
     datastores: Record<string, NeonDatastoreConfig>;
     dashboards: NeonDashboardConfig;
     layouts: Record<string, NeonLayoutConfig[]> | Record<string, Record<string, NeonLayoutConfig[]>>;
-    errors?: string[];
+    errors?: any[];
     neonServerUrl?: string;
     version: string;
 }

--- a/src/app/route-dashboard.component.ts
+++ b/src/app/route-dashboard.component.ts
@@ -12,9 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Inject } from '@angular/core';
+import { Component } from '@angular/core';
 import { Router } from '@angular/router';
-import { APP_BASE_HREF } from '@angular/common';
 
 import { ConfigService } from './services/config.service';
 import { DashboardService } from './services/dashboard.service';
@@ -27,11 +26,10 @@ import { RouteWithStateComponent } from './route-with-state.component';
 })
 export class RouteDashboardComponent extends RouteWithStateComponent {
     constructor(
-        @Inject(APP_BASE_HREF) private href: string,
         configService: ConfigService,
         dashboardService: DashboardService,
         router: Router
     ) {
-        super(href, configService, dashboardService, router, '');
+        super(configService, dashboardService, router);
     }
 }

--- a/src/app/route-request.component.ts
+++ b/src/app/route-request.component.ts
@@ -12,9 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Inject } from '@angular/core';
+import { Component } from '@angular/core';
 import { Router } from '@angular/router';
-import { APP_BASE_HREF } from '@angular/common';
 import { distinctUntilKeyChanged } from 'rxjs/operators';
 
 import { AbstractColorThemeService } from './services/abstract.color-theme.service';
@@ -31,13 +30,12 @@ export class RouteRequestComponent extends RouteWithStateComponent {
     public webpageTitle: string = 'Loading...';
 
     constructor(
-        @Inject(APP_BASE_HREF) private href: string,
         private colorThemeService: AbstractColorThemeService,
         configService: ConfigService,
         dashboardService: DashboardService,
         router: Router
     ) {
-        super(href, configService, dashboardService, router, 'submit/');
+        super(configService, dashboardService, router);
         dashboardService.configSource.pipe(distinctUntilKeyChanged('fileName')).subscribe((config) => {
             this.webpageTitle = 'Submit Data to ' + (config.projectTitle || 'Neon');
             document.title = this.webpageTitle;

--- a/src/app/route-with-state.component.ts
+++ b/src/app/route-with-state.component.ts
@@ -12,9 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { OnInit, HostBinding, Inject } from '@angular/core';
+import { OnInit, HostBinding } from '@angular/core';
 import { Router, NavigationEnd } from '@angular/router';
-import { APP_BASE_HREF } from '@angular/common';
 
 import { distinctUntilKeyChanged, filter, mergeMap } from 'rxjs/operators';
 
@@ -30,18 +29,16 @@ export class RouteWithStateComponent implements OnInit {
     loading = true;
 
     constructor(
-        @Inject(APP_BASE_HREF) private baseHref: string,
         private configService: ConfigService,
         private dashboardService: DashboardService,
-        private router: Router,
-        private hrefSuffix: string = ''
+        private router: Router
     ) { }
 
     ngOnInit() {
         this.router.events
             .pipe(
                 filter((ev) => ev instanceof NavigationEnd),
-                mergeMap(() => this.configService.setActiveByURL(window.location, this.baseHref + this.hrefSuffix)),
+                mergeMap(() => this.configService.setActiveByURL(window.location)),
                 distinctUntilKeyChanged('fileName')
             )
             .subscribe((config) => {
@@ -57,7 +54,7 @@ export class RouteWithStateComponent implements OnInit {
             }
         });
 
-        this.configService.setActiveByURL(window.location, this.baseHref + this.hrefSuffix).subscribe((config) => {
+        this.configService.setActiveByURL(window.location).subscribe((config) => {
             this.config = config;
             this.loading = false;
         });

--- a/src/app/services/config.service.spec.ts
+++ b/src/app/services/config.service.spec.ts
@@ -118,7 +118,7 @@ describe('Service: ConfigService Initialization', () => {
 
         const query = ConfigUtil.translate('[["a.b.c","=","5","and"]]', ConfigUtil.encodeFiltersMap);
 
-        configService.setActiveByURL(`http://website.com/ctx/configName/dashSet/dash1#${query}`, '/ctx')
+        configService.setActiveByURL(`http://website.com/ctx/?dashboard=configName/dashSet/dash1#${query}`)
             .subscribe((config) => {
                 expect(config.fileName).toEqual('configName');
                 expect(config).toBeTruthy();
@@ -143,7 +143,7 @@ describe('Service: ConfigService Initialization', () => {
 
         const query = ConfigUtil.translate('[["a.b.c","=","5","and"]]', ConfigUtil.encodeFiltersMap);
 
-        configService.setActiveByURL(`http://website.com/ctx/configName/dashSet/dash2#${query}`, '/ctx')
+        configService.setActiveByURL(`http://website.com/ctx/?dashboard=configName/dashSet/dash2#${query}`)
             .subscribe((config) => {
                 expect(config.fileName).toEqual('configName');
                 expect(config).toBeTruthy();
@@ -168,7 +168,7 @@ describe('Service: ConfigService Initialization', () => {
 
         const query = ConfigUtil.translate('[["a.b.c","=","5","and"]]', ConfigUtil.encodeFiltersMap);
 
-        configService.setActiveByURL(`http://website.com/ctx/configName#${query}`, '/ctx')
+        configService.setActiveByURL(`http://website.com/ctx/?dashboard=configName#${query}`)
             .subscribe((config) => {
                 expect(config.fileName).toEqual('configName');
                 expect(config).toBeTruthy();
@@ -192,7 +192,7 @@ describe('Service: ConfigService Initialization', () => {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         configService.load = loadConfig;
 
-        configService.setActiveByURL('http://website.com/ctx/configName', '/ctx')
+        configService.setActiveByURL('http://website.com/ctx/?dashboard=configName')
             .subscribe((config) => {
                 expect(config.fileName).toEqual('configName');
                 expect(config).toBeTruthy();

--- a/src/app/util/config.util.spec.ts
+++ b/src/app/util/config.util.spec.ts
@@ -136,26 +136,59 @@ describe('Config Util Tests', () => {
         expect(ConfigUtil.findDashboardByKey(config, [])).toEqual(config);
     });
 
-    it('should properly parse URL states', () => {
-        // Ensure baseHREF works
-        for (const ctx of ['ctx', '/ctx', 'ctx/', '/ctx/']) {
-            const res = ConfigUtil.getUrlState('http://localhost/ctx/file/path1/path2?random#filters', ctx);
-            expect(res.dashboardPath).toEqual('path1.path2');
-            expect(res.pathParts).toEqual(['file', 'path1', 'path2']);
-            expect(res.filters).toEqual('filters');
-        }
+    it('getUrlState does parse URLs', () => {
+        const result1 = ConfigUtil.getUrlState('http://localhost/');
+        expect(result1.dashboard).toBeUndefined();
+        expect(result1.filters).toEqual('');
+        expect(result1.paths).toEqual([ConfigUtil.DEFAULT_CONFIG_NAME]);
 
-        // Ensure path parsing is happy
-        for (const path of ['path1/path2', '/path1/path2', '/path1/path2/']) {
-            const res = ConfigUtil.getUrlState(`http://localhost/file/${path}?random#filters`, '/');
-            expect(res.dashboardPath).toEqual('path1.path2');
-            expect(res.pathParts).toEqual(['file', 'path1', 'path2']);
-            expect(res.filters).toEqual('filters');
-        }
+        const result2 = ConfigUtil.getUrlState('http://localhost/?dashboard=file');
+        expect(result2.dashboard).toEqual('file');
+        expect(result2.filters).toEqual('');
+        expect(result2.paths).toEqual(['file']);
 
-        // Ensure default filename if missing
-        const res = ConfigUtil.getUrlState('http://localhost/?random#filters', '/');
-        expect(res.filename).toEqual(ConfigUtil.DEFAULT_CONFIG_NAME);
-        expect(res.fullPath).toEqual(`/${ConfigUtil.DEFAULT_CONFIG_NAME}?random=`);
+        const result3 = ConfigUtil.getUrlState('http://localhost/#filters');
+        expect(result3.dashboard).toBeUndefined();
+        expect(result3.filters).toEqual('filters');
+        expect(result3.paths).toEqual([ConfigUtil.DEFAULT_CONFIG_NAME]);
+
+        const result4 = ConfigUtil.getUrlState('http://localhost/?dashboard=file#filters');
+        expect(result4.dashboard).toEqual('file');
+        expect(result4.filters).toEqual('filters');
+        expect(result4.paths).toEqual(['file']);
+    });
+
+    it('getUrlState does parse URLs with path', () => {
+        const result1 = ConfigUtil.getUrlState('http://localhost/?dashboard=file/path1');
+        expect(result1.dashboard).toEqual('file');
+        expect(result1.filters).toEqual('');
+        expect(result1.paths).toEqual(['file', 'path1']);
+
+        const result2 = ConfigUtil.getUrlState('http://localhost/?dashboard=file/dotted.path1');
+        expect(result2.dashboard).toEqual('file');
+        expect(result2.filters).toEqual('');
+        expect(result2.paths).toEqual(['file', 'dotted.path1']);
+
+        const result3 = ConfigUtil.getUrlState('http://localhost/?dashboard=file/path1#filters');
+        expect(result3.dashboard).toEqual('file');
+        expect(result3.filters).toEqual('filters');
+        expect(result3.paths).toEqual(['file', 'path1']);
+
+        const result4 = ConfigUtil.getUrlState('http://localhost/?dashboard=file/path1/path2/#filters');
+        expect(result4.dashboard).toEqual('file');
+        expect(result4.filters).toEqual('filters');
+        expect(result4.paths).toEqual(['file', 'path1', 'path2']);
+    });
+
+    it('getUrlState does parse URLs with custom base HREF', () => {
+        const result1 = ConfigUtil.getUrlState('http://localhost/folder1?dashboard=file/path1/path2#filters');
+        expect(result1.dashboard).toEqual('file');
+        expect(result1.filters).toEqual('filters');
+        expect(result1.paths).toEqual(['file', 'path1', 'path2']);
+
+        const result2 = ConfigUtil.getUrlState('http://localhost/folder1/folder2/?dashboard=file/path1/path2#filters');
+        expect(result2.dashboard).toEqual('file');
+        expect(result2.filters).toEqual('filters');
+        expect(result2.paths).toEqual(['file', 'path1', 'path2']);
     });
 });

--- a/src/app/util/config.util.ts
+++ b/src/app/util/config.util.ts
@@ -15,12 +15,9 @@
 import { NeonDashboardConfig, NeonDashboardLeafConfig, NeonDashboardChoiceConfig } from '../models/types';
 
 interface URLConfigState {
-    filename: string;
+    dashboard: string;
     filters: string;
-    url: URL;
-    fullPath: string;
-    dashboardPath: string;
-    pathParts: string[];
+    paths: string[];
 }
 
 export class ConfigUtil {
@@ -140,34 +137,16 @@ export class ConfigUtil {
         });
     }
 
-    static getUrlState(urlStr: string | Location, baseHref: string): URLConfigState {
-        const searchHref = `/${baseHref}/`.replace(/^[/]+|[/]+$/g, '/');
+    static getUrlState(urlStr: string | Location): URLConfigState {
         const url = new URL(urlStr.toString());
-        const rel = url.pathname.substring(url.pathname.indexOf(searchHref) + searchHref.length);
-
-        const [path, ...subPath] = rel.split('/').filter((part) => !!part);
-        const dashboardPath = subPath.join('.');
-
+        const parameter = url.searchParams.get('dashboard') || '';
         const filters = decodeURIComponent(url.hash.replace(/^#/g, ''));
-        const filename = path || this.DEFAULT_CONFIG_NAME;
-        const params = url.searchParams.toString();
-
-        let pathParts = [filename, ...subPath];
-        let finalPath = ['', ...pathParts].join('/');
-
-        if (params) {
-            finalPath = `${finalPath}?${params}`;
-        }
-
-        const out = {
-            filename,
+        const [dashboard, ...pathsArray] = parameter.split('/').filter((part) => !!part);
+        const paths = [dashboard || this.DEFAULT_CONFIG_NAME, ...pathsArray];
+        return {
+            dashboard,
             filters,
-            url,
-            fullPath: finalPath,
-            dashboardPath,
-            pathParts
+            paths
         };
-
-        return out;
     }
 }


### PR DESCRIPTION
Changed the URL from showing the current dashboard state as part of the base URL to be in the URL query parameters.  This allows us to avoid routing issues with Tomcat deployments.

Example:  `http://localhost:4200/?dashboard=-/seedling/ldc-ta2/network`