### PR TITLE
THOR-1398 Save filter IDs and relations in URL filters.

### DIFF
--- a/src/app/components/aggregation/aggregation.component.ts
+++ b/src/app/components/aggregation/aggregation.component.ts
@@ -1042,7 +1042,7 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
         if (boundsFilters.length || domainFilters.length) {
             // TODO THOR-1100 How should we handle multiple bounds and/or domain filters?  Should we draw multiple selected areas?
             for (const boundsFilter of boundsFilters) {
-                const bounds: BoundsValues = (boundsFilter as BoundsFilter).retrieveValues()[0];
+                const bounds: BoundsValues = (boundsFilter as BoundsFilter).retrieveValues();
                 const fieldKey1 = DatasetUtil.deconstructTableOrFieldKeySafely(bounds.field1);
                 const fieldKey2 = DatasetUtil.deconstructTableOrFieldKeySafely(bounds.field2);
                 if (fieldKey1.field === this.options.xField.columnName && fieldKey2.field === this.options.yField.columnName) {
@@ -1064,7 +1064,7 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
             }
 
             for (const domainFilter of domainFilters) {
-                let domain: DomainValues = (domainFilter as DomainFilter).retrieveValues()[0];
+                let domain: DomainValues = (domainFilter as DomainFilter).retrieveValues();
                 const fieldKey = DatasetUtil.deconstructTableOrFieldKeySafely(domain.field);
                 if (fieldKey.field === this.options.xField.columnName) {
                     this.subcomponentMain.select([{

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -502,7 +502,7 @@ export class MapComponent extends BaseNeonComponent implements OnInit, OnDestroy
             if (boundsFilters.length) {
                 // TODO THOR-1102 How should we handle multiple filters?  Should we draw multiple bounding boxes?
                 for (const boundsFilter of boundsFilters) {
-                    const bounds: BoundsValues = (boundsFilter as BoundsFilter).retrieveValues()[0];
+                    const bounds: BoundsValues = (boundsFilter as BoundsFilter).retrieveValues();
                     const fieldKey1 = DatasetUtil.deconstructTableOrFieldKeySafely(bounds.field1);
                     const fieldKey2 = DatasetUtil.deconstructTableOrFieldKeySafely(bounds.field2);
                     if (fieldKey1.field === options.latitudeField.columnName && fieldKey2.field === options.longitudeField.columnName) {

--- a/src/app/components/timeline/timeline.component.ts
+++ b/src/app/components/timeline/timeline.component.ts
@@ -214,7 +214,7 @@ export class TimelineComponent extends BaseNeonComponent implements OnInit, OnDe
         if (timelineFilters.length) {
             // TODO THOR-1105 How should we handle multiple filters?  Should we draw multiple brushes?
             for (const timelineFilter of timelineFilters) {
-                let domain: DomainValues = (timelineFilter as DomainFilter).retrieveValues()[0];
+                let domain: DomainValues = (timelineFilter as DomainFilter).retrieveValues();
                 this.selected = [domain.begin as Date, domain.end as Date];
                 // TODO THOR-1106 Update the brush element in the timelineChart.
             }

--- a/src/app/models/filter.ts
+++ b/src/app/models/filter.ts
@@ -52,10 +52,22 @@ export interface BoundsValues {
     end2: boolean|number|string;
 }
 
+export interface CompoundValues {
+    nested: FilterValues[];
+    type: CompoundFilterType;
+}
+
 export interface DomainValues {
     begin: boolean|number|string|Date;
     field: string;
     end: boolean|number|string|Date;
+}
+
+export interface ListOfValues {
+    field: string;
+    operator: string;
+    type: CompoundFilterType;
+    values: (boolean|number|string)[];
 }
 
 export interface PairOfValues {
@@ -63,6 +75,7 @@ export interface PairOfValues {
     field2: string;
     operator1: string;
     operator2: string;
+    type: CompoundFilterType;
     value1: boolean|number|string;
     value2: boolean|number|string;
 }
@@ -73,5 +86,5 @@ export interface OneValue {
     value: boolean|number|string;
 }
 
-export type FilterValues = BoundsValues | DomainValues | PairOfValues | OneValue;
+export type FilterValues = BoundsValues | CompoundValues | DomainValues | ListOfValues | PairOfValues | OneValue;
 

--- a/src/app/models/filter.ts
+++ b/src/app/models/filter.ts
@@ -43,48 +43,61 @@ export interface CompoundFilterConfig {
 
 export type FilterConfig = SimpleFilterConfig | CompoundFilterConfig;
 
-export interface BoundsValues {
-    begin1: boolean|number|string;
-    begin2: boolean|number|string;
-    field1: string;
-    field2: string;
-    end1: boolean|number|string;
-    end2: boolean|number|string;
+export abstract class FilterValues { }
+
+export class BoundsValues extends FilterValues {
+    constructor(
+        public begin1: boolean|number|string,
+        public begin2: boolean|number|string,
+        public field1: string,
+        public field2: string,
+        public end1: boolean|number|string,
+        public end2: boolean|number|string
+    ) {
+        super();
+    }
 }
 
-export interface CompoundValues {
-    nested: FilterValues[];
-    type: CompoundFilterType;
+export class CompoundValues extends FilterValues {
+    constructor(public type: CompoundFilterType, public nested: FilterValues[]) {
+        super();
+    }
 }
 
-export interface DomainValues {
-    begin: boolean|number|string|Date;
-    field: string;
-    end: boolean|number|string|Date;
+export class DomainValues extends FilterValues {
+    constructor(public begin: boolean|number|string|Date, public field: string, public end: boolean|number|string|Date) {
+        super();
+    }
 }
 
-export interface ListOfValues {
-    field: string;
-    operator: string;
-    type: CompoundFilterType;
-    values: (boolean|number|string)[];
+export class ListOfValues extends FilterValues {
+    constructor(
+        public type: CompoundFilterType,
+        public field: string,
+        public operator: string,
+        public values: (boolean|number|string)[]
+    ) {
+        super();
+    }
 }
 
-export interface PairOfValues {
-    field1: string;
-    field2: string;
-    operator1: string;
-    operator2: string;
-    type: CompoundFilterType;
-    value1: boolean|number|string;
-    value2: boolean|number|string;
+export class OneValue extends FilterValues {
+    constructor(public field: string, public operator: string, public value: boolean|number|string) {
+        super();
+    }
 }
 
-export interface OneValue {
-    field: string;
-    operator: string;
-    value: boolean|number|string;
+export class PairOfValues extends FilterValues {
+    constructor(
+        public type: CompoundFilterType,
+        public field1: string,
+        public field2: string,
+        public operator1: string,
+        public operator2: string,
+        public value1: boolean|number|string,
+        public value2: boolean|number|string
+    ) {
+        super();
+    }
 }
-
-export type FilterValues = BoundsValues | CompoundValues | DomainValues | ListOfValues | PairOfValues | OneValue;
 

--- a/src/app/models/filter.ts
+++ b/src/app/models/filter.ts
@@ -25,6 +25,7 @@ export interface FilterDataSource {
 
 export interface SimpleFilterConfig {
     id?: string;
+    relations?: string[];
     datastore: string;
     database: string;
     table: string;
@@ -35,6 +36,7 @@ export interface SimpleFilterConfig {
 
 export interface CompoundFilterConfig {
     id?: string;
+    relations?: string[];
     type: CompoundFilterType;
     filters: (SimpleFilterConfig | CompoundFilterConfig)[];
 }

--- a/src/app/services/dashboard.service.spec.ts
+++ b/src/app/services/dashboard.service.spec.ts
@@ -89,21 +89,21 @@ describe('Service: DashboardService', () => {
 
         spyOn(dashboardService['filterService'], 'getRawFilters').and.returnValue([
             new SimpleFilter(DashboardServiceMock.DATASTORE.name, DashboardServiceMock.DATABASES.testDatabase1,
-                DashboardServiceMock.TABLES.testTable1, DashboardServiceMock.FIELD_MAP.ID, '!=', 'testId1'),
+                DashboardServiceMock.TABLES.testTable1, DashboardServiceMock.FIELD_MAP.ID, '!=', 'testValue', 'id1', ['relation1']),
             new CompoundFilter(CompoundFilterType.AND, [
                 new SimpleFilter(DashboardServiceMock.DATASTORE.name, DashboardServiceMock.DATABASES.testDatabase2,
-                    DashboardServiceMock.TABLES.testTable2, DashboardServiceMock.FIELD_MAP.NAME, 'contains', 'testName1'),
+                    DashboardServiceMock.TABLES.testTable2, DashboardServiceMock.FIELD_MAP.NAME, 'contains', 'testName1', 'id3'),
                 new SimpleFilter(DashboardServiceMock.DATASTORE.name, DashboardServiceMock.DATABASES.testDatabase2,
-                    DashboardServiceMock.TABLES.testTable2, DashboardServiceMock.FIELD_MAP.TYPE, 'not contains', 'testType1')
-            ])
+                    DashboardServiceMock.TABLES.testTable2, DashboardServiceMock.FIELD_MAP.TYPE, 'not contains', 'testType1', 'id4')
+            ], 'id2', ['relation2'])
         ]);
 
         // Use the parse and stringify functions so we don't have to type unicode here.
         expect(dashboardService.getFiltersToSaveInURL()).toEqual(ConfigUtil.translate(JSON.stringify(JSON.parse(`[
-            ["datastore1.testDatabase1.testTable1.testIdField", "!=", "testId1"],
-            ["and",
-                ["datastore1.testDatabase2.testTable2.testNameField", "contains", "testName1"],
-                ["datastore1.testDatabase2.testTable2.testTypeField", "not contains", "testType1"]
+            ["id1", ["relation1"], "datastore1.testDatabase1.testTable1.testIdField", "!=", "testValue"],
+            ["and", "id2", ["relation2"],
+                ["id3", [], "datastore1.testDatabase2.testTable2.testNameField", "contains", "testName1"],
+                ["id4", [], "datastore1.testDatabase2.testTable2.testTypeField", "not contains", "testType1"]
             ]
         ]`)), ConfigUtil.encodeFiltersMap));
     });
@@ -113,21 +113,21 @@ describe('Service: DashboardService', () => {
 
         spyOn(dashboardService['filterService'], 'getRawFilters').and.returnValue([
             new SimpleFilter(DashboardServiceMock.DATASTORE.name, DashboardServiceMock.DATABASES.testDatabase1,
-                DashboardServiceMock.TABLES.testTable1, DashboardServiceMock.FIELD_MAP.ID, '!=', false),
+                DashboardServiceMock.TABLES.testTable1, DashboardServiceMock.FIELD_MAP.ID, '!=', false, 'id1'),
             new SimpleFilter(DashboardServiceMock.DATASTORE.name, DashboardServiceMock.DATABASES.testDatabase1,
-                DashboardServiceMock.TABLES.testTable1, DashboardServiceMock.FIELD_MAP.ID, '!=', ''),
+                DashboardServiceMock.TABLES.testTable1, DashboardServiceMock.FIELD_MAP.ID, '!=', '', 'id2'),
             new SimpleFilter(DashboardServiceMock.DATASTORE.name, DashboardServiceMock.DATABASES.testDatabase1,
-                DashboardServiceMock.TABLES.testTable1, DashboardServiceMock.FIELD_MAP.ID, '!=', null),
+                DashboardServiceMock.TABLES.testTable1, DashboardServiceMock.FIELD_MAP.ID, '!=', null, 'id3'),
             new SimpleFilter(DashboardServiceMock.DATASTORE.name, DashboardServiceMock.DATABASES.testDatabase1,
-                DashboardServiceMock.TABLES.testTable1, DashboardServiceMock.FIELD_MAP.ID, '!=', 1234)
+                DashboardServiceMock.TABLES.testTable1, DashboardServiceMock.FIELD_MAP.ID, '!=', 1234, 'id4')
         ]);
 
         // Use the parse and stringify functions so we don't have to type unicode here.
         expect(dashboardService.getFiltersToSaveInURL()).toEqual(ConfigUtil.translate(JSON.stringify(JSON.parse(`[
-            ["datastore1.testDatabase1.testTable1.testIdField", "!=", false],
-            ["datastore1.testDatabase1.testTable1.testIdField", "!=", ""],
-            ["datastore1.testDatabase1.testTable1.testIdField", "!=", null],
-            ["datastore1.testDatabase1.testTable1.testIdField", "!=", 1234]
+            ["id1", [], "datastore1.testDatabase1.testTable1.testIdField", "!=", false],
+            ["id2", [], "datastore1.testDatabase1.testTable1.testIdField", "!=", ""],
+            ["id3", [], "datastore1.testDatabase1.testTable1.testIdField", "!=", null],
+            ["id4", [], "datastore1.testDatabase1.testTable1.testIdField", "!=", 1234]
         ]`)), ConfigUtil.encodeFiltersMap));
     });
 });
@@ -179,10 +179,10 @@ describe('Service: DashboardService with Mock Data', () => {
 
         dashboardService.setActiveDashboard(NeonDashboardLeafConfig.get({
             filters: ConfigUtil.translate(`[
-                ["datastore1.testDatabase1.testTable1.testNameField", "=", "testValue"],
-                ["and",
-                    ["datastore1.testDatabase2.testTable2.testTypeField", "!=", ""],
-                    ["datastore1.testDatabase2.testTable2.testTypeField", "!=", null]
+                ["id1", ["relation1"], "datastore1.testDatabase1.testTable1.testNameField", "=", "testValue"],
+                ["and", "id2", ["relation2"],
+                    ["id3", [], "datastore1.testDatabase2.testTable2.testTypeField", "!=", ""],
+                    ["id4", [], "datastore1.testDatabase2.testTable2.testTypeField", "!=", null]
                 ]
             ]`, ConfigUtil.encodeFiltersMap)
         }));
@@ -190,7 +190,8 @@ describe('Service: DashboardService with Mock Data', () => {
         expect(spy.calls.count()).toEqual(1);
         const filters = spy.calls.argsFor(0)[0];
         expect(filters).toEqual([FilterUtil.createFilterFromConfig({
-            id: filters[0].id,
+            id: 'id1',
+            relations: ['relation1'],
             datastore: 'datastore1',
             database: 'testDatabase1',
             table: 'testTable1',
@@ -198,10 +199,11 @@ describe('Service: DashboardService with Mock Data', () => {
             operator: '=',
             value: 'testValue'
         }, DATASET), FilterUtil.createFilterFromConfig({
-            id: filters[1].id,
+            id: 'id2',
+            relations: ['relation2'],
             type: CompoundFilterType.AND,
             filters: [{
-                id: filters[1].filters[0].id,
+                id: 'id3',
                 datastore: 'datastore1',
                 database: 'testDatabase2',
                 table: 'testTable2',
@@ -209,7 +211,7 @@ describe('Service: DashboardService with Mock Data', () => {
                 operator: '!=',
                 value: ''
             }, {
-                id: filters[1].filters[1].id,
+                id: 'id4',
                 datastore: 'datastore1',
                 database: 'testDatabase2',
                 table: 'testTable2',
@@ -720,10 +722,10 @@ describe('Service: DashboardService with Mock Data', () => {
 
     it('exportConfig should produce valid results with string filter', (done) => {
         const { config, layouts } = getConfig(`[
-            ["datastore1.testDatabase1.testTable1.testNameField", "=", "testValue"],
-            ["and",
-                ["datastore1.testDatabase2.testTable2.testTypeField", "!=", ""],
-                ["datastore1.testDatabase2.testTable2.testTypeField", "!=", null]
+            ["id1", ["relation1"], "datastore1.testDatabase1.testTable1.testNameField", "=", "testValue"],
+            ["and", "id2", ["relation2"],
+                ["id3", [], "datastore1.testDatabase2.testTable2.testTypeField", "!=", ""],
+                ["id4", [], "datastore1.testDatabase2.testTable2.testTypeField", "!=", null]
             ]
         ]`);
 
@@ -764,15 +766,13 @@ describe('Service: DashboardService with Mock Data', () => {
                     fieldName: 'testNameField'
                 }
             });
-            const filters = (data.dashboards as any).filters;
             expect(data.dashboards.filters).toEqual([
-                new SimpleFilterDesign('datastore1', 'testDatabase1', 'testTable1', 'testNameField', '=', 'testValue', filters[0].id),
+                new SimpleFilterDesign('datastore1', 'testDatabase1', 'testTable1', 'testNameField', '=', 'testValue', 'id1',
+                    ['relation1']),
                 new CompoundFilterDesign(CompoundFilterType.AND, [
-                    new SimpleFilterDesign('datastore1', 'testDatabase2', 'testTable2', 'testTypeField', '!=', '',
-                        filters[1].filters[0].id),
-                    new SimpleFilterDesign('datastore1', 'testDatabase2', 'testTable2', 'testTypeField', '!=', null,
-                        filters[1].filters[1].id)
-                ], filters[1].id)
+                    new SimpleFilterDesign('datastore1', 'testDatabase2', 'testTable2', 'testTypeField', '!=', '', 'id3'),
+                    new SimpleFilterDesign('datastore1', 'testDatabase2', 'testTable2', 'testTypeField', '!=', null, 'id4')
+                ], 'id2', ['relation2'])
             ]);
             expect(data.datastores).toEqual(config.datastores);
             expect(data.layouts).toEqual(layouts);

--- a/src/app/services/filter.service.spec.ts
+++ b/src/app/services/filter.service.spec.ts
@@ -164,7 +164,9 @@ describe('FilterService with filters', () => {
         relationFilter2.relations = [relationFilter1.id];
 
         relationConfig1.id = relationFilter1.id;
+        relationConfig1.relations = relationFilter1.relations;
         relationConfig2.id = relationFilter2.id;
+        relationConfig2.relations = relationFilter2.relations;
     };
 
     it('should have expected properties', () => {
@@ -384,6 +386,7 @@ describe('FilterService with filters', () => {
         expect((listComplete[0] as SimpleFilter).value).toEqual('testRelation');
 
         relationConfig1.id = listComplete[0].id;
+        relationConfig1.relations = listComplete[0].relations;
 
         listComplete = filterService['filterCollection'].getFilters(relationSource2);
         expect(listComplete.length).toEqual(1);
@@ -394,6 +397,7 @@ describe('FilterService with filters', () => {
         expect((listComplete[0] as SimpleFilter).value).toEqual('testRelation');
 
         relationConfig2.id = listComplete[0].id;
+        relationConfig2.relations = listComplete[0].relations;
 
         expect(actual.size).toEqual(4);
         let keys = Array.from(actual.keys());
@@ -429,7 +433,7 @@ describe('FilterService with filters', () => {
         expect((listComplete[0] as SimpleFilter).value).toEqual('testExchangeRelation');
 
         let testConfig1 = new SimpleFilterDesign(DATASTORE.name, DATABASES.testDatabase1.name, TABLES.testTable1.name,
-            FIELD_MAP.RELATION_A.columnName, '=', 'testExchangeRelation', listComplete[0].id);
+            FIELD_MAP.RELATION_A.columnName, '=', 'testExchangeRelation', listComplete[0].id, listComplete[0].relations);
 
         listComplete = filterService['filterCollection'].getFilters(relationSource2);
         expect(listComplete.length).toEqual(1);
@@ -440,6 +444,7 @@ describe('FilterService with filters', () => {
         expect((listComplete[0] as SimpleFilter).value).toEqual('testExchangeRelation');
 
         testConfig2.id = listComplete[0].id;
+        testConfig2.relations = listComplete[0].relations;
 
         expect(actual.size).toEqual(4);
         let keys = Array.from(actual.keys());
@@ -924,6 +929,7 @@ describe('FilterService with filters', () => {
         expect((listComplete[0] as SimpleFilter).value).toEqual('testRelation');
 
         relationConfig1.id = listComplete[0].id;
+        relationConfig1.relations = listComplete[0].relations;
 
         listComplete = filterService['filterCollection'].getFilters(relationSource2);
         expect(listComplete.length).toEqual(1);
@@ -934,6 +940,7 @@ describe('FilterService with filters', () => {
         expect((listComplete[0] as SimpleFilter).value).toEqual('testRelation');
 
         relationConfig2.id = listComplete[0].id;
+        relationConfig2.relations = listComplete[0].relations;
 
         expect(actual.size).toEqual(4);
         let keys = Array.from(actual.keys());
@@ -970,7 +977,7 @@ describe('FilterService with filters', () => {
         expect((listComplete[1] as SimpleFilter).value).toEqual('testToggleRelation');
 
         let testConfig1 = new SimpleFilterDesign(DATASTORE.name, DATABASES.testDatabase1.name, TABLES.testTable1.name,
-            FIELD_MAP.RELATION_A.columnName, '=', 'testToggleRelation', listComplete[1].id);
+            FIELD_MAP.RELATION_A.columnName, '=', 'testToggleRelation', listComplete[1].id, listComplete[1].relations);
 
         listComplete = filterService['filterCollection'].getFilters(relationSource2);
         expect(listComplete.length).toEqual(2);
@@ -982,6 +989,7 @@ describe('FilterService with filters', () => {
         expect((listComplete[1] as SimpleFilter).value).toEqual('testToggleRelation');
 
         testConfig2.id = listComplete[1].id;
+        testConfig2.relations = listComplete[1].relations;
 
         expect(actual.size).toEqual(4);
         let keys = Array.from(actual.keys());
@@ -1033,7 +1041,9 @@ describe('FilterService with filters', () => {
         testFilter2.relations = [testFilter1.id];
 
         testConfig1.id = testFilter1.id;
+        testConfig1.relations = testFilter1.relations;
         testConfig2.id = testFilter2.id;
+        testConfig2.relations = testFilter2.relations;
 
         filterService['filterCollection'].setFilters(relationSource1, [relationFilter1, testFilter1]);
         filterService['filterCollection'].setFilters(relationSource2, [relationFilter2, testFilter2]);

--- a/src/app/services/filter.service.ts
+++ b/src/app/services/filter.service.ts
@@ -288,7 +288,8 @@ export class FilterService {
             }
             let filterList: AbstractFilter[] = this.filterCollection.getFilters(filterDataSourceList).filter((filter) =>
                 filter.doesAffectSearch(datastoreName, databaseName, tableName));
-            let filter: AbstractFilter = filterList.length ? new CompoundFilter(CompoundFilterType.OR, filterList) : null;
+            // Assign a dummy ID because we won't need it here.
+            let filter: AbstractFilter = filterList.length ? new CompoundFilter(CompoundFilterType.OR, filterList, '_') : null;
             return returnList.concat(filter || []);
         }, [] as AbstractFilter[]);
     }

--- a/src/app/util/filter.util.spec.ts
+++ b/src/app/util/filter.util.spec.ts
@@ -15,13 +15,17 @@
 
 import {
     BoundsFilter,
+    BoundsFilterDesign,
     CompoundFilter,
     CompoundFilterDesign,
     DomainFilter,
+    DomainFilterDesign,
     FilterCollection,
     FilterUtil,
     ListFilter,
+    ListFilterDesign,
     PairFilter,
+    PairFilterDesign,
     SimpleFilter,
     SimpleFilterDesign
 } from './filter.util';
@@ -606,15 +610,15 @@ describe('FilterUtil', () => {
 
     it('createFilterFromDataList does return simple filter object', () => {
         const actual = FilterUtil.createFilterFromDataList([
-            'id1',
-            ['relation1'],
+            'filterId1',
+            ['relationId1'],
             'datastore1.testDatabase2.testTable2.testIdField',
             '=',
             'testValue'
         ], DATASET);
         expect(actual instanceof SimpleFilter).toEqual(true);
-        expect(actual.id).toEqual('id1');
-        expect(actual.relations).toEqual(['relation1']);
+        expect(actual.id).toEqual('filterId1');
+        expect(actual.relations).toEqual(['relationId1']);
         expect((actual as any).datastore).toEqual('datastore1');
         expect((actual as any).database).toEqual(DATABASES.testDatabase2);
         expect((actual as any).table).toEqual(TABLES.testTable2);
@@ -626,8 +630,8 @@ describe('FilterUtil', () => {
     it('createFilterFromDataList does return bounds filter object', () => {
         const actual = FilterUtil.createFilterFromDataList([
             'bounds',
-            'id1',
-            ['relation1'],
+            'filterId1',
+            ['relationId1'],
             'datastore1.testDatabase2.testTable2.testXField',
             'testBegin1',
             'testEnd1',
@@ -636,8 +640,8 @@ describe('FilterUtil', () => {
             'testEnd2'
         ], DATASET);
         expect(actual instanceof BoundsFilter).toEqual(true);
-        expect(actual.id).toEqual('id1');
-        expect(actual.relations).toEqual(['relation1']);
+        expect(actual.id).toEqual('filterId1');
+        expect(actual.relations).toEqual(['relationId1']);
         expect((actual as any).type).toEqual(CompoundFilterType.AND);
         expect((actual as any).filters.length).toEqual(4);
         expect((actual as any).filters[0] instanceof SimpleFilter).toEqual(true);
@@ -673,15 +677,15 @@ describe('FilterUtil', () => {
     it('createFilterFromDataList does return domain filter object', () => {
         const actual = FilterUtil.createFilterFromDataList([
             'domain',
-            'id1',
-            ['relation1'],
+            'filterId1',
+            ['relationId1'],
             'datastore1.testDatabase2.testTable2.testSizeField',
             'testBegin',
             'testEnd'
         ], DATASET);
         expect(actual instanceof DomainFilter).toEqual(true);
-        expect(actual.id).toEqual('id1');
-        expect(actual.relations).toEqual(['relation1']);
+        expect(actual.id).toEqual('filterId1');
+        expect(actual.relations).toEqual(['relationId1']);
         expect((actual as any).type).toEqual(CompoundFilterType.AND);
         expect((actual as any).filters.length).toEqual(2);
         expect((actual as any).filters[0] instanceof SimpleFilter).toEqual(true);
@@ -703,8 +707,8 @@ describe('FilterUtil', () => {
     it('createFilterFromDataList does return list filter object', () => {
         const actual = FilterUtil.createFilterFromDataList([
             'list',
-            'id1',
-            ['relation1'],
+            'filterId1',
+            ['relationId1'],
             'and',
             'datastore1.testDatabase2.testTable2.testTextField',
             '!=',
@@ -712,8 +716,8 @@ describe('FilterUtil', () => {
             'testValue2'
         ], DATASET);
         expect(actual instanceof ListFilter).toEqual(true);
-        expect(actual.id).toEqual('id1');
-        expect(actual.relations).toEqual(['relation1']);
+        expect(actual.id).toEqual('filterId1');
+        expect(actual.relations).toEqual(['relationId1']);
         expect((actual as any).type).toEqual(CompoundFilterType.AND);
         expect((actual as any).filters.length).toEqual(2);
         expect((actual as any).filters[0] instanceof SimpleFilter).toEqual(true);
@@ -735,8 +739,8 @@ describe('FilterUtil', () => {
     it('createFilterFromDataList does return pair filter object', () => {
         const actual = FilterUtil.createFilterFromDataList([
             'pair',
-            'id1',
-            ['relation1'],
+            'filterId1',
+            ['relationId1'],
             'and',
             'datastore1.testDatabase2.testTable2.testNameField',
             'contains',
@@ -746,8 +750,8 @@ describe('FilterUtil', () => {
             'testValue2'
         ], DATASET);
         expect(actual instanceof PairFilter).toEqual(true);
-        expect(actual.id).toEqual('id1');
-        expect(actual.relations).toEqual(['relation1']);
+        expect(actual.id).toEqual('filterId1');
+        expect(actual.relations).toEqual(['relationId1']);
         expect((actual as any).type).toEqual(CompoundFilterType.AND);
         expect((actual as any).filters.length).toEqual(2);
         expect((actual as any).filters[0] instanceof SimpleFilter).toEqual(true);
@@ -769,23 +773,23 @@ describe('FilterUtil', () => {
     it('createFilterFromDataList does return compound filter object', () => {
         const actual = FilterUtil.createFilterFromDataList([
             'and',
-            'id1',
-            ['relation1'],
+            'filterId1',
+            ['relationId1'],
             ['and',
                 'id2',
-                ['relation2'],
+                ['relationId2'],
                 ['id3', [], 'datastore1.testDatabase2.testTable2.testNameField', 'contains', 'testValue1'],
                 ['id4', [], 'datastore1.testDatabase2.testTable2.testTypeField', 'not contains', 'testValue2']],
             ['id5', [], 'datastore1.testDatabase2.testTable2.testIdField', '=', 'testValue3']
         ], DATASET);
         expect(actual instanceof CompoundFilter).toEqual(true);
-        expect(actual.id).toEqual('id1');
-        expect(actual.relations).toEqual(['relation1']);
+        expect(actual.id).toEqual('filterId1');
+        expect(actual.relations).toEqual(['relationId1']);
         expect((actual as any).type).toEqual(CompoundFilterType.AND);
         expect((actual as any).filters.length).toEqual(2);
         expect((actual as any).filters[0] instanceof CompoundFilter).toEqual(true);
         expect((actual as any).filters[0].id).toEqual('id2');
-        expect((actual as any).filters[0].relations).toEqual(['relation2']);
+        expect((actual as any).filters[0].relations).toEqual(['relationId2']);
         expect((actual as any).filters[0].type).toEqual(CompoundFilterType.AND);
         expect((actual as any).filters[0].filters.length).toEqual(2);
         expect((actual as any).filters[0].filters[0] instanceof SimpleFilter).toEqual(true);
@@ -1886,6 +1890,14 @@ describe('SimpleFilter', () => {
         expect(simpleFilter.isEquivalentToFilter(testFilter8)).toEqual(true);
     });
 
+    it('retrieveValues on simple filter should return expected object', () => {
+        expect(simpleFilter.retrieveValues()).toEqual([{
+            field: 'testNameField',
+            operator: '=',
+            value: 'testName1'
+        }]);
+    });
+
     it('toConfig on simple filter should return expected object', () => {
         expect(simpleFilter.toConfig()).toEqual(new SimpleFilterDesign(DATASTORE.name, DATABASES.testDatabase1.name,
             TABLES.testTable1.name, FIELD_MAP.NAME.columnName, '=', 'testName1', simpleFilter.id));
@@ -2614,6 +2626,18 @@ describe('CompoundFilter (One Field)', () => {
         expect(compoundFilter.isEquivalentToFilter(testFilter8)).toEqual(true);
     });
 
+    it('retrieveValues on compound filter should return expected object', () => {
+        expect(compoundFilter.retrieveValues()).toEqual([{
+            field: 'testXField',
+            operator: '>',
+            value: -100
+        }, {
+            field: 'testXField',
+            operator: '<',
+            value: 100
+        }]);
+    });
+
     it('toConfig on compound filter should return expected object', () => {
         expect(compoundFilter.toConfig()).toEqual(new CompoundFilterDesign(CompoundFilterType.AND, [
             new SimpleFilterDesign(DATASTORE.name, DATABASES.testDatabase1.name, TABLES.testTable1.name, FIELD_MAP.X.columnName, '>',
@@ -3214,6 +3238,18 @@ describe('CompoundFilter (Multi-Field)', () => {
         expect(compoundFilter.isEquivalentToFilter(testFilter8)).toEqual(true);
     });
 
+    it('retrieveValues on compound multi-field filter should return expected object', () => {
+        expect(compoundFilter.retrieveValues()).toEqual([{
+            field: 'testNameField',
+            operator: '=',
+            value: 'testName1'
+        }, {
+            field: 'testXField',
+            operator: '=',
+            value: 10
+        }]);
+    });
+
     it('toConfig on compound multi-field filter should return expected object', () => {
         expect(compoundFilter.toConfig()).toEqual(new CompoundFilterDesign(CompoundFilterType.OR, [
             new SimpleFilterDesign(DATASTORE.name, DATABASES.testDatabase1.name, TABLES.testTable1.name, FIELD_MAP.NAME.columnName,
@@ -3304,6 +3340,26 @@ describe('CompoundFilter (Nested Compound Filters)', () => {
         expect(compoundFilter.filters[1].filters[1].value).toEqual('testName2');
     });
 
+    it('retrieveValues on compound nested filter should return expected object', () => {
+        expect(compoundFilter.retrieveValues()).toEqual([{
+            field: 'testXField',
+            operator: '=',
+            value: 10
+        }, {
+            field: 'testXField',
+            operator: '=',
+            value: 20
+        }, {
+            field: 'testNameField',
+            operator: '=',
+            value: 'testName1'
+        }, {
+            field: 'testNameField',
+            operator: '=',
+            value: 'testName2'
+        }]);
+    });
+
     it('toConfig on compound nested filters should return expected object', () => {
         expect(compoundFilter.toConfig()).toEqual(new CompoundFilterDesign(CompoundFilterType.AND, [
             new CompoundFilterDesign(CompoundFilterType.OR, [
@@ -3319,6 +3375,459 @@ describe('CompoundFilter (Nested Compound Filters)', () => {
                     '=', 'testName2', compoundFilter.filters[1].filters[1].id)
             ], compoundFilter.filters[1].id)
         ], compoundFilter.id));
+    });
+});
+
+describe('Filter.fromDataList static functions', () => {
+    it('SimpleFilter.fromDataList does return expected object', () => {
+        expect(SimpleFilter.fromDataList(['filterId1', ['relationId1'], 'datastore1.testDatabase2.testTable2.testIdField', '=', 'testId'],
+            DATASET)).toEqual(new SimpleFilter(DATASTORE.name, DATABASES.testDatabase2, TABLES.testTable2, FIELD_MAP.ID, '=', 'testId',
+            'filterId1', ['relationId1']));
+    });
+
+    it('CompoundFilter.fromDataList does return expected object', () => {
+        expect(CompoundFilter.fromDataList([
+            'and',
+            'filterId1',
+            ['relationId1'],
+            [
+                'and',
+                'filterId2',
+                ['relationId2'],
+                ['filterId3', [], 'datastore1.testDatabase2.testTable2.testNameField', '=', 'testName'],
+                ['filterId4', [], 'datastore1.testDatabase2.testTable2.testTypeField', '!=', 'testType']
+            ],
+            ['filterId5', [], 'datastore1.testDatabase2.testTable2.testIdField', '=', 'testId']
+        ], DATASET)).toEqual(new CompoundFilter(CompoundFilterType.AND, [
+            new CompoundFilter(CompoundFilterType.AND, [
+                new SimpleFilter(DATASTORE.name, DATABASES.testDatabase2, TABLES.testTable2, FIELD_MAP.NAME, '=', 'testName', 'filterId3'),
+                new SimpleFilter(DATASTORE.name, DATABASES.testDatabase2, TABLES.testTable2, FIELD_MAP.TYPE, '!=', 'testType', 'filterId4')
+            ], 'filterId2', ['relationId2']),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase2, TABLES.testTable2, FIELD_MAP.ID, '=', 'testId', 'filterId5')
+        ], 'filterId1', ['relationId1']));
+    });
+
+    it('BoundsFilter.fromDataList does return expected object', () => {
+        const boundsFilterA = BoundsFilter.fromDataList(['bounds',
+            'filterId1',
+            ['relationId1'],
+            'datastore1.testDatabase2.testTable2.testXField',
+            1,
+            2,
+            'datastore1.testDatabase2.testTable2.testYField',
+            3,
+            4], DATASET);
+        expect(boundsFilterA.fieldKey1).toEqual(DATASTORE.name + '.' + DATABASES.testDatabase2.name + '.' + TABLES.testTable2.name + '.' +
+            FIELD_MAP.X.columnName);
+        expect(boundsFilterA.fieldKey2).toEqual(DATASTORE.name + '.' + DATABASES.testDatabase2.name + '.' + TABLES.testTable2.name + '.' +
+            FIELD_MAP.Y.columnName);
+        expect(boundsFilterA.begin1).toEqual(1);
+        expect(boundsFilterA.begin2).toEqual(3);
+        expect(boundsFilterA.end1).toEqual(2);
+        expect(boundsFilterA.end2).toEqual(4);
+        expect(boundsFilterA.id).toEqual('filterId1');
+        expect(boundsFilterA.relations).toEqual(['relationId1']);
+        expect(boundsFilterA.type).toEqual(CompoundFilterType.AND);
+        expect(boundsFilterA.filters.length).toEqual(4);
+    });
+
+    it('DomainFilter.fromDataList does return expected object', () => {
+        const domainFilterA = DomainFilter.fromDataList(['domain',
+            'filterId1',
+            ['relationId1'],
+            'datastore1.testDatabase2.testTable2.testXField',
+            1,
+            2], DATASET);
+        expect(domainFilterA.fieldKey).toEqual(DATASTORE.name + '.' + DATABASES.testDatabase2.name + '.' + TABLES.testTable2.name + '.' +
+            FIELD_MAP.X.columnName);
+        expect(domainFilterA.begin).toEqual(1);
+        expect(domainFilterA.end).toEqual(2);
+        expect(domainFilterA.id).toEqual('filterId1');
+        expect(domainFilterA.relations).toEqual(['relationId1']);
+        expect(domainFilterA.type).toEqual(CompoundFilterType.AND);
+        expect(domainFilterA.filters.length).toEqual(2);
+    });
+
+    it('ListFilter.fromDataList does return expected object', () => {
+        const listFilterA = ListFilter.fromDataList(['list',
+            'filterId1',
+            ['relationId1'],
+            'or',
+            'datastore1.testDatabase2.testTable2.testTextField',
+            '!=',
+            'testText1',
+            'testText2'], DATASET);
+        expect(listFilterA.fieldKey).toEqual(DATASTORE.name + '.' + DATABASES.testDatabase2.name + '.' + TABLES.testTable2.name + '.' +
+            FIELD_MAP.TEXT.columnName);
+        expect(listFilterA.operator).toEqual('!=');
+        expect(listFilterA.values).toEqual(['testText1', 'testText2']);
+        expect(listFilterA.id).toEqual('filterId1');
+        expect(listFilterA.relations).toEqual(['relationId1']);
+        expect(listFilterA.type).toEqual(CompoundFilterType.OR);
+        expect(listFilterA.filters.length).toEqual(2);
+    });
+
+    it('PairFilter.fromDataList does return expected object', () => {
+        const pairFilterA = PairFilter.fromDataList(['pair',
+            'filterId1',
+            ['relationId1'],
+            'or',
+            'datastore1.testDatabase2.testTable2.testNameField',
+            '=',
+            'testName',
+            'datastore1.testDatabase2.testTable2.testTypeField',
+            '!=',
+            'testType'], DATASET);
+        expect(pairFilterA.fieldKey1).toEqual(DATASTORE.name + '.' + DATABASES.testDatabase2.name + '.' + TABLES.testTable2.name + '.' +
+            FIELD_MAP.NAME.columnName);
+        expect(pairFilterA.fieldKey2).toEqual(DATASTORE.name + '.' + DATABASES.testDatabase2.name + '.' + TABLES.testTable2.name + '.' +
+            FIELD_MAP.TYPE.columnName);
+        expect(pairFilterA.operator1).toEqual('=');
+        expect(pairFilterA.operator2).toEqual('!=');
+        expect(pairFilterA.value1).toEqual('testName');
+        expect(pairFilterA.value2).toEqual('testType');
+        expect(pairFilterA.id).toEqual('filterId1');
+        expect(pairFilterA.relations).toEqual(['relationId1']);
+        expect(pairFilterA.type).toEqual(CompoundFilterType.OR);
+        expect(pairFilterA.filters.length).toEqual(2);
+    });
+});
+
+describe('Filter.fromFilters static functions', () => {
+    it('BoundsFilter.fromFilters does return expected object', () => {
+        const filterA = new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.X, '>=', -50);
+        const filterB = new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.X, '<=', 50);
+        const filterC = new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.Y, '>=', -100);
+        const filterD = new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.Y, '<=', 100);
+        const boundsFilterA = BoundsFilter.fromFilters([filterA, filterB, filterC, filterD]);
+        expect(boundsFilterA).toEqual(new BoundsFilter(
+            DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.X.columnName,
+            DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.Y.columnName,
+            -50,
+            -100,
+            50,
+            100,
+            [filterA, filterB, filterC, filterD],
+            boundsFilterA.id
+        ));
+    });
+
+    it('DomainFilter.fromFilters does return expected object', () => {
+        const filterA = new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.SIZE, '>=', -100);
+        const filterB = new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.SIZE, '<=', 100);
+        const domainFilterA = DomainFilter.fromFilters([filterA, filterB]);
+        expect(domainFilterA).toEqual(new DomainFilter(
+            DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.SIZE.columnName,
+            -100,
+            100,
+            [filterA, filterB],
+            domainFilterA.id
+        ));
+    });
+
+    it('ListFilter.fromFilters does return expected object', () => {
+        const filterA = new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText1');
+        const filterB = new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText2');
+        const listFilterA = ListFilter.fromFilters([filterA, filterB], CompoundFilterType.OR);
+        expect(listFilterA).toEqual(new ListFilter(CompoundFilterType.OR,
+            DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.TEXT.columnName,
+            '!=',
+            ['testText1', 'testText2'],
+            [filterA, filterB],
+            listFilterA.id));
+    });
+
+    it('PairFilter.fromFilters does return expected object', () => {
+        const filterA = new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.NAME, '=', 'testName');
+        const filterB = new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TYPE, '!=', 'testType');
+        const pairFilterA = PairFilter.fromFilters([filterA, filterB], CompoundFilterType.OR);
+        expect(pairFilterA).toEqual(new PairFilter(CompoundFilterType.OR,
+            DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.NAME.columnName,
+            DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.TYPE.columnName,
+            '=',
+            '!=',
+            'testName',
+            'testType',
+            [filterA, filterB],
+            pairFilterA.id));
+    });
+});
+
+describe('BoundsFilter', () => {
+    it('getLabel functions on bounds filter should return expected strings', () => {
+        let boundsFilterA: CompoundFilter = BoundsFilter.fromFilters([
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.X, '>=', -50),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.X, '<=', 50),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.Y, '>=', -100),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.Y, '<=', 100)
+        ]);
+
+        expect(boundsFilterA.getLabelForField()).toEqual('Test Database 1 / Test Table 1 / Test X Field and Test Database 1 / ' +
+            'Test Table 1 / Test Y Field');
+        expect(boundsFilterA.getLabelForField(true)).toEqual('Test X Field and Test Y Field');
+        expect(boundsFilterA.getLabelForOperator()).toEqual('');
+        expect(boundsFilterA.getLabelForValue()).toEqual('from (-50, -100) to (50, 100)');
+    });
+
+    it('retrieveValues on bounds filter does return expected values', () => {
+        let boundsFilterA: CompoundFilter = BoundsFilter.fromFilters([
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.X, '>=', -50),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.X, '<=', 50),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.Y, '>=', -100),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.Y, '<=', 100)
+        ]);
+
+        expect(boundsFilterA.retrieveValues()).toEqual([{
+            begin1: -50,
+            begin2: -100,
+            field1: DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.X.columnName,
+            field2: DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.Y.columnName,
+            end1: 50,
+            end2: 100
+        }]);
+    });
+
+    it('toDataList on bounds filter does return expected list', () => {
+        let boundsFilterA: CompoundFilter = BoundsFilter.fromFilters([
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.X, '>=', -50),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.X, '<=', 50),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.Y, '>=', -100),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.Y, '<=', 100)
+        ]);
+
+        expect(boundsFilterA.toDataList()).toEqual([
+            'bounds',
+            boundsFilterA.id,
+            [],
+            DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.X.columnName,
+            -50,
+            50,
+            DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.Y.columnName,
+            -100,
+            100
+        ]);
+    });
+});
+
+describe('DomainFilter', () => {
+    it('getLabel functions on domain filter should return expected strings', () => {
+        let domainFilterA: CompoundFilter = DomainFilter.fromFilters([
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.SIZE, '>=', -100),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.SIZE, '<=', 100)
+        ]);
+
+        expect(domainFilterA.getLabelForField()).toEqual('Test Database 1 / Test Table 1 / Test Size Field');
+        expect(domainFilterA.getLabelForField(true)).toEqual('Test Size Field');
+        expect(domainFilterA.getLabelForOperator()).toEqual('');
+        expect(domainFilterA.getLabelForValue()).toEqual('between -100 and 100');
+    });
+
+    it('retrieveValues on domain filter does return expected values', () => {
+        let domainFilterA: CompoundFilter = DomainFilter.fromFilters([
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.SIZE, '>=', -100),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.SIZE, '<=', 100)
+        ]);
+
+        expect(domainFilterA.retrieveValues()).toEqual([{
+            begin: -100,
+            field: DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.SIZE.columnName,
+            end: 100
+        }]);
+    });
+
+    it('toDataList on domain filter does return expected list', () => {
+        let domainFilterA: CompoundFilter = DomainFilter.fromFilters([
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.SIZE, '>=', -100),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.SIZE, '<=', 100)
+        ]);
+
+        expect(domainFilterA.toDataList()).toEqual([
+            'domain',
+            domainFilterA.id,
+            [],
+            DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.SIZE.columnName,
+            -100,
+            100
+        ]);
+    });
+});
+
+describe('ListFilter', () => {
+    it('getLabel functions on list filter should return expected strings', () => {
+        let listFilterA: CompoundFilter = ListFilter.fromFilters([
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText1'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText2'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText3')
+        ], CompoundFilterType.OR);
+
+        expect(listFilterA.getLabelForField()).toEqual('Test Database 1 / Test Table 1 / Test Text Field');
+        expect(listFilterA.getLabelForField(true)).toEqual('Test Text Field');
+        expect(listFilterA.getLabelForOperator()).toEqual('');
+        expect(listFilterA.getLabelForValue()).toEqual('!= (testText1 or testText2 or testText3)');
+        expect(listFilterA.getLabelForValue(true)).toEqual('!= (testText1 or testText2 or testText3)');
+    });
+
+    it('getLabel functions on list filter with equals operator should return expected strings', () => {
+        let listFilterB: CompoundFilter = ListFilter.fromFilters([
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText1'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText2'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText3')
+        ], CompoundFilterType.OR);
+
+        expect(listFilterB.getLabelForField()).toEqual('Test Database 1 / Test Table 1 / Test Text Field');
+        expect(listFilterB.getLabelForField(true)).toEqual('Test Text Field');
+        expect(listFilterB.getLabelForOperator()).toEqual('');
+        expect(listFilterB.getLabelForValue()).toEqual('testText1 or testText2 or testText3');
+        expect(listFilterB.getLabelForValue(true)).toEqual('testText1 or testText2 or testText3');
+    });
+
+    it('getLabel functions on list filter with many clauses should return expected strings', () => {
+        let listFilterC: CompoundFilter = ListFilter.fromFilters([
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText1'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText2'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText3'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText4'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText5'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText6'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText7'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText8'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText9')
+        ], CompoundFilterType.OR);
+
+        expect(listFilterC.getLabelForField()).toEqual('Test Database 1 / Test Table 1 / Test Text Field');
+        expect(listFilterC.getLabelForField(true)).toEqual('Test Text Field');
+        expect(listFilterC.getLabelForOperator()).toEqual('');
+        expect(listFilterC.getLabelForValue()).toEqual('!= (testText1 or testText2 or testText3 or testText4 or testText5 or 4 more...)');
+        expect(listFilterC.getLabelForValue(true)).toEqual('!= (testText1 or testText2 or testText3 or testText4 or testText5 or 4 ' +
+            'more...)');
+    });
+
+    it('getLabel functions on list filter with many clauses and equals operator should return expected strings', () => {
+        let listFilterD: CompoundFilter = ListFilter.fromFilters([
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText1'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText2'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText3'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText4'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText5'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText6'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText7'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText8'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText9')
+        ], CompoundFilterType.OR);
+
+        expect(listFilterD.getLabelForField()).toEqual('Test Database 1 / Test Table 1 / Test Text Field');
+        expect(listFilterD.getLabelForField(true)).toEqual('Test Text Field');
+        expect(listFilterD.getLabelForOperator()).toEqual('');
+        expect(listFilterD.getLabelForValue()).toEqual('testText1 or testText2 or testText3 or testText4 or testText5 or 4 more...');
+        expect(listFilterD.getLabelForValue(true)).toEqual('testText1 or testText2 or testText3 or testText4 or testText5 or 4 more...');
+    });
+
+    it('retrieveValues on list filter does return expected values', () => {
+        let listFilterA: CompoundFilter = ListFilter.fromFilters([
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText1'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText2'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText3')
+        ], CompoundFilterType.OR);
+
+        expect(listFilterA.retrieveValues()).toEqual([{
+            field: DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.TEXT.columnName,
+            operator: '!=',
+            value: 'testText1'
+        }, {
+            field: DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.TEXT.columnName,
+            operator: '!=',
+            value: 'testText2'
+        }, {
+            field: DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.TEXT.columnName,
+            operator: '!=',
+            value: 'testText3'
+        }]);
+    });
+
+    it('toDataList on list filter does return expected list', () => {
+        let listFilterA: CompoundFilter = ListFilter.fromFilters([
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText1'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText2'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText3')
+        ], CompoundFilterType.OR);
+
+        expect(listFilterA.toDataList()).toEqual([
+            'list',
+            listFilterA.id,
+            [],
+            CompoundFilterType.OR,
+            DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.TEXT.columnName,
+            '!=',
+            'testText1',
+            'testText2',
+            'testText3'
+        ]);
+    });
+});
+
+describe('PairFilter', () => {
+    it('getLabel functions on pair filter should return expected strings', () => {
+        let pairFilterA: CompoundFilter = PairFilter.fromFilters([
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.NAME, '=', 'testName'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TYPE, '!=', 'testType')
+        ], CompoundFilterType.OR);
+
+        expect(pairFilterA.getLabelForField()).toEqual('Test Database 1 / Test Table 1 / Test Name Field or Test Database 1 / ' +
+            'Test Table 1 / Test Type Field');
+        expect(pairFilterA.getLabelForField(true)).toEqual('Test Name Field or Test Type Field');
+        expect(pairFilterA.getLabelForOperator()).toEqual('');
+        expect(pairFilterA.getLabelForValue()).toEqual('testName or != testType');
+        expect(pairFilterA.getLabelForValue(true)).toEqual('testName or != testType');
+    });
+
+    it('getLabel functions on pair filter with same operator should return expected strings', () => {
+        let pairFilterB: CompoundFilter = PairFilter.fromFilters([
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.NAME, '!=', 'testName'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TYPE, '!=', 'testType')
+        ], CompoundFilterType.OR);
+
+        expect(pairFilterB.getLabelForField()).toEqual('Test Database 1 / Test Table 1 / Test Name Field or Test Database 1 / ' +
+            'Test Table 1 / Test Type Field');
+        expect(pairFilterB.getLabelForField(true)).toEqual('Test Name Field or Test Type Field');
+        expect(pairFilterB.getLabelForOperator()).toEqual('');
+        expect(pairFilterB.getLabelForValue()).toEqual('!= (testName or testType)');
+        expect(pairFilterB.getLabelForValue(true)).toEqual('!= (testName or testType)');
+    });
+
+    it('retrieveValues on pair filter does return expected values', () => {
+        let pairFilterA: CompoundFilter = PairFilter.fromFilters([
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.NAME, '=', 'testName'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TYPE, '!=', 'testType')
+        ], CompoundFilterType.OR);
+
+        expect(pairFilterA.retrieveValues()).toEqual([{
+            field1: DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.NAME.columnName,
+            field2: DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.TYPE.columnName,
+            operator1: '=',
+            operator2: '!=',
+            value1: 'testName',
+            value2: 'testType'
+        }]);
+    });
+
+    it('toDataList on pair filter does return expected list', () => {
+        let pairFilterA: CompoundFilter = PairFilter.fromFilters([
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.NAME, '=', 'testName'),
+            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TYPE, '!=', 'testType')
+        ], CompoundFilterType.OR);
+
+        expect(pairFilterA.toDataList()).toEqual([
+            'pair',
+            pairFilterA.id,
+            [],
+            CompoundFilterType.OR,
+            DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.NAME.columnName,
+            '=',
+            'testName',
+            DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.TYPE.columnName,
+            '!=',
+            'testType'
+        ]);
     });
 });
 
@@ -3457,21 +3966,6 @@ describe('Filter Labels', () => {
         expect(zeroEqualsFilter.getLabelForValue()).toEqual('0');
     });
 
-    it('getLabel functions on bounds filter should return expected strings', () => {
-        let boundsFilter: CompoundFilter = BoundsFilter.fromFilters([
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.X, '>=', -50),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.X, '<=', 50),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.Y, '>=', -100),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.Y, '<=', 100)
-        ]);
-
-        expect(boundsFilter.getLabelForField()).toEqual('Test Database 1 / Test Table 1 / Test X Field and Test Database 1 / ' +
-            'Test Table 1 / Test Y Field');
-        expect(boundsFilter.getLabelForField(true)).toEqual('Test X Field and Test Y Field');
-        expect(boundsFilter.getLabelForOperator()).toEqual('');
-        expect(boundsFilter.getLabelForValue()).toEqual('from (-50, -100) to (50, 100)');
-    });
-
     it('getLabel functions on compound filter should return expected strings', () => {
         let compoundFilter: CompoundFilter = FilterUtil.createFilterFromConfig({
             type: 'or',
@@ -3509,114 +4003,117 @@ describe('Filter Labels', () => {
         expect(compoundFilter.getLabelForValue(true)).toEqual('(Test Name Field testName) or (Test Text Field contains testText) or ' +
             '(Test Type Field != testType)');
     });
+});
 
-    it('getLabel functions on domain filter should return expected strings', () => {
-        let domainFilter: CompoundFilter = DomainFilter.fromFilters([
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.SIZE, '>=', -100),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.SIZE, '<=', 100)
-        ]);
-
-        expect(domainFilter.getLabelForField()).toEqual('Test Database 1 / Test Table 1 / Test Size Field');
-        expect(domainFilter.getLabelForField(true)).toEqual('Test Size Field');
-        expect(domainFilter.getLabelForOperator()).toEqual('');
-        expect(domainFilter.getLabelForValue()).toEqual('between -100 and 100');
+describe('FilterDesign constructors', () => {
+    it('BoundsFilterDesign does have expected filters', () => {
+        const boundsDesignA = new BoundsFilterDesign(
+            DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.X.columnName,
+            DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.Y.columnName,
+            1,
+            2,
+            3,
+            4
+        );
+        expect(boundsDesignA.filters).toEqual([{
+            datastore: DATASTORE.name,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.X.columnName,
+            operator: '>=',
+            value: 1
+        }, {
+            datastore: DATASTORE.name,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.X.columnName,
+            operator: '<=',
+            value: 3
+        }, {
+            datastore: DATASTORE.name,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.Y.columnName,
+            operator: '>=',
+            value: 2
+        }, {
+            datastore: DATASTORE.name,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.Y.columnName,
+            operator: '<=',
+            value: 4
+        }]);
     });
 
-    it('getLabel functions on list filter should return expected strings', () => {
-        let listFilter: CompoundFilter = ListFilter.fromFilters([
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText1'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText2'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText3')
-        ], CompoundFilterType.OR);
-
-        expect(listFilter.getLabelForField()).toEqual('Test Database 1 / Test Table 1 / Test Text Field');
-        expect(listFilter.getLabelForField(true)).toEqual('Test Text Field');
-        expect(listFilter.getLabelForOperator()).toEqual('');
-        expect(listFilter.getLabelForValue()).toEqual('!= (testText1 or testText2 or testText3)');
-        expect(listFilter.getLabelForValue(true)).toEqual('!= (testText1 or testText2 or testText3)');
+    it('DomainFilterDesign does have expected filters', () => {
+        const domainDesignA = new DomainFilterDesign(
+            DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.X.columnName,
+            1,
+            2
+        );
+        expect(domainDesignA.filters).toEqual([{
+            datastore: DATASTORE.name,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.X.columnName,
+            operator: '>=',
+            value: 1
+        }, {
+            datastore: DATASTORE.name,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.X.columnName,
+            operator: '<=',
+            value: 2
+        }]);
     });
 
-    it('getLabel functions on list filter with equals operator should return expected strings', () => {
-        let listFilter: CompoundFilter = ListFilter.fromFilters([
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText1'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText2'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText3')
-        ], CompoundFilterType.OR);
-
-        expect(listFilter.getLabelForField()).toEqual('Test Database 1 / Test Table 1 / Test Text Field');
-        expect(listFilter.getLabelForField(true)).toEqual('Test Text Field');
-        expect(listFilter.getLabelForOperator()).toEqual('');
-        expect(listFilter.getLabelForValue()).toEqual('testText1 or testText2 or testText3');
-        expect(listFilter.getLabelForValue(true)).toEqual('testText1 or testText2 or testText3');
+    it('ListFilterDesign does have expected filters', () => {
+        const listDesignA = new ListFilterDesign(CompoundFilterType.OR,
+            DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.TEXT.columnName,
+            '!=',
+            ['testText1', 'testText2']);
+        expect(listDesignA.filters).toEqual([{
+            datastore: DATASTORE.name,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.TEXT.columnName,
+            operator: '!=',
+            value: 'testText1'
+        }, {
+            datastore: DATASTORE.name,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.TEXT.columnName,
+            operator: '!=',
+            value: 'testText2'
+        }]);
     });
 
-    it('getLabel functions on list filter with many clauses should return expected strings', () => {
-        let listFilter: CompoundFilter = ListFilter.fromFilters([
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText1'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText2'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText3'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText4'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText5'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText6'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText7'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText8'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText9')
-        ], CompoundFilterType.OR);
-
-        expect(listFilter.getLabelForField()).toEqual('Test Database 1 / Test Table 1 / Test Text Field');
-        expect(listFilter.getLabelForField(true)).toEqual('Test Text Field');
-        expect(listFilter.getLabelForOperator()).toEqual('');
-        expect(listFilter.getLabelForValue()).toEqual('!= (testText1 or testText2 or testText3 or testText4 or testText5 or 4 more...)');
-        expect(listFilter.getLabelForValue(true)).toEqual('!= (testText1 or testText2 or testText3 or testText4 or testText5 or 4 ' +
-            'more...)');
-    });
-
-    it('getLabel functions on list filter with many clauses and equals operator should return expected strings', () => {
-        let listFilter: CompoundFilter = ListFilter.fromFilters([
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText1'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText2'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText3'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText4'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText5'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText6'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText7'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText8'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '=', 'testText9')
-        ], CompoundFilterType.OR);
-
-        expect(listFilter.getLabelForField()).toEqual('Test Database 1 / Test Table 1 / Test Text Field');
-        expect(listFilter.getLabelForField(true)).toEqual('Test Text Field');
-        expect(listFilter.getLabelForOperator()).toEqual('');
-        expect(listFilter.getLabelForValue()).toEqual('testText1 or testText2 or testText3 or testText4 or testText5 or 4 more...');
-        expect(listFilter.getLabelForValue(true)).toEqual('testText1 or testText2 or testText3 or testText4 or testText5 or 4 more...');
-    });
-
-    it('getLabel functions on pair filter should return expected strings', () => {
-        let pairFilter: CompoundFilter = PairFilter.fromFilters([
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.NAME, '=', 'testName'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TYPE, '!=', 'testType')
-        ], CompoundFilterType.OR);
-
-        expect(pairFilter.getLabelForField()).toEqual('Test Database 1 / Test Table 1 / Test Name Field or Test Database 1 / ' +
-            'Test Table 1 / Test Type Field');
-        expect(pairFilter.getLabelForField(true)).toEqual('Test Name Field or Test Type Field');
-        expect(pairFilter.getLabelForOperator()).toEqual('');
-        expect(pairFilter.getLabelForValue()).toEqual('testName or != testType');
-        expect(pairFilter.getLabelForValue(true)).toEqual('testName or != testType');
-    });
-
-    it('getLabel functions on pair filter with same operator should return expected strings', () => {
-        let pairFilter: CompoundFilter = PairFilter.fromFilters([
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.NAME, '!=', 'testName'),
-            new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TYPE, '!=', 'testType')
-        ], CompoundFilterType.OR);
-
-        expect(pairFilter.getLabelForField()).toEqual('Test Database 1 / Test Table 1 / Test Name Field or Test Database 1 / ' +
-            'Test Table 1 / Test Type Field');
-        expect(pairFilter.getLabelForField(true)).toEqual('Test Name Field or Test Type Field');
-        expect(pairFilter.getLabelForOperator()).toEqual('');
-        expect(pairFilter.getLabelForValue()).toEqual('!= (testName or testType)');
-        expect(pairFilter.getLabelForValue(true)).toEqual('!= (testName or testType)');
+    it('PairFilterDesign does have expected filters', () => {
+        const pairDesignA = new PairFilterDesign(CompoundFilterType.OR,
+            DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.NAME.columnName,
+            DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.TYPE.columnName,
+            '=',
+            '!=',
+            'testName',
+            'testType');
+        expect(pairDesignA.filters).toEqual([{
+            datastore: DATASTORE.name,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.NAME.columnName,
+            operator: '=',
+            value: 'testName'
+        }, {
+            datastore: DATASTORE.name,
+            database: DATABASES.testDatabase1.name,
+            table: TABLES.testTable1.name,
+            field: FIELD_MAP.TYPE.columnName,
+            operator: '!=',
+            value: 'testType'
+        }]);
     });
 });
 

--- a/src/app/util/filter.util.spec.ts
+++ b/src/app/util/filter.util.spec.ts
@@ -605,8 +605,16 @@ describe('FilterUtil', () => {
     });
 
     it('createFilterFromDataList does return simple filter object', () => {
-        const actual = FilterUtil.createFilterFromDataList(['datastore1.testDatabase2.testTable2.testIdField', '=', 'testValue'], DATASET);
+        const actual = FilterUtil.createFilterFromDataList([
+            'id1',
+            ['relation1'],
+            'datastore1.testDatabase2.testTable2.testIdField',
+            '=',
+            'testValue'
+        ], DATASET);
         expect(actual instanceof SimpleFilter).toEqual(true);
+        expect(actual.id).toEqual('id1');
+        expect(actual.relations).toEqual(['relation1']);
         expect((actual as any).datastore).toEqual('datastore1');
         expect((actual as any).database).toEqual(DATABASES.testDatabase2);
         expect((actual as any).table).toEqual(TABLES.testTable2);
@@ -616,14 +624,20 @@ describe('FilterUtil', () => {
     });
 
     it('createFilterFromDataList does return bounds filter object', () => {
-        const actual = FilterUtil.createFilterFromDataList(['bounds',
+        const actual = FilterUtil.createFilterFromDataList([
+            'bounds',
+            'id1',
+            ['relation1'],
             'datastore1.testDatabase2.testTable2.testXField',
             'testBegin1',
             'testEnd1',
             'datastore1.testDatabase2.testTable2.testYField',
             'testBegin2',
-            'testEnd2'], DATASET);
+            'testEnd2'
+        ], DATASET);
         expect(actual instanceof BoundsFilter).toEqual(true);
+        expect(actual.id).toEqual('id1');
+        expect(actual.relations).toEqual(['relation1']);
         expect((actual as any).type).toEqual(CompoundFilterType.AND);
         expect((actual as any).filters.length).toEqual(4);
         expect((actual as any).filters[0] instanceof SimpleFilter).toEqual(true);
@@ -657,11 +671,17 @@ describe('FilterUtil', () => {
     });
 
     it('createFilterFromDataList does return domain filter object', () => {
-        const actual = FilterUtil.createFilterFromDataList(['domain',
+        const actual = FilterUtil.createFilterFromDataList([
+            'domain',
+            'id1',
+            ['relation1'],
             'datastore1.testDatabase2.testTable2.testSizeField',
             'testBegin',
-            'testEnd'], DATASET);
+            'testEnd'
+        ], DATASET);
         expect(actual instanceof DomainFilter).toEqual(true);
+        expect(actual.id).toEqual('id1');
+        expect(actual.relations).toEqual(['relation1']);
         expect((actual as any).type).toEqual(CompoundFilterType.AND);
         expect((actual as any).filters.length).toEqual(2);
         expect((actual as any).filters[0] instanceof SimpleFilter).toEqual(true);
@@ -681,13 +701,19 @@ describe('FilterUtil', () => {
     });
 
     it('createFilterFromDataList does return list filter object', () => {
-        const actual = FilterUtil.createFilterFromDataList(['list',
+        const actual = FilterUtil.createFilterFromDataList([
+            'list',
+            'id1',
+            ['relation1'],
             'and',
             'datastore1.testDatabase2.testTable2.testTextField',
             '!=',
             'testValue1',
-            'testValue2'], DATASET);
+            'testValue2'
+        ], DATASET);
         expect(actual instanceof ListFilter).toEqual(true);
+        expect(actual.id).toEqual('id1');
+        expect(actual.relations).toEqual(['relation1']);
         expect((actual as any).type).toEqual(CompoundFilterType.AND);
         expect((actual as any).filters.length).toEqual(2);
         expect((actual as any).filters[0] instanceof SimpleFilter).toEqual(true);
@@ -707,15 +733,21 @@ describe('FilterUtil', () => {
     });
 
     it('createFilterFromDataList does return pair filter object', () => {
-        const actual = FilterUtil.createFilterFromDataList(['pair',
+        const actual = FilterUtil.createFilterFromDataList([
+            'pair',
+            'id1',
+            ['relation1'],
             'and',
             'datastore1.testDatabase2.testTable2.testNameField',
             'contains',
             'testValue1',
             'datastore1.testDatabase2.testTable2.testTypeField',
             'not contains',
-            'testValue2'], DATASET);
+            'testValue2'
+        ], DATASET);
         expect(actual instanceof PairFilter).toEqual(true);
+        expect(actual.id).toEqual('id1');
+        expect(actual.relations).toEqual(['relation1']);
         expect((actual as any).type).toEqual(CompoundFilterType.AND);
         expect((actual as any).filters.length).toEqual(2);
         expect((actual as any).filters[0] instanceof SimpleFilter).toEqual(true);
@@ -735,15 +767,25 @@ describe('FilterUtil', () => {
     });
 
     it('createFilterFromDataList does return compound filter object', () => {
-        const actual = FilterUtil.createFilterFromDataList(['and',
-            ['and', ['datastore1.testDatabase2.testTable2.testNameField',
-                'contains',
-                'testValue1'], ['datastore1.testDatabase2.testTable2.testTypeField', 'not contains', 'testValue2']],
-            ['datastore1.testDatabase2.testTable2.testIdField', '=', 'testValue3']], DATASET);
+        const actual = FilterUtil.createFilterFromDataList([
+            'and',
+            'id1',
+            ['relation1'],
+            ['and',
+                'id2',
+                ['relation2'],
+                ['id3', [], 'datastore1.testDatabase2.testTable2.testNameField', 'contains', 'testValue1'],
+                ['id4', [], 'datastore1.testDatabase2.testTable2.testTypeField', 'not contains', 'testValue2']],
+            ['id5', [], 'datastore1.testDatabase2.testTable2.testIdField', '=', 'testValue3']
+        ], DATASET);
         expect(actual instanceof CompoundFilter).toEqual(true);
+        expect(actual.id).toEqual('id1');
+        expect(actual.relations).toEqual(['relation1']);
         expect((actual as any).type).toEqual(CompoundFilterType.AND);
         expect((actual as any).filters.length).toEqual(2);
         expect((actual as any).filters[0] instanceof CompoundFilter).toEqual(true);
+        expect((actual as any).filters[0].id).toEqual('id2');
+        expect((actual as any).filters[0].relations).toEqual(['relation2']);
         expect((actual as any).filters[0].type).toEqual(CompoundFilterType.AND);
         expect((actual as any).filters[0].filters.length).toEqual(2);
         expect((actual as any).filters[0].filters[0] instanceof SimpleFilter).toEqual(true);

--- a/src/app/util/filter.util.spec.ts
+++ b/src/app/util/filter.util.spec.ts
@@ -1891,11 +1891,11 @@ describe('SimpleFilter', () => {
     });
 
     it('retrieveValues on simple filter should return expected object', () => {
-        expect(simpleFilter.retrieveValues()).toEqual([{
+        expect(simpleFilter.retrieveValues()).toEqual({
             field: 'testNameField',
             operator: '=',
             value: 'testName1'
-        }]);
+        });
     });
 
     it('toConfig on simple filter should return expected object', () => {
@@ -2627,15 +2627,18 @@ describe('CompoundFilter (One Field)', () => {
     });
 
     it('retrieveValues on compound filter should return expected object', () => {
-        expect(compoundFilter.retrieveValues()).toEqual([{
-            field: 'testXField',
-            operator: '>',
-            value: -100
-        }, {
-            field: 'testXField',
-            operator: '<',
-            value: 100
-        }]);
+        expect(compoundFilter.retrieveValues()).toEqual({
+            type: CompoundFilterType.AND,
+            nested: [{
+                field: 'testXField',
+                operator: '>',
+                value: -100
+            }, {
+                field: 'testXField',
+                operator: '<',
+                value: 100
+            }]
+        });
     });
 
     it('toConfig on compound filter should return expected object', () => {
@@ -3239,15 +3242,18 @@ describe('CompoundFilter (Multi-Field)', () => {
     });
 
     it('retrieveValues on compound multi-field filter should return expected object', () => {
-        expect(compoundFilter.retrieveValues()).toEqual([{
-            field: 'testNameField',
-            operator: '=',
-            value: 'testName1'
-        }, {
-            field: 'testXField',
-            operator: '=',
-            value: 10
-        }]);
+        expect(compoundFilter.retrieveValues()).toEqual({
+            type: CompoundFilterType.OR,
+            nested: [{
+                field: 'testNameField',
+                operator: '=',
+                value: 'testName1'
+            }, {
+                field: 'testXField',
+                operator: '=',
+                value: 10
+            }]
+        });
     });
 
     it('toConfig on compound multi-field filter should return expected object', () => {
@@ -3341,23 +3347,32 @@ describe('CompoundFilter (Nested Compound Filters)', () => {
     });
 
     it('retrieveValues on compound nested filter should return expected object', () => {
-        expect(compoundFilter.retrieveValues()).toEqual([{
-            field: 'testXField',
-            operator: '=',
-            value: 10
-        }, {
-            field: 'testXField',
-            operator: '=',
-            value: 20
-        }, {
-            field: 'testNameField',
-            operator: '=',
-            value: 'testName1'
-        }, {
-            field: 'testNameField',
-            operator: '=',
-            value: 'testName2'
-        }]);
+        expect(compoundFilter.retrieveValues()).toEqual({
+            type: CompoundFilterType.AND,
+            nested: [{
+                type: CompoundFilterType.OR,
+                nested: [{
+                    field: 'testXField',
+                    operator: '=',
+                    value: 10
+                }, {
+                    field: 'testXField',
+                    operator: '=',
+                    value: 20
+                }]
+            }, {
+                type: CompoundFilterType.OR,
+                nested: [{
+                    field: 'testNameField',
+                    operator: '=',
+                    value: 'testName1'
+                }, {
+                    field: 'testNameField',
+                    operator: '=',
+                    value: 'testName2'
+                }]
+            }]
+        });
     });
 
     it('toConfig on compound nested filters should return expected object', () => {
@@ -3577,14 +3592,14 @@ describe('BoundsFilter', () => {
             new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.Y, '<=', 100)
         ]);
 
-        expect(boundsFilterA.retrieveValues()).toEqual([{
+        expect(boundsFilterA.retrieveValues()).toEqual({
             begin1: -50,
             begin2: -100,
             field1: DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.X.columnName,
             field2: DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.Y.columnName,
             end1: 50,
             end2: 100
-        }]);
+        });
     });
 
     it('toDataList on bounds filter does return expected list', () => {
@@ -3628,11 +3643,11 @@ describe('DomainFilter', () => {
             new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.SIZE, '<=', 100)
         ]);
 
-        expect(domainFilterA.retrieveValues()).toEqual([{
+        expect(domainFilterA.retrieveValues()).toEqual({
             begin: -100,
             field: DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.SIZE.columnName,
             end: 100
-        }]);
+        });
     });
 
     it('toDataList on domain filter does return expected list', () => {
@@ -3729,19 +3744,12 @@ describe('ListFilter', () => {
             new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TEXT, '!=', 'testText3')
         ], CompoundFilterType.OR);
 
-        expect(listFilterA.retrieveValues()).toEqual([{
+        expect(listFilterA.retrieveValues()).toEqual({
+            type: CompoundFilterType.OR,
             field: DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.TEXT.columnName,
             operator: '!=',
-            value: 'testText1'
-        }, {
-            field: DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.TEXT.columnName,
-            operator: '!=',
-            value: 'testText2'
-        }, {
-            field: DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.TEXT.columnName,
-            operator: '!=',
-            value: 'testText3'
-        }]);
+            values: ['testText1', 'testText2', 'testText3']
+        });
     });
 
     it('toDataList on list filter does return expected list', () => {
@@ -3800,14 +3808,15 @@ describe('PairFilter', () => {
             new SimpleFilter(DATASTORE.name, DATABASES.testDatabase1, TABLES.testTable1, FIELD_MAP.TYPE, '!=', 'testType')
         ], CompoundFilterType.OR);
 
-        expect(pairFilterA.retrieveValues()).toEqual([{
+        expect(pairFilterA.retrieveValues()).toEqual({
+            type: CompoundFilterType.OR,
             field1: DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.NAME.columnName,
             field2: DATASTORE.name + '.' + DATABASES.testDatabase1.name + '.' + TABLES.testTable1.name + '.' + FIELD_MAP.TYPE.columnName,
             operator1: '=',
             operator2: '!=',
             value1: 'testName',
             value2: 'testType'
-        }]);
+        });
     });
 
     it('toDataList on pair filter does return expected list', () => {

--- a/src/app/util/filter.util.ts
+++ b/src/app/util/filter.util.ts
@@ -30,7 +30,6 @@ import { DatasetUtil } from './dataset.util';
 
 import * as _ from 'lodash';
 import * as moment from 'moment';
-import * as uuidv4 from 'uuid/v4';
 
 export class FilterUtil {
     /**
@@ -127,22 +126,23 @@ export class FilterUtil {
 
             if (datastore && datastore.name && database && database.name && table && table.name && field && field.columnName &&
                 typeof filterConfig.value !== 'undefined') {
-                filter = new SimpleFilter(datastore.name, database, table, field, filterConfig.operator, filterConfig.value);
+                filter = new SimpleFilter(datastore.name, database, table, field, filterConfig.operator, filterConfig.value,
+                    filterConfig.id, filterConfig.relations);
             }
         } else if (this.isCompoundFilterConfig(filterConfig)) {
             const nestedFilters: AbstractFilter[] = filterConfig.filters.map((nestedConfig) =>
                 this.createFilterFromConfig(nestedConfig, dataset));
 
             if (filterConfig instanceof BoundsFilterDesign) {
-                filter = BoundsFilter.fromFilters(nestedFilters);
+                filter = BoundsFilter.fromFilters(nestedFilters, filterConfig.id, filterConfig.relations);
             } else if (filterConfig instanceof DomainFilterDesign) {
-                filter = DomainFilter.fromFilters(nestedFilters);
+                filter = DomainFilter.fromFilters(nestedFilters, filterConfig.id, filterConfig.relations);
             } else if (filterConfig instanceof ListFilterDesign) {
-                filter = ListFilter.fromFilters(nestedFilters, filterConfig.type);
+                filter = ListFilter.fromFilters(nestedFilters, filterConfig.type, filterConfig.id, filterConfig.relations);
             } else if (filterConfig instanceof PairFilterDesign) {
-                filter = PairFilter.fromFilters(nestedFilters, filterConfig.type);
+                filter = PairFilter.fromFilters(nestedFilters, filterConfig.type, filterConfig.id, filterConfig.relations);
             } else {
-                filter = new CompoundFilter(filterConfig.type, nestedFilters);
+                filter = new CompoundFilter(filterConfig.type, nestedFilters, filterConfig.id, filterConfig.relations);
             }
         }
 
@@ -335,12 +335,17 @@ export class FilterCollection {
     }
 }
 
-export abstract class AbstractFilter {
-    public id: string;
-    public relations: string[] = [];
+let filterIdCollection: Map<string, boolean> = new Map<string, boolean>();
+let nextFilterId = 1;
 
-    constructor() {
-        this.id = uuidv4();
+export abstract class AbstractFilter {
+    constructor(public id?: string, public relations: string[] = []) {
+        if (!this.id) {
+            do {
+                this.id = 'id' + (nextFilterId++);
+            } while (filterIdCollection.get(this.id));
+        }
+        filterIdCollection.set(this.id, true);
     }
 
     /**
@@ -440,14 +445,16 @@ export class SimpleFilter extends AbstractFilter {
      * Creates and returns a simple filter object using the given data list (or null if it is not the correct type of data list).
      */
     static fromDataList(dataList: any[], dataset: Dataset): SimpleFilter {
-        if (dataList.length === 3) {
-            const fieldKeyString = dataList[0];
-            const operator = dataList[1];
-            const value = dataList[2];
+        if (dataList.length === 5 && !(dataList[0] === 'and' || dataList[0] === 'or')) {
+            const id = dataList[0];
+            const relations = dataList[1];
+            const fieldKeyString = dataList[2];
+            const operator = dataList[3];
+            const value = dataList[4];
             const fieldKey: FieldKey = DatasetUtil.deconstructTableOrFieldKey(fieldKeyString);
             if (fieldKey) {
                 const [datastore, database, table, field] = DatasetUtil.retrieveMetaDataFromFieldKey(fieldKey, dataset);
-                return new SimpleFilter(datastore.name, database, table, field, operator, value);
+                return new SimpleFilter(datastore.name, database, table, field, operator, value, id, relations);
             }
         }
         return null;
@@ -459,9 +466,11 @@ export class SimpleFilter extends AbstractFilter {
         public table: NeonTableMetaData,
         public field: NeonFieldMetaData,
         public operator: string,
-        public value: any
+        public value: any,
+        id?: string,
+        relations?: string[]
     ) {
-        super();
+        super(id, relations);
     }
 
     /**
@@ -608,7 +617,7 @@ export class SimpleFilter extends AbstractFilter {
      */
     public toConfig(): FilterConfig {
         return new SimpleFilterDesign(this.datastore, this.database.name, this.table.name, this.field.columnName, this.operator,
-            this.value, this.id);
+            this.value, this.id, this.relations);
     }
 
     /**
@@ -617,7 +626,11 @@ export class SimpleFilter extends AbstractFilter {
     public toDataList(): any[] {
         const value = (typeof this.value === 'number' && (/[<>]=?/).test(this.operator) && (/[.]\d{4,100}/).test(`${this.value}`)) ?
             parseFloat(this.value.toFixed(3)) : this.value;
-        return [`${this.datastore}.${this.database.name}.${this.table.name}.${this.field.columnName}`, this.operator, value];
+        return [this.id,
+            this.relations,
+            `${this.datastore}.${this.database.name}.${this.table.name}.${this.field.columnName}`,
+            this.operator,
+            value];
     }
 }
 
@@ -627,17 +640,19 @@ export class CompoundFilter extends AbstractFilter {
      */
     static fromDataList(dataList: any[], dataset: Dataset): CompoundFilter {
         if (dataList.length && (dataList[0] === 'and' || dataList[0] === 'or')) {
-            const [type, ...filters] = dataList;
-            return new CompoundFilter(type, filters.map((filter) => FilterUtil.createFilterFromDataList(filter, dataset)));
+            const [type, id, relations, ...filters] = dataList;
+            return new CompoundFilter(type, filters.map((filter) => FilterUtil.createFilterFromDataList(filter, dataset)), id, relations);
         }
         return null;
     }
 
     constructor(
         public type: CompoundFilterType,
-        public filters: AbstractFilter[]
+        public filters: AbstractFilter[],
+        id?: string,
+        relations?: string[]
     ) {
-        super();
+        super(id, relations);
     }
 
     public asBoundsFilter(): { lowerA: SimpleFilter, lowerB: SimpleFilter, upperA: SimpleFilter, upperB: SimpleFilter } {
@@ -950,14 +965,14 @@ export class CompoundFilter extends AbstractFilter {
      * @return {FilterConfig}
      */
     public toConfig(): FilterConfig {
-        return new CompoundFilterDesign(this.type, this.filters.map((filter) => filter.toConfig()), this.id);
+        return new CompoundFilterDesign(this.type, this.filters.map((filter) => filter.toConfig()), this.id, this.relations);
     }
 
     /**
      * Returns the filter as a data list to save as a string in a text file or URL.
      */
     public toDataList(): any[] {
-        return ([this.type] as any[]).concat(this.filters.map((filter) => filter.toDataList()));
+        return ([this.type, this.id, this.relations] as any[]).concat(this.filters.map((filter) => filter.toDataList()));
     }
 }
 
@@ -966,13 +981,15 @@ export class BoundsFilter extends CompoundFilter {
      * Creates and returns a bounds filter object using the given data list (or null if it is not the correct type of data list).
      */
     static fromDataList(dataList: any[], dataset: Dataset): BoundsFilter {
-        if (dataList.length === 7 && dataList[0] === 'bounds') {
-            const fieldKeyString1 = dataList[1];
-            const begin1 = dataList[2];
-            const end1 = dataList[3];
-            const fieldKeyString2 = dataList[4];
-            const begin2 = dataList[5];
-            const end2 = dataList[6];
+        if (dataList.length === 9 && dataList[0] === 'bounds') {
+            const id = dataList[1];
+            const relations = dataList[2];
+            const fieldKeyString1 = dataList[3];
+            const begin1 = dataList[4];
+            const end1 = dataList[5];
+            const fieldKeyString2 = dataList[6];
+            const begin2 = dataList[7];
+            const end2 = dataList[8];
 
             const fieldKey1: FieldKey = DatasetUtil.deconstructTableOrFieldKey(fieldKeyString1);
             const fieldKey2: FieldKey = DatasetUtil.deconstructTableOrFieldKey(fieldKeyString2);
@@ -984,7 +1001,7 @@ export class BoundsFilter extends CompoundFilter {
                     new SimpleFilter(datastore1.name, database1, table1, field1, '<=', end1),
                     new SimpleFilter(datastore2.name, database2, table2, field2, '>=', begin2),
                     new SimpleFilter(datastore2.name, database2, table2, field2, '<=', end2)
-                ]);
+                ], id, relations);
             }
         }
         return null;
@@ -993,7 +1010,7 @@ export class BoundsFilter extends CompoundFilter {
     /**
      * Creates and returns a bounds filter object using the given array of four simple filter objects.
      */
-    static fromFilters(filters: AbstractFilter[]): BoundsFilter {
+    static fromFilters(filters: AbstractFilter[], id?: string, relations?: string[]): BoundsFilter {
         if (filters.length === 4 && filters.every((filter) => filter instanceof SimpleFilter)) {
             let fieldKeys = _.uniq(filters.map((filter) => {
                 let simple = filter as SimpleFilter;
@@ -1008,7 +1025,7 @@ export class BoundsFilter extends CompoundFilter {
 
                 if (filter1 && filter2 && filter3 && filter4) {
                     return new BoundsFilter(fieldKeys[0], fieldKeys[1], filter1.value, filter3.value, filter2.value, filter4.value,
-                        [filter1, filter2, filter3, filter4]);
+                        [filter1, filter2, filter3, filter4], id, relations);
                 }
             }
         }
@@ -1022,9 +1039,11 @@ export class BoundsFilter extends CompoundFilter {
         public begin2: any,
         public end1: any,
         public end2: any,
-        public filters: AbstractFilter[]
+        filters: AbstractFilter[],
+        id?: string,
+        relations?: string[]
     ) {
-        super(CompoundFilterType.AND, filters);
+        super(CompoundFilterType.AND, filters, id, relations);
     }
 
     protected createCompoundFilter(filterTransformation: (filters) => AbstractFilter): CompoundFilter {
@@ -1064,14 +1083,15 @@ export class BoundsFilter extends CompoundFilter {
      * Returns the filter config for the filter object.
      */
     public toConfig(): FilterConfig {
-        return new BoundsFilterDesign(this.fieldKey1, this.fieldKey2, this.begin1, this.begin2, this.end1, this.end2, this.id);
+        return new BoundsFilterDesign(this.fieldKey1, this.fieldKey2, this.begin1, this.begin2, this.end1, this.end2, this.id,
+            this.relations);
     }
 
     /**
      * Returns the filter as a data list to save as a string in a text file or URL.
      */
     public toDataList(): any[] {
-        return ['bounds', this.fieldKey1, this.begin1, this.end1, this.fieldKey2, this.begin2, this.end2];
+        return ['bounds', this.id, this.relations, this.fieldKey1, this.begin1, this.end1, this.fieldKey2, this.begin2, this.end2];
     }
 }
 
@@ -1080,10 +1100,12 @@ export class DomainFilter extends CompoundFilter {
      * Creates and returns a list filter object using the given data list (or null if it is not the correct type of data list).
      */
     static fromDataList(dataList: any[], dataset: Dataset): DomainFilter {
-        if (dataList.length === 4 && dataList[0] === 'domain') {
-            const fieldKeyString = dataList[1];
-            const begin = dataList[2];
-            const end = dataList[3];
+        if (dataList.length === 6 && dataList[0] === 'domain') {
+            const id = dataList[1];
+            const relations = dataList[2];
+            const fieldKeyString = dataList[3];
+            const begin = dataList[4];
+            const end = dataList[5];
 
             const fieldKey: FieldKey = DatasetUtil.deconstructTableOrFieldKey(fieldKeyString);
             if (fieldKey) {
@@ -1091,7 +1113,7 @@ export class DomainFilter extends CompoundFilter {
                 return new DomainFilter(fieldKeyString, begin, end, [
                     new SimpleFilter(datastore.name, database, table, field, '>=', begin),
                     new SimpleFilter(datastore.name, database, table, field, '<=', end)
-                ]);
+                ], id, relations);
             }
         }
         return null;
@@ -1100,7 +1122,7 @@ export class DomainFilter extends CompoundFilter {
     /**
      * Creates and returns a domain filter object using the given array of two simple filter objects.
      */
-    static fromFilters(filters: AbstractFilter[]): DomainFilter {
+    static fromFilters(filters: AbstractFilter[], id?: string, relations?: string[]): DomainFilter {
         if (filters.length === 2 && filters.every((filter) => filter instanceof SimpleFilter)) {
             let fieldKeys = _.uniq(filters.map((filter) => {
                 let simple = filter as SimpleFilter;
@@ -1112,15 +1134,22 @@ export class DomainFilter extends CompoundFilter {
                 const filter2: SimpleFilter = FilterUtil.findFilterWithFieldKey(filters as SimpleFilter[], fieldKeys[0], '<=');
 
                 if (filter1 && filter2) {
-                    return new DomainFilter(fieldKeys[0], filter1.value, filter2.value, [filter1, filter2]);
+                    return new DomainFilter(fieldKeys[0], filter1.value, filter2.value, [filter1, filter2], id, relations);
                 }
             }
         }
         return null;
     }
 
-    constructor(public fieldKey: string, public begin: any, public end: any, filters: AbstractFilter[]) {
-        super(CompoundFilterType.AND, filters);
+    constructor(
+        public fieldKey: string,
+        public begin: any,
+        public end: any,
+        filters: AbstractFilter[],
+        id?: string,
+        relations?: string[]
+    ) {
+        super(CompoundFilterType.AND, filters, id, relations);
     }
 
     protected createCompoundFilter(filterTransformation: (filters) => AbstractFilter): CompoundFilter {
@@ -1156,14 +1185,14 @@ export class DomainFilter extends CompoundFilter {
      * Returns the filter config for the filter object.
      */
     public toConfig(): FilterConfig {
-        return new DomainFilterDesign(this.fieldKey, this.begin, this.end, this.id);
+        return new DomainFilterDesign(this.fieldKey, this.begin, this.end, this.id, this.relations);
     }
 
     /**
      * Returns the filter as a data list to save as a string in a text file or URL.
      */
     public toDataList(): any[] {
-        return ['domain', this.fieldKey, this.begin, this.end];
+        return ['domain', this.id, this.relations, this.fieldKey, this.begin, this.end];
     }
 }
 
@@ -1172,17 +1201,19 @@ export class ListFilter extends CompoundFilter {
      * Creates and returns a list filter object using the given data list (or null if it is not the correct type of data list).
      */
     static fromDataList(dataList: any[], dataset: Dataset): ListFilter {
-        if (dataList.length >= 5 && dataList[0] === 'list') {
-            const type = dataList[1];
-            const fieldKeyString = dataList[2];
-            const operator = dataList[3];
-            const values = dataList.slice(4);
+        if (dataList.length >= 7 && dataList[0] === 'list') {
+            const id = dataList[1];
+            const relations = dataList[2];
+            const type = dataList[3];
+            const fieldKeyString = dataList[4];
+            const operator = dataList[5];
+            const values = dataList.slice(6);
 
             const fieldKey: FieldKey = DatasetUtil.deconstructTableOrFieldKey(fieldKeyString);
             if (fieldKey) {
                 const [datastore, database, table, field] = DatasetUtil.retrieveMetaDataFromFieldKey(fieldKey, dataset);
                 return new ListFilter(type, fieldKeyString, operator, values, values.map((value) =>
-                    new SimpleFilter(datastore.name, database, table, field, operator, value)));
+                    new SimpleFilter(datastore.name, database, table, field, operator, value)), id, relations);
             }
         }
         return null;
@@ -1191,7 +1222,7 @@ export class ListFilter extends CompoundFilter {
     /**
      * Creates and returns a list filter object using the given array of one or more simple filter objects and the filter type.
      */
-    static fromFilters(filters: AbstractFilter[], type: CompoundFilterType): ListFilter {
+    static fromFilters(filters: AbstractFilter[], type: CompoundFilterType, id?: string, relations?: string[]): ListFilter {
         if (filters.length && filters.every((filter) => filter instanceof SimpleFilter)) {
             let sample = filters[0] as SimpleFilter;
             let fieldKey = sample.datastore + '.' + sample.database.name + '.' + sample.table.name + '.' + sample.field.columnName;
@@ -1202,20 +1233,23 @@ export class ListFilter extends CompoundFilter {
                 return simple.operator === operator && (simple.datastore + '.' + simple.database.name + '.' + simple.table.name + '.' +
                     simple.field.columnName) === fieldKey;
             })) {
-                return new ListFilter(type, fieldKey, operator, filters.map((filter) => (filter as SimpleFilter).value), filters);
+                return new ListFilter(type, fieldKey, operator, filters.map((filter) => (filter as SimpleFilter).value), filters, id,
+                    relations);
             }
         }
         return null;
     }
 
     constructor(
-        public type: CompoundFilterType,
+        type: CompoundFilterType,
         public fieldKey: string,
         public operator: string,
         public values: any[],
-        public filters: AbstractFilter[]
+        filters: AbstractFilter[],
+        id?: string,
+        relations?: string[]
     ) {
-        super(type, filters);
+        super(type, filters, id, relations);
     }
 
     protected createCompoundFilter(filterTransformation: (filters) => AbstractFilter): CompoundFilter {
@@ -1256,14 +1290,14 @@ export class ListFilter extends CompoundFilter {
      * Returns the filter config for the filter object.
      */
     public toConfig(): FilterConfig {
-        return new ListFilterDesign(this.type, this.fieldKey, this.operator, this.values, this.id);
+        return new ListFilterDesign(this.type, this.fieldKey, this.operator, this.values, this.id, this.relations);
     }
 
     /**
      * Returns the filter as a data list to save as a string in a text file or URL.
      */
     public toDataList(): any[] {
-        return ['list', this.type, this.fieldKey, this.operator].concat(this.values.map((value) => value));
+        return ['list', this.id, this.relations, this.type, this.fieldKey, this.operator].concat(this.values.map((value) => value));
     }
 }
 
@@ -1272,14 +1306,16 @@ export class PairFilter extends CompoundFilter {
      * Creates and returns a pair filter object using the given data list (or null if it is not the correct type of data list).
      */
     static fromDataList(dataList: any[], dataset: Dataset): PairFilter {
-        if (dataList.length === 8 && dataList[0] === 'pair') {
-            const type = dataList[1];
-            const fieldKeyString1 = dataList[2];
-            const operator1 = dataList[3];
-            const value1 = dataList[4];
-            const fieldKeyString2 = dataList[5];
-            const operator2 = dataList[6];
-            const value2 = dataList[7];
+        if (dataList.length === 10 && dataList[0] === 'pair') {
+            const id = dataList[1];
+            const relations = dataList[2];
+            const type = dataList[3];
+            const fieldKeyString1 = dataList[4];
+            const operator1 = dataList[5];
+            const value1 = dataList[6];
+            const fieldKeyString2 = dataList[7];
+            const operator2 = dataList[8];
+            const value2 = dataList[9];
 
             const fieldKey1: FieldKey = DatasetUtil.deconstructTableOrFieldKey(fieldKeyString1);
             const fieldKey2: FieldKey = DatasetUtil.deconstructTableOrFieldKey(fieldKeyString2);
@@ -1289,7 +1325,7 @@ export class PairFilter extends CompoundFilter {
                 return new PairFilter(type, fieldKeyString1, fieldKeyString2, operator1, operator2, value1, value2, [
                     new SimpleFilter(datastore1.name, database1, table1, field1, operator1, value1),
                     new SimpleFilter(datastore2.name, database2, table2, field2, operator2, value2)
-                ]);
+                ], id, relations);
             }
         }
         return null;
@@ -1298,7 +1334,7 @@ export class PairFilter extends CompoundFilter {
     /**
      * Creates and returns a pair filter object using the given array of two simple filter objects and the filter type.
      */
-    static fromFilters(filters: AbstractFilter[], type: CompoundFilterType): PairFilter {
+    static fromFilters(filters: AbstractFilter[], type: CompoundFilterType, id?: string, relations?: string[]): PairFilter {
         if (filters.length === 2 && filters.every((filter) => filter instanceof SimpleFilter)) {
             let fieldKeys = _.uniq(filters.map((filter) => {
                 let simple = filter as SimpleFilter;
@@ -1311,7 +1347,7 @@ export class PairFilter extends CompoundFilter {
 
                 if (filter1 && filter2) {
                     return new PairFilter(type, fieldKeys[0], fieldKeys[1], filter1.operator, filter2.operator, filter1.value,
-                        filter2.value, [filter1, filter2]);
+                        filter2.value, [filter1, filter2], id, relations);
                 }
             }
         }
@@ -1319,16 +1355,18 @@ export class PairFilter extends CompoundFilter {
     }
 
     constructor(
-        public type: CompoundFilterType,
+        type: CompoundFilterType,
         public fieldKey1: string,
         public fieldKey2: string,
         public operator1: any,
         public operator2: any,
         public value1: any,
         public value2: any,
-        public filters: AbstractFilter[]
+        filters: AbstractFilter[],
+        id?: string,
+        relations?: string[]
     ) {
-        super(type, filters);
+        super(type, filters, id, relations);
     }
 
     protected createCompoundFilter(filterTransformation: (filters) => AbstractFilter): CompoundFilter {
@@ -1375,18 +1413,28 @@ export class PairFilter extends CompoundFilter {
      */
     public toConfig(): FilterConfig {
         return new PairFilterDesign(this.type, this.fieldKey1, this.fieldKey2, this.operator1, this.operator2, this.value1, this.value2,
-            this.id);
+            this.id, this.relations);
     }
 
     /**
      * Returns the filter as a data list to save as a string in a text file or URL.
      */
     public toDataList(): any[] {
-        return ['pair', this.type, this.fieldKey1, this.operator1, this.value1, this.fieldKey2, this.operator2, this.value2];
+        return ['pair',
+            this.id,
+            this.relations,
+            this.type,
+            this.fieldKey1,
+            this.operator1,
+            this.value1,
+            this.fieldKey2,
+            this.operator2,
+            this.value2];
     }
 }
 
 export abstract class AbstractFilterDesign {
+    constructor(public id?: string, public relations: string[] = []) { }
 }
 
 export class SimpleFilterDesign extends AbstractFilterDesign implements SimpleFilterConfig {
@@ -1402,9 +1450,10 @@ export class SimpleFilterDesign extends AbstractFilterDesign implements SimpleFi
         public field: string,
         public operator: string,
         public value?: any,
-        public id?: string
+        id?: string,
+        relations?: string[]
     ) {
-        super();
+        super(id, relations);
     }
 }
 
@@ -1418,9 +1467,10 @@ export class CompoundFilterDesign extends AbstractFilterDesign implements Compou
     constructor(
         public type: CompoundFilterType,
         public filters: (SimpleFilterConfig | CompoundFilterConfig)[],
-        public id?: string
+        id?: string,
+        relations?: string[]
     ) {
-        super();
+        super(id, relations);
         this.designs = this.filters.map((filter) => filter instanceof AbstractFilterDesign ? filter :
             (FilterUtil.isSimpleFilterConfig(filter) ? SimpleFilterDesign.fromConfig(filter) : CompoundFilterDesign.fromConfig(filter)));
     }
@@ -1476,9 +1526,11 @@ export class BoundsFilterDesign extends CompoundFilterDesign {
         public begin2: any,
         public end1: any,
         public end2: any,
-        public id?: string
+        id?: string,
+        relations?: string[]
     ) {
-        super(CompoundFilterType.AND, BoundsFilterDesign.createFilterConfigs(fieldKey1, fieldKey2, begin1, begin2, end1, end2), id);
+        super(CompoundFilterType.AND, BoundsFilterDesign.createFilterConfigs(fieldKey1, fieldKey2, begin1, begin2, end1, end2), id,
+            relations);
     }
 }
 
@@ -1503,8 +1555,8 @@ export class DomainFilterDesign extends CompoundFilterDesign {
         }] as SimpleFilterConfig[];
     }
 
-    constructor(public fieldKey: string, public begin: any, public end: any, public id?: string) {
-        super(CompoundFilterType.AND, DomainFilterDesign.createFilterConfigs(fieldKey, begin, end), id);
+    constructor(public fieldKey: string, public begin: any, public end: any, id?: string, relations?: string[]) {
+        super(CompoundFilterType.AND, DomainFilterDesign.createFilterConfigs(fieldKey, begin, end), id, relations);
     }
 }
 
@@ -1523,13 +1575,14 @@ export class ListFilterDesign extends CompoundFilterDesign {
     }
 
     constructor(
-        public type: CompoundFilterType,
+        type: CompoundFilterType,
         public fieldKey: string,
         public operator: string,
         public values: any[],
-        public id?: string
+        id?: string,
+        relations?: string[]
     ) {
-        super(type, ListFilterDesign.createFilterConfigs(fieldKey, operator, values), id);
+        super(type, ListFilterDesign.createFilterConfigs(fieldKey, operator, values), id, relations);
     }
 }
 
@@ -1563,16 +1616,17 @@ export class PairFilterDesign extends CompoundFilterDesign {
     }
 
     constructor(
-        public type: CompoundFilterType,
+        type: CompoundFilterType,
         public fieldKey1: string,
         public fieldKey2: string,
         public operator1: any,
         public operator2: any,
         public value1: any,
         public value2: any,
-        public id?: string
+        id?: string,
+        relations?: string[]
     ) {
-        super(type, PairFilterDesign.createFilterConfigs(fieldKey1, fieldKey2, operator1, operator2, value1, value2), id);
+        super(type, PairFilterDesign.createFilterConfigs(fieldKey1, fieldKey2, operator1, operator2, value1, value2), id, relations);
     }
 }
 

--- a/src/app/util/filter.util.ts
+++ b/src/app/util/filter.util.ts
@@ -604,12 +604,8 @@ export class SimpleFilter extends AbstractFilter {
     /**
      * Returns the filtered values for the filter object.
      */
-    public retrieveValues(): FilterValues {
-        return {
-            field: this.field.columnName,
-            operator: this.operator,
-            value: this.value
-        } as OneValue;
+    public retrieveValues(): OneValue {
+        return new OneValue(this.field.columnName, this.operator, this.value);
     }
 
     /**
@@ -830,10 +826,7 @@ export class CompoundFilter extends AbstractFilter {
      * Returns the filtered values for the filter object.
      */
     public retrieveValues(): FilterValues {
-        return {
-            type: this.type,
-            nested: this.filters.reduce((list, filter) => list.concat(filter.retrieveValues()), [])
-        } as CompoundValues;
+        return new CompoundValues(this.type, this.filters.reduce((list, filter) => list.concat(filter.retrieveValues()), []));
     }
 
     /**
@@ -946,14 +939,7 @@ export class BoundsFilter extends CompoundFilter {
      * Returns the filtered values for the filter object.
      */
     public retrieveValues(): BoundsValues {
-        return {
-            begin1: this.begin1,
-            begin2: this.begin2,
-            field1: this.fieldKey1,
-            field2: this.fieldKey2,
-            end1: this.end1,
-            end2: this.end2
-        } as BoundsValues;
+        return new BoundsValues(this.begin1, this.begin2, this.fieldKey1, this.fieldKey2, this.end1, this.end2);
     }
 
     /**
@@ -1051,11 +1037,7 @@ export class DomainFilter extends CompoundFilter {
      * Returns the filtered values for the filter object.
      */
     public retrieveValues(): DomainValues {
-        return {
-            begin: this.begin,
-            field: this.fieldKey,
-            end: this.end
-        } as DomainValues;
+        return new DomainValues(this.begin, this.fieldKey, this.end);
     }
 
     /**
@@ -1157,12 +1139,7 @@ export class ListFilter extends CompoundFilter {
      * Returns the filtered values for the filter object.
      */
     public retrieveValues(): ListOfValues {
-        return {
-            type: this.type,
-            field: this.fieldKey,
-            operator: this.operator,
-            values: this.values
-        } as ListOfValues;
+        return new ListOfValues(this.type, this.fieldKey, this.operator, this.values);
     }
 
     /**
@@ -1279,15 +1256,7 @@ export class PairFilter extends CompoundFilter {
      * Returns the filtered values for the filter object.
      */
     public retrieveValues(): PairOfValues {
-        return {
-            type: this.type,
-            field1: this.fieldKey1,
-            field2: this.fieldKey2,
-            operator1: this.operator1,
-            operator2: this.operator2,
-            value1: this.value1,
-            value2: this.value2
-        } as PairOfValues;
+        return new PairOfValues(this.type, this.fieldKey1, this.fieldKey2, this.operator1, this.operator2, this.value1, this.value2);
     }
 
     /**

--- a/src/app/util/filter.util.ts
+++ b/src/app/util/filter.util.ts
@@ -17,10 +17,12 @@ import { CompoundFilterType } from '../models/widget-option';
 import {
     BoundsValues,
     CompoundFilterConfig,
+    CompoundValues,
     DomainValues,
     FilterConfig,
     FilterDataSource,
     FilterValues,
+    ListOfValues,
     OneValue,
     PairOfValues,
     SimpleFilterConfig
@@ -424,7 +426,7 @@ export abstract class AbstractFilter {
     /**
      * Returns the filtered values for the filter object.
      */
-    public abstract retrieveValues(): FilterValues[];
+    public abstract retrieveValues(): FilterValues;
 
     /**
      * Returns the filter config for the filter object.
@@ -602,12 +604,12 @@ export class SimpleFilter extends AbstractFilter {
     /**
      * Returns the filtered values for the filter object.
      */
-    public retrieveValues(): FilterValues[] {
-        return [{
+    public retrieveValues(): FilterValues {
+        return {
             field: this.field.columnName,
             operator: this.operator,
             value: this.value
-        } as OneValue];
+        } as OneValue;
     }
 
     /**
@@ -827,8 +829,11 @@ export class CompoundFilter extends AbstractFilter {
     /**
      * Returns the filtered values for the filter object.
      */
-    public retrieveValues(): FilterValues[] {
-        return this.filters.reduce((list, filter) => list.concat(filter.retrieveValues()), []);
+    public retrieveValues(): FilterValues {
+        return {
+            type: this.type,
+            nested: this.filters.reduce((list, filter) => list.concat(filter.retrieveValues()), [])
+        } as CompoundValues;
     }
 
     /**
@@ -940,15 +945,15 @@ export class BoundsFilter extends CompoundFilter {
     /**
      * Returns the filtered values for the filter object.
      */
-    public retrieveValues(): BoundsValues[] {
-        return [{
+    public retrieveValues(): BoundsValues {
+        return {
             begin1: this.begin1,
             begin2: this.begin2,
             field1: this.fieldKey1,
             field2: this.fieldKey2,
             end1: this.end1,
             end2: this.end2
-        } as BoundsValues];
+        } as BoundsValues;
     }
 
     /**
@@ -1045,12 +1050,12 @@ export class DomainFilter extends CompoundFilter {
     /**
      * Returns the filtered values for the filter object.
      */
-    public retrieveValues(): DomainValues[] {
-        return [{
+    public retrieveValues(): DomainValues {
+        return {
             begin: this.begin,
             field: this.fieldKey,
             end: this.end
-        } as DomainValues];
+        } as DomainValues;
     }
 
     /**
@@ -1151,12 +1156,13 @@ export class ListFilter extends CompoundFilter {
     /**
      * Returns the filtered values for the filter object.
      */
-    public retrieveValues(): OneValue[] {
-        return this.values.map((value) => ({
+    public retrieveValues(): ListOfValues {
+        return {
+            type: this.type,
             field: this.fieldKey,
             operator: this.operator,
-            value
-        } as OneValue));
+            values: this.values
+        } as ListOfValues;
     }
 
     /**
@@ -1272,15 +1278,16 @@ export class PairFilter extends CompoundFilter {
     /**
      * Returns the filtered values for the filter object.
      */
-    public retrieveValues(): PairOfValues[] {
-        return [{
+    public retrieveValues(): PairOfValues {
+        return {
+            type: this.type,
             field1: this.fieldKey1,
             field2: this.fieldKey2,
             operator1: this.operator1,
             operator2: this.operator2,
             value1: this.value1,
             value2: this.value2
-        } as PairOfValues];
+        } as PairOfValues;
     }
 
     /**


### PR DESCRIPTION
Fixed the bug where, if you remove a filter that has a related filter (for example, by clicking on the X in the Query Bar), the related filter won't be removed too.  I've added the filter ID and the relations to the URL filters.  I've also shortened the length of the filter IDs and the URL filter fragments.