### PR TITLE
THOR-1336 Replaced the Angular Injector with Standard Data Bindings

### DIFF
--- a/src/app/components/aggregation/aggregation.component.spec.ts
+++ b/src/app/components/aggregation/aggregation.component.spec.ts
@@ -14,7 +14,6 @@
  */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { Injector } from '@angular/core';
 import { } from 'jasmine-core';
 
 import { AggregationModule } from './aggregation.module';
@@ -55,8 +54,7 @@ describe('Component: Aggregation', () => {
             InjectableColorThemeService,
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
         ],
         imports: [
             AggregationModule
@@ -91,10 +89,10 @@ describe('Component: Aggregation', () => {
         expect(component.options.notFilterable).toEqual(false);
         expect(component.options.requireAll).toEqual(false);
         expect(component.options.savePrevious).toEqual(false);
-        expect(component.options.scaleMaxX).toEqual(null);
-        expect(component.options.scaleMaxY).toEqual(null);
-        expect(component.options.scaleMinX).toEqual(null);
-        expect(component.options.scaleMinY).toEqual(null);
+        expect(component.options.scaleMaxX).toEqual(undefined);
+        expect(component.options.scaleMaxY).toEqual(undefined);
+        expect(component.options.scaleMinX).toEqual(undefined);
+        expect(component.options.scaleMinY).toEqual(undefined);
         expect(component.options.showHeat).toEqual(false);
         expect(component.options.showLegend).toEqual(true);
         expect(component.options.sortByAggregation).toEqual(false);
@@ -3829,38 +3827,7 @@ describe('Component: Aggregation with config', () => {
             InjectableColorThemeService,
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector,
-            { provide: 'tableKey', useValue: 'table_key_2' },
-            { provide: 'filter', useValue: { lhs: 'testConfigFilterField', operator: '=', rhs: 'testConfigFilterValue' } },
-            { provide: 'limit', useValue: 1234 },
-            { provide: 'title', useValue: 'Test Title' },
-            { provide: 'aggregationField', useValue: 'testSizeField' },
-            { provide: 'groupField', useValue: 'testCategoryField' },
-            { provide: 'xField', useValue: 'testXField' },
-            { provide: 'yField', useValue: 'testYField' },
-            { provide: 'aggregation', useValue: AggregationType.SUM },
-            { provide: 'granularity', useValue: TimeInterval.DAY_OF_MONTH },
-            { provide: 'hideGridLines', useValue: true },
-            { provide: 'hideGridTicks', useValue: true },
-            { provide: 'ignoreSelf', useValue: true },
-            { provide: 'lineCurveTension', useValue: 0 },
-            { provide: 'lineFillArea', useValue: true },
-            { provide: 'logScaleX', useValue: true },
-            { provide: 'logScaleY', useValue: true },
-            { provide: 'notFilterable', useValue: true },
-            { provide: 'requireAll', useValue: true },
-            { provide: 'savePrevious', useValue: true },
-            { provide: 'scaleMaxX', useValue: '44' },
-            { provide: 'scaleMaxY', useValue: '33' },
-            { provide: 'scaleMinX', useValue: '22' },
-            { provide: 'scaleMinY', useValue: '11' },
-            { provide: 'showHeat', useValue: true },
-            { provide: 'showLegend', useValue: true },
-            { provide: 'sortByAggregation', useValue: true },
-            { provide: 'timeFill', useValue: true },
-            { provide: 'type', useValue: 'scatter' },
-            { provide: 'yPercentage', useValue: 0.5 }
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
         ],
         imports: [
             AggregationModule
@@ -3870,6 +3837,38 @@ describe('Component: Aggregation with config', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(AggregationComponent);
         component = fixture.componentInstance;
+        component.configOptions = {
+            tableKey: 'table_key_2',
+            filter: { lhs: 'testConfigFilterField', operator: '=', rhs: 'testConfigFilterValue' },
+            limit: 1234,
+            title: 'Test Title',
+            aggregationField: 'testSizeField',
+            groupField: 'testCategoryField',
+            xField: 'testXField',
+            yField: 'testYField',
+            aggregation: AggregationType.SUM,
+            granularity: TimeInterval.DAY_OF_MONTH,
+            hideGridLines: true,
+            hideGridTicks: true,
+            ignoreSelf: true,
+            lineCurveTension: 0,
+            lineFillArea: true,
+            logScaleX: true,
+            logScaleY: true,
+            notFilterable: true,
+            requireAll: true,
+            savePrevious: true,
+            scaleMaxX: '44',
+            scaleMaxY: '33',
+            scaleMinX: '22',
+            scaleMinY: '11',
+            showHeat: true,
+            showLegend: true,
+            sortByAggregation: true,
+            timeFill: true,
+            type: 'scatter',
+            yPercentage: 0.5
+        };
         fixture.detectChanges();
     });
 
@@ -3930,42 +3929,49 @@ describe('Component: Aggregation with XY config', () => {
             InjectableColorThemeService,
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector,
-            { provide: 'tableKey', useValue: 'table_key_2' },
-            { provide: 'filter', useValue: { lhs: 'testConfigFilterField', operator: '=', rhs: 'testConfigFilterValue' } },
-            { provide: 'limit', useValue: 1234 },
-            { provide: 'title', useValue: 'Test Title' },
-            { provide: 'aggregationField', useValue: 'testSizeField' },
-            { provide: 'groupField', useValue: 'testCategoryField' },
-            { provide: 'xField', useValue: 'testXField' },
-            { provide: 'yField', useValue: 'testYField' },
-            { provide: 'aggregation', useValue: AggregationType.SUM },
-            { provide: 'granularity', useValue: TimeInterval.DAY_OF_MONTH },
-            { provide: 'hideGridLines', useValue: true },
-            { provide: 'hideGridTicks', useValue: true },
-            { provide: 'ignoreSelf', useValue: true },
-            { provide: 'lineCurveTension', useValue: 0 },
-            { provide: 'lineFillArea', useValue: true },
-            { provide: 'logScaleX', useValue: true },
-            { provide: 'logScaleY', useValue: true },
-            { provide: 'notFilterable', useValue: true },
-            { provide: 'requireAll', useValue: true },
-            { provide: 'savePrevious', useValue: true },
-            { provide: 'scaleMaxX', useValue: '44' },
-            { provide: 'scaleMaxY', useValue: '33' },
-            { provide: 'scaleMinX', useValue: '22' },
-            { provide: 'scaleMinY', useValue: '11' },
-            { provide: 'showHeat', useValue: true },
-            { provide: 'showLegend', useValue: true },
-            { provide: 'sortByAggregation', useValue: true },
-            { provide: 'timeFill', useValue: true },
-            { provide: 'type', useValue: 'scatter-xy' },
-            { provide: 'yPercentage', useValue: 0.5 }
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
         ],
         imports: [
             AggregationModule
         ]
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(AggregationComponent);
+        component = fixture.componentInstance;
+        component.configOptions = {
+            tableKey: 'table_key_2',
+            filter: { lhs: 'testConfigFilterField', operator: '=', rhs: 'testConfigFilterValue' },
+            limit: 1234,
+            title: 'Test Title',
+            aggregationField: 'testSizeField',
+            groupField: 'testCategoryField',
+            xField: 'testXField',
+            yField: 'testYField',
+            aggregation: AggregationType.SUM,
+            granularity: TimeInterval.DAY_OF_MONTH,
+            hideGridLines: true,
+            hideGridTicks: true,
+            ignoreSelf: true,
+            lineCurveTension: 0,
+            lineFillArea: true,
+            logScaleX: true,
+            logScaleY: true,
+            notFilterable: true,
+            requireAll: true,
+            savePrevious: true,
+            scaleMaxX: '44',
+            scaleMaxY: '33',
+            scaleMinX: '22',
+            scaleMinY: '11',
+            showHeat: true,
+            showLegend: true,
+            sortByAggregation: true,
+            timeFill: true,
+            type: 'scatter-xy',
+            yPercentage: 0.5
+        };
+        fixture.detectChanges();
     });
 
     it('custom XY class options properties are set to expected values from config', () => {
@@ -4014,12 +4020,6 @@ describe('Component: Aggregation with XY config', () => {
         expect(header).not.toBeNull();
         expect(header.nativeElement.textContent).toContain('Test Title');
     });
-
-    beforeEach(() => {
-        fixture = TestBed.createComponent(AggregationComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-    });
 });
 
 describe('Component: Aggregation with date config', () => {
@@ -4031,38 +4031,7 @@ describe('Component: Aggregation with date config', () => {
             InjectableColorThemeService,
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector,
-            { provide: 'tableKey', useValue: 'table_key_2' },
-            { provide: 'filter', useValue: { lhs: 'testConfigFilterField', operator: '=', rhs: 'testConfigFilterValue' } },
-            { provide: 'limit', useValue: 1234 },
-            { provide: 'title', useValue: 'Test Title' },
-            { provide: 'aggregationField', useValue: 'testSizeField' },
-            { provide: 'groupField', useValue: 'testCategoryField' },
-            { provide: 'xField', useValue: 'testDateField' },
-            { provide: 'yField', useValue: 'testYField' },
-            { provide: 'aggregation', useValue: AggregationType.SUM },
-            { provide: 'granularity', useValue: TimeInterval.DAY_OF_MONTH },
-            { provide: 'hideGridLines', useValue: true },
-            { provide: 'hideGridTicks', useValue: true },
-            { provide: 'ignoreSelf', useValue: true },
-            { provide: 'lineCurveTension', useValue: 0 },
-            { provide: 'lineFillArea', useValue: true },
-            { provide: 'logScaleX', useValue: true },
-            { provide: 'logScaleY', useValue: true },
-            { provide: 'notFilterable', useValue: true },
-            { provide: 'requireAll', useValue: true },
-            { provide: 'savePrevious', useValue: true },
-            { provide: 'scaleMaxX', useValue: '44' },
-            { provide: 'scaleMaxY', useValue: '33' },
-            { provide: 'scaleMinX', useValue: '22' },
-            { provide: 'scaleMinY', useValue: '11' },
-            { provide: 'showHeat', useValue: true },
-            { provide: 'showLegend', useValue: true },
-            { provide: 'sortByAggregation', useValue: true },
-            { provide: 'timeFill', useValue: true },
-            { provide: 'type', useValue: 'scatter' },
-            { provide: 'yPercentage', useValue: 0.5 }
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
         ],
         imports: [
             AggregationModule
@@ -4072,6 +4041,38 @@ describe('Component: Aggregation with date config', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(AggregationComponent);
         component = fixture.componentInstance;
+        component.configOptions = {
+            tableKey: 'table_key_2',
+            filter: { lhs: 'testConfigFilterField', operator: '=', rhs: 'testConfigFilterValue' },
+            limit: 1234,
+            title: 'Test Title',
+            aggregationField: 'testSizeField',
+            groupField: 'testCategoryField',
+            xField: 'testDateField',
+            yField: 'testYField',
+            aggregation: AggregationType.SUM,
+            granularity: TimeInterval.DAY_OF_MONTH,
+            hideGridLines: true,
+            hideGridTicks: true,
+            ignoreSelf: true,
+            lineCurveTension: 0,
+            lineFillArea: true,
+            logScaleX: true,
+            logScaleY: true,
+            notFilterable: true,
+            requireAll: true,
+            savePrevious: true,
+            scaleMaxX: '44',
+            scaleMaxY: '33',
+            scaleMinX: '22',
+            scaleMinY: '11',
+            showHeat: true,
+            showLegend: true,
+            sortByAggregation: true,
+            timeFill: true,
+            type: 'scatter',
+            yPercentage: 0.5
+        };
         fixture.detectChanges();
     });
 

--- a/src/app/components/aggregation/aggregation.component.ts
+++ b/src/app/components/aggregation/aggregation.component.ts
@@ -18,7 +18,6 @@ import {
     ChangeDetectorRef,
     Component,
     ElementRef,
-    Injector,
     OnDestroy,
     OnInit,
     ViewChild,
@@ -196,7 +195,6 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
         dashboardService: DashboardService,
         filterService: InjectableFilterService,
         searchService: AbstractSearchService,
-        injector: Injector,
         ref: ChangeDetectorRef,
         dialog: MatDialog,
         protected colorThemeService: InjectableColorThemeService,
@@ -206,7 +204,6 @@ export class AggregationComponent extends BaseNeonComponent implements OnInit, O
             dashboardService,
             filterService,
             searchService,
-            injector,
             ref,
             dialog
         );

--- a/src/app/components/annotation-viewer/annotation-viewer.component.spec.ts
+++ b/src/app/components/annotation-viewer/annotation-viewer.component.spec.ts
@@ -12,8 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Injector } from '@angular/core';
-
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { } from 'jasmine-core';
 
@@ -40,8 +38,7 @@ describe('Component: AnnotationViewer', () => {
             InjectableColorThemeService,
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
         ],
         imports: [
             AnnotationViewerModule

--- a/src/app/components/annotation-viewer/annotation-viewer.component.ts
+++ b/src/app/components/annotation-viewer/annotation-viewer.component.ts
@@ -17,7 +17,6 @@ import {
     ChangeDetectorRef,
     Component,
     ElementRef,
-    Injector,
     OnDestroy,
     OnInit,
     ViewChild,
@@ -115,7 +114,6 @@ export class AnnotationViewerComponent extends BaseNeonComponent implements OnIn
         dashboardService: DashboardService,
         filterService: InjectableFilterService,
         searchService: AbstractSearchService,
-        injector: Injector,
         ref: ChangeDetectorRef,
         dialog: MatDialog,
         public visualization: ElementRef
@@ -124,7 +122,6 @@ export class AnnotationViewerComponent extends BaseNeonComponent implements OnIn
             dashboardService,
             filterService,
             searchService,
-            injector,
             ref,
             dialog
         );
@@ -697,7 +694,9 @@ export class AnnotationViewerComponent extends BaseNeonComponent implements OnIn
      */
     initializeProperties() {
         // Backwards compatibility (documentLimit deprecated due to its redundancy with limit).
-        this.options.limit = this.injector.get('documentLimit', this.options.limit);
+        if (typeof this.options.documentLimit !== 'undefined') {
+            this.options.limit = this.options.documentLimit;
+        }
     }
 
     /**

--- a/src/app/components/base-neon-component/base-neon.component.spec.ts
+++ b/src/app/components/base-neon-component/base-neon.component.spec.ts
@@ -19,7 +19,6 @@ import {
     Component,
     ChangeDetectionStrategy,
     ChangeDetectorRef,
-    Injector,
     OnInit,
     ViewEncapsulation
 } from '@angular/core';
@@ -73,7 +72,6 @@ class TestBaseNeonComponent extends BaseNeonComponent implements OnInit, OnDestr
         dashboardService: DashboardService,
         filterService: InjectableFilterService,
         searchService: AbstractSearchService,
-        injector: Injector,
         changeDetection: ChangeDetectorRef,
         dialog: MatDialog
     ) {
@@ -81,7 +79,6 @@ class TestBaseNeonComponent extends BaseNeonComponent implements OnInit, OnDestr
             dashboardService,
             filterService,
             searchService,
-            injector,
             changeDetection,
             dialog
         );
@@ -186,7 +183,6 @@ describe('BaseNeonComponent', () => {
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector,
             { provide: ConfigService, useValue: getConfigService(testConfig) },
             { provide: 'testDate', useValue: 'testDateField' },
             { provide: 'testFake', useValue: 'testFakeField' },
@@ -235,7 +231,7 @@ describe('BaseNeonComponent', () => {
         expect(component.options.database).toEqual(DashboardServiceMock.DATABASES.testDatabase1);
         expect(component.options.databases).toEqual(DashboardServiceMock.DATABASES_LIST);
         expect(component.options.fields).toEqual(DashboardServiceMock.FIELDS);
-        expect(component.options.filter).toEqual(null);
+        expect(component.options.filter).toEqual(undefined);
         expect(component.options.hideUnfiltered).toEqual(false);
         expect(component.options.limit).toEqual(1000);
         expect(component.options.table).toEqual(DashboardServiceMock.TABLES.testTable1);
@@ -1642,49 +1638,44 @@ describe('Advanced BaseNeonComponent with config', () => {
             { provide: DashboardService, useValue: dashboardService },
             InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector,
-            { provide: ConfigService, useValue: getConfigService(testConfig) },
-            { provide: 'configFilter', useValue: { lhs: 'testConfigField', operator: '!=', rhs: 'testConfigValue' } },
-            { provide: 'contributionKeys', useValue: ['organization1', 'organization2'] },
-            {
-                provide: 'customEventsToPublish',
-                useValue: [{
-                    id: 'testPublishId',
-                    fields: [{
-                        columnName: 'testPublishColumnName',
-                        prettyName: 'testPublishPrettyName'
-                    }]
-                }]
-            },
-            {
-                provide: 'customEventsToReceive',
-                useValue: [{
-                    id: 'testReceiveId',
-                    fields: [{
-                        columnName: 'testReceiveColumnName',
-                        type: 'testReceiveType'
-                    }]
-                }]
-            },
-            { provide: 'hideUnfiltered', useValue: true },
-            { provide: 'limit', useValue: 10 },
-            { provide: 'tableKey', useValue: 'table_key_2' },
-            { provide: 'testArray', useValue: [4, 3, 2, 1] },
-            { provide: 'testFreeText', useValue: 'the quick brown fox jumps over the lazy dog' },
-            { provide: 'testMultipleFields', useValue: ['testXField', 'testYField'] },
-            { provide: 'testMultipleSelect', useValue: ['b', 'c'] },
-            { provide: 'testObject', useValue: { key: 'value' } },
-            { provide: 'testOptionalField', useValue: 'testNameField' },
-            { provide: 'testRequiredField', useValue: 'testSizeField' },
-            { provide: 'testSelect', useValue: 'z' },
-            { provide: 'testToggle', useValue: true },
-            { provide: 'title', useValue: 'VisualizationTitle' }
+            { provide: ConfigService, useValue: getConfigService(testConfig) }
         ]
     });
 
     beforeEach(() => {
         fixture = TestBed.createComponent(TestAdvancedNeonComponent);
         component = fixture.componentInstance;
+        component.configOptions = {
+            configFilter: { lhs: 'testConfigField', operator: '!=', rhs: 'testConfigValue' },
+            contributionKeys: ['organization1', 'organization2'],
+            customEventsToPublish: [{
+                id: 'testPublishId',
+                fields: [{
+                    columnName: 'testPublishColumnName',
+                    prettyName: 'testPublishPrettyName'
+                }]
+            }],
+            customEventsToReceive: [{
+                id: 'testReceiveId',
+                fields: [{
+                    columnName: 'testReceiveColumnName',
+                    type: 'testReceiveType'
+                }]
+            }],
+            hideUnfiltered: true,
+            limit: 10,
+            tableKey: 'table_key_2',
+            testArray: [4, 3, 2, 1],
+            testFreeText: 'the quick brown fox jumps over the lazy dog',
+            testMultipleFields: ['testXField', 'testYField'],
+            testMultipleSelect: ['b', 'c'],
+            testObject: { key: 'value' },
+            testOptionalField: 'testNameField',
+            testRequiredField: 'testSizeField',
+            testSelect: 'z',
+            testToggle: true,
+            title: 'VisualizationTitle'
+        };
         fixture.detectChanges();
     });
 

--- a/src/app/components/base-neon-component/base-neon.component.ts
+++ b/src/app/components/base-neon-component/base-neon.component.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AfterViewInit, ChangeDetectorRef, Injector, OnDestroy, OnInit } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Input, OnDestroy, OnInit } from '@angular/core';
 
 import {
     AbstractSearchService,
@@ -41,13 +41,6 @@ import { MatDialogRef, MatDialog } from '@angular/material';
 import { DynamicDialogComponent } from '../dynamic-dialog/dynamic-dialog.component';
 import { RequestWrapper } from '../../library/core/services/connection.service';
 import { DashboardState } from '../../models/dashboard-state';
-
-export class InjectorOptionConfig extends OptionConfig {
-    public get(bindingKey: string, defaultValue: any): any {
-        // Assume config is an Angular Injector
-        return this.config.get(bindingKey, defaultValue);
-    }
-}
 
 /**
  * @class BaseNeonComponent
@@ -87,6 +80,7 @@ export abstract class BaseNeonComponent implements AfterViewInit, OnInit, OnDest
     protected lastPage: boolean = true;
     protected page: number = 1;
 
+    @Input() configOptions: { [key: string]: any };
     public options: RootWidgetOptionCollection & { [key: string]: any };
 
     private contributorsRef: MatDialogRef<DynamicDialogComponent>;
@@ -97,7 +91,6 @@ export abstract class BaseNeonComponent implements AfterViewInit, OnInit, OnDest
         protected dashboardService: DashboardService,
         protected filterService: InjectableFilterService,
         protected searchService: AbstractSearchService,
-        protected injector: Injector,
         public changeDetection: ChangeDetectorRef,
         public dialog: MatDialog
     ) {
@@ -123,7 +116,8 @@ export abstract class BaseNeonComponent implements AfterViewInit, OnInit, OnDest
     public ngOnInit(): void {
         this.initializing = true;
 
-        this.options = this.createWidgetOptions(this.injector, this.getVisualizationDefaultTitle(), this.getVisualizationDefaultLimit());
+        this.options = this.createWidgetOptions(this.configOptions, this.getVisualizationDefaultTitle(),
+            this.getVisualizationDefaultLimit());
         this.options.title = this.getVisualizationTitle(this.options.title);
         this.id = this.options._id;
 
@@ -958,15 +952,10 @@ export abstract class BaseNeonComponent implements AfterViewInit, OnInit, OnDest
 
     /**
      * Creates and returns the options for the visualization with the given title and limit.
-     *
-     * @arg {Injector} injector
-     * @arg {string} visualizationTitle
-     * @arg {number} defaultLimit
-     * @return {any}
      */
-    private createWidgetOptions(injector: Injector, visualizationTitle: string, defaultLimit: number): any {
+    private createWidgetOptions(configOptions: any, visualizationTitle: string, defaultLimit: number): any {
         let options = new RootWidgetOptionCollection(this.dataset, this.createOptions.bind(this), this.createOptionsForLayer.bind(this),
-            visualizationTitle, defaultLimit, this.shouldCreateDefaultLayer(), new InjectorOptionConfig(injector));
+            visualizationTitle, defaultLimit, this.shouldCreateDefaultLayer(), new OptionConfig(configOptions));
 
         this.layerIdToQueryIdToQueryObject.set(options._id, new Map<string, RequestWrapper>());
 
@@ -1114,16 +1103,14 @@ export abstract class BaseNeonComponent implements AfterViewInit, OnInit, OnDest
 
     protected getContributorsForComponent() {
         let allContributors = this.dashboardState.dashboard.contributors;
-        let contributorKeys = this.options.contributionKeys !== null ? this.options.contributionKeys :
-            Object.keys(allContributors);
+        let contributorKeys = this.options.contributionKeys || Object.keys(allContributors);
 
         return contributorKeys.filter((key) => !!allContributors[key]).map((key) => allContributors[key]);
     }
 
     protected getContributorAbbreviations() {
         let contributors = this.dashboardState.dashboard.contributors;
-        let contributorKeys = this.options.contributionKeys !== null ? this.options.contributionKeys :
-            Object.keys(contributors);
+        let contributorKeys = this.options.contributionKeys || Object.keys(contributors);
 
         let contributorAbbreviations = contributorKeys.filter((key) =>
             !!(contributors[key] && contributors[key].abbreviation)).map((key) => contributors[key].abbreviation);

--- a/src/app/components/data-table/data-table.component.spec.ts
+++ b/src/app/components/data-table/data-table.component.spec.ts
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Injector } from '@angular/core';
 
 import { } from 'jasmine-core';
 
@@ -42,8 +41,7 @@ describe('Component: DataTable', () => {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
         ],
         imports: [
             DataTableModule

--- a/src/app/components/data-table/data-table.component.ts
+++ b/src/app/components/data-table/data-table.component.ts
@@ -17,7 +17,6 @@ import {
     ChangeDetectorRef,
     Component,
     ElementRef,
-    Injector,
     OnDestroy,
     OnInit,
     ViewChild,
@@ -98,7 +97,6 @@ export class DataTableComponent extends BaseNeonComponent implements OnInit, OnD
         dashboardService: DashboardService,
         filterService: InjectableFilterService,
         searchService: AbstractSearchService,
-        injector: Injector,
         ref: ChangeDetectorRef,
         dialog: MatDialog,
         public visualization: ElementRef
@@ -107,7 +105,6 @@ export class DataTableComponent extends BaseNeonComponent implements OnInit, OnD
             dashboardService,
             filterService,
             searchService,
-            injector,
             ref,
             dialog
         );

--- a/src/app/components/document-viewer/document-viewer.component.spec.ts
+++ b/src/app/components/document-viewer/document-viewer.component.spec.ts
@@ -16,7 +16,6 @@ import { By } from '@angular/platform-browser';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FilterCollection } from '../../library/core/models/filters';
 import { DatabaseConfig, FieldConfig, TableConfig } from '../../library/core/models/dataset';
-import { Injector } from '@angular/core';
 
 import { DocumentViewerComponent } from './document-viewer.component';
 
@@ -42,8 +41,7 @@ describe('Component: DocumentViewer', () => {
                 useClass: DashboardServiceMock
             },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
         ],
         imports: [
             DocumentViewerModule
@@ -881,32 +879,7 @@ describe('Component: Document Viewer with Config', () => {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector,
-            { provide: 'title', useValue: 'Document Viewer Title' },
-            { provide: 'tableKey', useValue: 'table_key_1' },
-            { provide: 'dataField', useValue: 'testTextField' },
-            { provide: 'dateField', useValue: 'testDateField' },
-            { provide: 'idField', useValue: 'testIdField' },
-            {
-                provide: 'metadataFields',
-                useValue: [
-                    [{
-                        name: 'Single Item Metadata Row',
-                        field: 'singleItemMetadataRow'
-                    }],
-                    [{
-                        name: 'First of Multiple Item Metadata Row',
-                        field: 'firstOfMultipleItemMetadataRow'
-                    },
-                    {
-                        name: 'Second of Multiple Item Metadata Row',
-                        field: 'secondOfMultipleItemMetadataRow'
-                    }]
-                ]
-            },
-            { provide: 'popoutFields', useValue: [] },
-            { provide: 'limit', useValue: 25 }
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
         ],
         imports: [
             DocumentViewerModule
@@ -916,6 +889,29 @@ describe('Component: Document Viewer with Config', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(DocumentViewerComponent);
         component = fixture.componentInstance;
+        component.configOptions = {
+            title: 'Document Viewer Title',
+            tableKey: 'table_key_1',
+            dataField: 'testTextField',
+            dateField: 'testDateField',
+            idField: 'testIdField',
+            metadataFields: [
+                [{
+                    name: 'Single Item Metadata Row',
+                    field: 'singleItemMetadataRow'
+                }],
+                [{
+                    name: 'First of Multiple Item Metadata Row',
+                    field: 'firstOfMultipleItemMetadataRow'
+                },
+                {
+                    name: 'Second of Multiple Item Metadata Row',
+                    field: 'secondOfMultipleItemMetadataRow'
+                }]
+            ],
+            popoutFields: [],
+            limit: 25
+        };
         fixture.detectChanges();
     });
 

--- a/src/app/components/document-viewer/document-viewer.component.ts
+++ b/src/app/components/document-viewer/document-viewer.component.ts
@@ -17,7 +17,6 @@ import {
     ChangeDetectorRef,
     Component,
     ElementRef,
-    Injector,
     OnDestroy,
     OnInit,
     ViewChild,
@@ -66,7 +65,6 @@ export class DocumentViewerComponent extends BaseNeonComponent implements OnInit
         dashboardService: DashboardService,
         filterService: InjectableFilterService,
         searchService: AbstractSearchService,
-        injector: Injector,
         public viewContainerRef: ViewContainerRef,
         ref: ChangeDetectorRef,
         public dialog: MatDialog,
@@ -76,7 +74,6 @@ export class DocumentViewerComponent extends BaseNeonComponent implements OnInit
             dashboardService,
             filterService,
             searchService,
-            injector,
             ref,
             dialog
         );
@@ -91,8 +88,10 @@ export class DocumentViewerComponent extends BaseNeonComponent implements OnInit
      */
     initializeProperties() {
         // Backwards compatibility (sortOrder deprecated and replaced by sortDescending).
-        let sortOrder = this.injector.get('sortOrder', null);
-        this.options.sortDescending = sortOrder ? (sortOrder === 'DESCENDING') : this.options.sortDescending;
+        if (typeof this.options.sortOrder !== 'undefined') {
+            let sortOrder = this.options.sortOrder;
+            this.options.sortDescending = sortOrder ? (sortOrder === 'DESCENDING') : this.options.sortDescending;
+        }
     }
 
     /**

--- a/src/app/components/filter-builder/filter-builder.component.ts
+++ b/src/app/components/filter-builder/filter-builder.component.ts
@@ -108,9 +108,11 @@ export class FilterBuilderComponent {
      * @arg {FilterClauseMetaData} filterClause
      */
     public handleChangeDatabaseOfClause(filterClause: FilterClauseMetaData): void {
-        filterClause.database = filterClause.changeDatabase;
-        filterClause.updateTables(this._dataset);
-        filterClause.changeTable = filterClause.table;
+        if (filterClause.changeDatabase && filterClause.changeDatabase.name) {
+            filterClause.database = filterClause.changeDatabase;
+            filterClause.updateTables(this._dataset);
+            filterClause.changeTable = filterClause.table;
+        }
     }
 
     /**
@@ -128,7 +130,9 @@ export class FilterBuilderComponent {
      * @arg {FilterClauseMetaData} filterClause
      */
     public handleChangeFieldOfClause(filterClause: FilterClauseMetaData): void {
-        filterClause.field = filterClause.changeField;
+        if (filterClause.changeField && filterClause.changeField.columnName) {
+            filterClause.field = filterClause.changeField;
+        }
     }
 
     /**
@@ -137,8 +141,10 @@ export class FilterBuilderComponent {
      * @arg {FilterClauseMetaData} filterClause
      */
     public handleChangeTableOfClause(filterClause: FilterClauseMetaData): void {
-        filterClause.table = filterClause.changeTable;
-        filterClause.updateFields();
+        if (filterClause.changeTable && filterClause.changeTable.name) {
+            filterClause.table = filterClause.changeTable;
+            filterClause.updateFields();
+        }
     }
 
     /**

--- a/src/app/components/map/map.component.spec.ts
+++ b/src/app/components/map/map.component.spec.ts
@@ -17,7 +17,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     ElementRef,
-    Injector,
     ViewEncapsulation
 } from '@angular/core';
 
@@ -60,10 +59,6 @@ class TestMapComponent extends MapComponent {
         this.options.type = -1;
         this.mapObject = new TestMap();
         return this.mapObject;
-    }
-
-    getInjector(): Injector {
-        return this.injector;
     }
 
     getMapPoints(databaseName: string, tableName: string, idField: string, filterFields: FieldConfig[], lngField: string,
@@ -187,9 +182,7 @@ describe('Component: Map', () => {
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector,
             InjectableColorThemeService
-
         ],
         imports: [
             CommonWidgetModule,
@@ -205,19 +198,19 @@ describe('Component: Map', () => {
 
     it('does have expected default options', () => {
         expect(component.options.clusterPixelRange).toEqual(15);
-        expect(component.options.customServer).toEqual(null);
+        expect(component.options.customServer).toEqual(undefined);
         expect(component.options.disableCtrlZoom).toEqual(false);
-        expect(component.options.hoverSelect).toEqual(null);
+        expect(component.options.hoverSelect).toEqual(undefined);
         expect(component.options.limit).toEqual(1000);
         expect(component.options.minClusterSize).toEqual(5);
         expect(component.options.singleColor).toEqual(false);
         expect(component.options.title).toEqual('Map');
         expect(component.options.type).toEqual(MapType.Leaflet);
 
-        expect(component.options.west).toEqual(null);
-        expect(component.options.east).toEqual(null);
-        expect(component.options.north).toEqual(null);
-        expect(component.options.south).toEqual(null);
+        expect(component.options.west).toEqual(undefined);
+        expect(component.options.east).toEqual(undefined);
+        expect(component.options.north).toEqual(undefined);
+        expect(component.options.south).toEqual(undefined);
     });
 
     it('does have expected public properties', () => {
@@ -947,33 +940,7 @@ describe('Component: Map with config', () => {
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector,
-            InjectableColorThemeService,
-            { provide: 'tableKey', useValue: 'table_key_1' },
-            {
-                provide: 'layers',
-                useValue: [{
-                    colorField: 'testColorField',
-                    hoverPopupField: 'testHoverField',
-                    dateField: 'testDateField',
-                    latitudeField: 'testLatitudeField',
-                    longitudeField: 'testLongitudeField',
-                    sizeField: 'testSizeField',
-                    title: 'Test Layer Title'
-                }]
-            },
-            { provide: 'limit', useValue: 9999 },
-            { provide: 'clusterPixelRange', useValue: 20 },
-            { provide: 'customServer', useValue: { mapUrl: 'testUrl', layer: 'testLayer' } },
-            { provide: 'disableCtrlZoom', useValue: true },
-            { provide: 'hoverSelect', useValue: { hoverTime: 5 } },
-            { provide: 'minClusterSize', useValue: 10 },
-            { provide: 'singleColor', useValue: true },
-            { provide: 'west', useValue: 1 },
-            { provide: 'east', useValue: 2 },
-            { provide: 'south', useValue: 3 },
-            { provide: 'north', useValue: 4 },
-            { provide: 'title', useValue: 'Test Title' }
+            InjectableColorThemeService
         ],
         imports: [
             CommonWidgetModule,
@@ -984,6 +951,30 @@ describe('Component: Map with config', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(TestMapComponent);
         component = fixture.componentInstance;
+        component.configOptions = {
+            tableKey: 'table_key_1',
+            layers: [{
+                colorField: 'testColorField',
+                hoverPopupField: 'testHoverField',
+                dateField: 'testDateField',
+                latitudeField: 'testLatitudeField',
+                longitudeField: 'testLongitudeField',
+                sizeField: 'testSizeField',
+                title: 'Test Layer Title'
+            }],
+            limit: 9999,
+            clusterPixelRange: 20,
+            customServer: { mapUrl: 'testUrl', layer: 'testLayer' },
+            disableCtrlZoom: true,
+            hoverSelect: { hoverTime: 5 },
+            minClusterSize: 10,
+            singleColor: true,
+            west: 1,
+            east: 2,
+            south: 3,
+            north: 4,
+            title: 'Test Title'
+        };
         fixture.detectChanges();
     });
 

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -18,7 +18,6 @@ import {
     ChangeDetectorRef,
     Component,
     ElementRef,
-    Injector,
     OnDestroy,
     OnInit,
     ViewChild,
@@ -108,7 +107,6 @@ export class MapComponent extends BaseNeonComponent implements OnInit, OnDestroy
         dashboardService: DashboardService,
         filterService: InjectableFilterService,
         searchService: AbstractSearchService,
-        injector: Injector,
         protected colorThemeService: InjectableColorThemeService,
         ref: ChangeDetectorRef,
         dialog: MatDialog,
@@ -118,7 +116,6 @@ export class MapComponent extends BaseNeonComponent implements OnInit, OnDestroy
             dashboardService,
             filterService,
             searchService,
-            injector,
             ref,
             dialog
         );
@@ -151,7 +148,9 @@ export class MapComponent extends BaseNeonComponent implements OnInit, OnDestroy
      */
     initializeProperties() {
         // Backwards compatibility (mapType deprecated and replaced by type).
-        this.options.type = this.injector.get('mapType', this.options.type);
+        if (typeof this.options.mapType !== 'undefined') {
+            this.options.type = this.options.mapType;
+        }
     }
 
     /**

--- a/src/app/components/map/map.type.abstract.ts
+++ b/src/app/components/map/map.type.abstract.ts
@@ -116,7 +116,9 @@ export abstract class AbstractMap {
 
     // Utility
     areBoundsSet() {
-        return this.mapOptions.west !== null && this.mapOptions.east !== null &&
+        return typeof this.mapOptions.west !== 'undefined' && typeof this.mapOptions.east !== 'undefined' &&
+            typeof this.mapOptions.north !== 'undefined' && typeof this.mapOptions.south !== 'undefined' &&
+            this.mapOptions.west !== null && this.mapOptions.east !== null &&
             this.mapOptions.north !== null && this.mapOptions.south !== null;
     }
 }

--- a/src/app/components/media-viewer/media-viewer.component.spec.ts
+++ b/src/app/components/media-viewer/media-viewer.component.spec.ts
@@ -16,7 +16,6 @@ import { By } from '@angular/platform-browser';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { DatabaseConfig, FieldConfig, TableConfig } from '../../library/core/models/dataset';
 import { MediaTypes } from '../../models/types';
-import { Injector } from '@angular/core';
 
 import { } from 'jasmine-core';
 
@@ -38,11 +37,9 @@ describe('Component: MediaViewer', () => {
 
     initializeTestBed('Media Viewer', {
         providers: [
-            DashboardService,
+            { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector
-
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
         ],
         imports: [
             MediaViewerModule
@@ -671,21 +668,7 @@ describe('Component: MediaViewer with config', () => {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector,
-            { provide: 'title', useValue: 'Test Title' },
-            { provide: 'tableKey', useValue: 'table_key_1' },
-            { provide: 'idField', useValue: 'testIdField' },
-            { provide: 'linkField', useValue: 'testLinkField' },
-            { provide: 'nameField', useValue: 'testNameField' },
-            { provide: 'typeField', useValue: 'testTypeField' },
-            { provide: 'border', useValue: 'grey' },
-            { provide: 'linkPrefix', useValue: 'prefix/' },
-            { provide: 'id', useValue: 'testId' },
-            { provide: 'resize', useValue: false },
-            { provide: 'typeMap', useValue: { jpg: 'img' } },
-            { provide: 'url', useValue: 'https://kafka.apache.org/intro' },
-            { provide: 'autoplay', useValue: true }
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
         ],
         imports: [
             MediaViewerModule
@@ -695,6 +678,21 @@ describe('Component: MediaViewer with config', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(MediaViewerComponent);
         component = fixture.componentInstance;
+        component.configOptions = {
+            title: 'Test Title',
+            tableKey: 'table_key_1',
+            idField: 'testIdField',
+            linkField: 'testLinkField',
+            nameField: 'testNameField',
+            typeField: 'testTypeField',
+            border: 'grey',
+            linkPrefix: 'prefix/',
+            id: 'testId',
+            resize: false,
+            typeMap: { jpg: 'img' },
+            url: 'https://kafka.apache.org/intro',
+            autoplay: true
+        };
         fixture.detectChanges();
     });
 

--- a/src/app/components/media-viewer/media-viewer.component.ts
+++ b/src/app/components/media-viewer/media-viewer.component.ts
@@ -17,7 +17,6 @@ import {
     ChangeDetectorRef,
     Component,
     ElementRef,
-    Injector,
     OnDestroy,
     OnInit,
     ViewChild,
@@ -89,7 +88,6 @@ export class MediaViewerComponent extends BaseNeonComponent implements OnInit, O
         dashboardService: DashboardService,
         filterService: InjectableFilterService,
         searchService: AbstractSearchService,
-        injector: Injector,
         ref: ChangeDetectorRef,
         private sanitizer: DomSanitizer,
         dialog: MatDialog,
@@ -99,7 +97,6 @@ export class MediaViewerComponent extends BaseNeonComponent implements OnInit, O
             dashboardService,
             filterService,
             searchService,
-            injector,
             ref,
             dialog
         );

--- a/src/app/components/network-graph/network-graph.component.spec.ts
+++ b/src/app/components/network-graph/network-graph.component.spec.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { CUSTOM_ELEMENTS_SCHEMA, Injector } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { NetworkGraphComponent } from './network-graph.component';
 import { DashboardService } from '../../services/dashboard.service';
 import { FieldConfig } from '../../library/core/models/dataset';
@@ -38,10 +38,8 @@ describe('Component: NetworkGraph', () => {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            Injector,
             { provide: AbstractSearchService, useClass: SearchServiceMock },
-            InjectableColorThemeService,
-            { provide: 'limit', useValue: 'testLimit' }
+            InjectableColorThemeService
         ],
         imports: [
             NetworkGraphModule
@@ -69,7 +67,7 @@ describe('Component: NetworkGraph', () => {
         expect(component.options.edgeColor).toEqual('#2b7ce9');
         expect(component.options.fontColor).toEqual('#343434');
         expect(component.options.edgeWidth).toEqual(1);
-        expect(component.options.limit).toEqual('testLimit');
+        expect(component.options.limit).toEqual(500000);
         expect(component.options.filterFields).toEqual([]);
         expect(component.options.physics).toEqual(true);
         expect(component.options.filterable).toEqual(false);

--- a/src/app/components/network-graph/network-graph.component.ts
+++ b/src/app/components/network-graph/network-graph.component.ts
@@ -18,7 +18,6 @@ import {
     ChangeDetectorRef,
     Component,
     ElementRef,
-    Injector,
     OnDestroy,
     OnInit,
     ViewChild,
@@ -241,7 +240,6 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
         dashboardService: DashboardService,
         filterService: InjectableFilterService,
         searchService: AbstractSearchService,
-        injector: Injector,
         protected colorThemeService: InjectableColorThemeService,
         ref: ChangeDetectorRef,
         dialog: MatDialog,
@@ -251,7 +249,6 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
             dashboardService,
             filterService,
             searchService,
-            injector,
             ref,
             dialog
         );
@@ -275,7 +272,9 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
      */
     initializeProperties() {
         // Backwards compatibility (showOnlyFiltered deprecated due to its redundancy with hideUnfiltered).
-        this.options.hideUnfiltered = this.injector.get('showOnlyFiltered', this.options.hideUnfiltered);
+        if (typeof this.options.showOnlyFiltered !== 'undefined') {
+            this.options.hideUnfiltered = this.options.showOnlyFiltered;
+        }
 
         this.displayGraph = !this.options.hideUnfiltered;
     }
@@ -1437,10 +1436,10 @@ export class NetworkGraphComponent extends BaseNeonComponent implements OnInit, 
     }
 
     resetColors() {
-        this.options.linkColor = this.injector.get('linkColor', NetworkGraphComponent.DEFAULT_NODE_COLOR);
-        this.options.nodeColor = this.injector.get('nodeColor', NetworkGraphComponent.DEFAULT_NODE_COLOR);
-        this.options.edgeColor = this.injector.get('edgeColor', NetworkGraphComponent.DEFAULT_EDGE_COLOR);
-        this.options.fontColor = this.injector.get('fontColor', NetworkGraphComponent.DEFAULT_FONT_COLOR);
+        this.options.linkColor = this.options.access('linkColor').valueDefault;
+        this.options.nodeColor = this.options.access('nodeColor').valueDefault;
+        this.options.edgeColor = this.options.access('edgeColor').valueDefault;
+        this.options.fontColor = this.options.access('fontColor').valueDefault;
         this.reloadGraph();
     }
 }

--- a/src/app/components/news-feed/news-feed.component.spec.ts
+++ b/src/app/components/news-feed/news-feed.component.spec.ts
@@ -14,7 +14,6 @@
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DatabaseConfig, FieldConfig, TableConfig } from '../../library/core/models/dataset';
-import { Injector } from '@angular/core';
 
 import { } from 'jasmine-core';
 
@@ -39,9 +38,7 @@ describe('Component: NewsFeed', () => {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector
-
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
         ],
         imports: [
             NewsFeedModule
@@ -57,7 +54,7 @@ describe('Component: NewsFeed', () => {
 
     // Checks if all class properties are there
     it('does have expected class options properties', () => {
-        expect(component.options.id).toEqual(null);
+        expect(component.options.id).toEqual(undefined);
         expect(component.options.ignoreSelf).toEqual(false);
         expect(component.options.contentField).toEqual(FieldConfig.get());
         expect(component.options.secondaryContentField).toEqual(FieldConfig.get());

--- a/src/app/components/news-feed/news-feed.component.ts
+++ b/src/app/components/news-feed/news-feed.component.ts
@@ -17,7 +17,6 @@ import {
     ChangeDetectorRef,
     Component,
     ElementRef,
-    Injector,
     OnDestroy,
     OnInit,
     ViewChild,
@@ -82,7 +81,6 @@ export class NewsFeedComponent extends BaseNeonComponent implements OnInit, OnDe
         dashboardService: DashboardService,
         filterService: InjectableFilterService,
         searchService: AbstractSearchService,
-        injector: Injector,
         ref: ChangeDetectorRef,
         dialog: MatDialog,
         public visualization: ElementRef
@@ -91,7 +89,6 @@ export class NewsFeedComponent extends BaseNeonComponent implements OnInit, OnDe
             dashboardService,
             filterService,
             searchService,
-            injector,
             ref,
             dialog
         );
@@ -339,9 +336,14 @@ export class NewsFeedComponent extends BaseNeonComponent implements OnInit, OnDe
      */
     initializeProperties() {
         // Backwards compatibility (showOnlyFiltered deprecated due to its redundancy with hideUnfiltered).
-        this.options.hideUnfiltered = this.injector.get('showOnlyFiltered', this.options.hideUnfiltered);
+        if (typeof this.options.showOnlyFiltered !== 'undefined') {
+            this.options.hideUnfiltered = this.options.showOnlyFiltered;
+        }
+
         // Backwards compatibility (ascending deprecated and replaced by sortDescending).
-        this.options.sortDescending = !(this.injector.get('ascending', !this.options.sortDescending));
+        if (typeof this.options.ascending !== 'undefined') {
+            this.options.sortDescending = !this.options.ascending;
+        }
     }
 
     /**

--- a/src/app/components/query-bar/query-bar.component.ts
+++ b/src/app/components/query-bar/query-bar.component.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 import { Observable } from 'rxjs';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Injector, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, ViewChild } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { map, startWith } from 'rxjs/operators';
 
@@ -66,7 +66,6 @@ export class QueryBarComponent extends BaseNeonComponent {
         dashboardService: DashboardService,
         filterService: InjectableFilterService,
         searchService: AbstractSearchService,
-        injector: Injector,
         protected colorThemeService: InjectableColorThemeService,
         ref: ChangeDetectorRef,
         dialog: MatDialog
@@ -75,7 +74,6 @@ export class QueryBarComponent extends BaseNeonComponent {
             dashboardService,
             filterService,
             searchService,
-            injector,
             ref,
             dialog
         );

--- a/src/app/components/sample/sample.component.spec.ts
+++ b/src/app/components/sample/sample.component.spec.ts
@@ -14,7 +14,7 @@
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Injector, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, ViewEncapsulation } from '@angular/core';
 import { } from 'jasmine-core';
 
 import { SampleComponent } from './sample.component';
@@ -83,7 +83,6 @@ class TestSampleComponent extends SampleComponent {
         dashboardService: DashboardService,
         filterService: InjectableFilterService,
         searchService: AbstractSearchService,
-        injector: Injector,
         ref: ChangeDetectorRef,
         dialog: MatDialog,
         visualization: ElementRef
@@ -92,7 +91,6 @@ class TestSampleComponent extends SampleComponent {
             dashboardService,
             filterService,
             searchService,
-            injector,
             ref,
             dialog,
             visualization
@@ -132,8 +130,7 @@ describe('Component: Sample', () => {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
 
         ],
         imports: [
@@ -524,19 +521,7 @@ describe('Component: Sample with config', () => {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector,
-            { provide: 'customEventsToPublish', useValue: [{ id: 'test_publish_event', fields: [{ columnName: 'testPublishField' }] }] },
-            { provide: 'customEventsToReceive', useValue: [{ id: 'test_receive_event', fields: [{ columnName: 'testReceiveField' }] }] },
-            { provide: 'filter', useValue: { lhs: 'testConfigFilterField', operator: '=', rhs: 'testConfigFilterValue' } },
-            { provide: 'hideUnfiltered', useValue: true },
-            { provide: 'limit', useValue: 1234 },
-            { provide: 'sampleOptionalField', useValue: 'testNameField' },
-            { provide: 'sampleRequiredField', useValue: 'testCategoryField' },
-            { provide: 'sortDescending', useValue: true },
-            { provide: 'subcomponentType', useValue: 'Impl2' },
-            { provide: 'tableKey', useValue: 'table_key_2' },
-            { provide: 'title', useValue: 'Test Title' }
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
         ],
         imports: [
             CommonWidgetModule
@@ -546,6 +531,19 @@ describe('Component: Sample with config', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(TestSampleComponent);
         component = fixture.componentInstance;
+        component.configOptions = {
+            customEventsToPublish: [{ id: 'test_publish_event', fields: [{ columnName: 'testPublishField' }] }],
+            customEventsToReceive: [{ id: 'test_receive_event', fields: [{ columnName: 'testReceiveField' }] }],
+            filter: { lhs: 'testConfigFilterField', operator: '=', rhs: 'testConfigFilterValue' },
+            hideUnfiltered: true,
+            limit: 1234,
+            sampleOptionalField: 'testNameField',
+            sampleRequiredField: 'testCategoryField',
+            sortDescending: true,
+            subcomponentType: 'Impl2',
+            tableKey: 'table_key_2',
+            title: 'Test Title'
+        };
         fixture.detectChanges();
     });
 

--- a/src/app/components/sample/sample.component.ts
+++ b/src/app/components/sample/sample.component.ts
@@ -17,7 +17,6 @@ import {
     ChangeDetectorRef,
     Component,
     ElementRef,
-    Injector,
     OnDestroy,
     OnInit,
     ViewChild,
@@ -76,7 +75,6 @@ export class SampleComponent extends BaseNeonComponent implements OnInit, OnDest
         dashboardService: DashboardService,
         filterService: InjectableFilterService,
         searchService: AbstractSearchService,
-        injector: Injector,
         ref: ChangeDetectorRef,
         dialog: MatDialog,
         public visualization: ElementRef
@@ -85,7 +83,6 @@ export class SampleComponent extends BaseNeonComponent implements OnInit, OnDest
             dashboardService,
             filterService,
             searchService,
-            injector,
             ref,
             dialog
         );

--- a/src/app/components/taxonomy-viewer/taxonomy-viewer.component.spec.ts
+++ b/src/app/components/taxonomy-viewer/taxonomy-viewer.component.spec.ts
@@ -14,7 +14,6 @@
  */
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { Injector } from '@angular/core';
 import { } from 'jasmine-core';
 
 import { AbstractSearchService } from '../../library/core/services/abstract.search.service';
@@ -153,9 +152,7 @@ describe('Component: TaxonomyViewer', () => {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector
-
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
         ],
         imports: [
             TaxonomyViewerModule

--- a/src/app/components/taxonomy-viewer/taxonomy-viewer.component.ts
+++ b/src/app/components/taxonomy-viewer/taxonomy-viewer.component.ts
@@ -17,7 +17,6 @@ import {
     ChangeDetectorRef,
     Component,
     ElementRef,
-    Injector,
     OnDestroy,
     OnInit,
     ViewChild,
@@ -110,7 +109,6 @@ export class TaxonomyViewerComponent extends BaseNeonComponent implements OnInit
         dashboardService: DashboardService,
         filterService: InjectableFilterService,
         searchService: AbstractSearchService,
-        injector: Injector,
         ref: ChangeDetectorRef,
         dialog: MatDialog,
         public visualization: ElementRef
@@ -119,7 +117,6 @@ export class TaxonomyViewerComponent extends BaseNeonComponent implements OnInit
             dashboardService,
             filterService,
             searchService,
-            injector,
             ref,
             dialog
         );

--- a/src/app/components/text-cloud/text-cloud.component.spec.ts
+++ b/src/app/components/text-cloud/text-cloud.component.spec.ts
@@ -16,8 +16,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FilterCollection, ListFilter, ListFilterDesign } from '../../library/core/models/filters';
 import { DatabaseConfig, FieldConfig, TableConfig } from '../../library/core/models/dataset';
 
-import { Injector } from '@angular/core';
-
 import { TextCloudComponent } from './text-cloud.component';
 
 import { AbstractSearchService } from '../../library/core/services/abstract.search.service';
@@ -39,14 +37,9 @@ describe('Component: TextCloud', () => {
     initializeTestBed('Text Cloud', {
         providers: [
             InjectableColorThemeService,
-            {
-                provide: DashboardService,
-                useClass: DashboardServiceMock
-            },
+            { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector
-
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
         ],
         imports: [
             TextCloudModule

--- a/src/app/components/text-cloud/text-cloud.component.ts
+++ b/src/app/components/text-cloud/text-cloud.component.ts
@@ -17,7 +17,6 @@ import {
     ChangeDetectorRef,
     Component,
     ElementRef,
-    Injector,
     OnDestroy,
     OnInit,
     ViewChild,
@@ -66,7 +65,6 @@ export class TextCloudComponent extends BaseNeonComponent implements OnInit, OnD
         dashboardService: DashboardService,
         filterService: InjectableFilterService,
         searchService: AbstractSearchService,
-        injector: Injector,
         ref: ChangeDetectorRef,
         protected colorThemeService: InjectableColorThemeService,
         dialog: MatDialog,
@@ -76,7 +74,6 @@ export class TextCloudComponent extends BaseNeonComponent implements OnInit, OnD
             dashboardService,
             filterService,
             searchService,
-            injector,
             ref,
             dialog
         );
@@ -89,7 +86,11 @@ export class TextCloudComponent extends BaseNeonComponent implements OnInit, OnD
      */
     initializeProperties() {
         // Backwards compatibility (sizeAggregation deprecated and replaced by aggregation).
-        this.options.aggregation = (this.options.aggregation || this.injector.get('sizeAggregation', AggregationType.COUNT)).toLowerCase();
+        if (typeof this.options.sizeAggregation !== 'undefined') {
+            this.options.aggregation = this.options.sizeAggregation;
+        }
+
+        this.options.aggregation = (this.options.aggregation || AggregationType.COUNT).toLowerCase();
     }
 
     /**

--- a/src/app/components/thumbnail-grid/thumbnail-grid.component.spec.ts
+++ b/src/app/components/thumbnail-grid/thumbnail-grid.component.spec.ts
@@ -16,7 +16,6 @@ import { By } from '@angular/platform-browser';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FilterCollection } from '../../library/core/models/filters';
 import { FieldConfig } from '../../library/core/models/dataset';
-import { Injector } from '@angular/core';
 
 import { } from 'jasmine-core';
 
@@ -40,9 +39,7 @@ describe('Component: ThumbnailGrid', () => {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector
-
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
         ],
         imports: [
             ThumbnailGridModule
@@ -757,38 +754,7 @@ describe('Component: ThumbnailGrid with config', () => {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector,
-            { provide: 'filter', useValue: { lhs: 'testConfigFilterField', operator: '=', rhs: 'testConfigFilterValue' } },
-            { provide: 'limit', useValue: 10 },
-            { provide: 'border', useValue: 'percentCompare' },
-            { provide: 'borderCompareValue', useValue: 'Test Compare Value' },
-            { provide: 'borderPercentThreshold', useValue: 0.25 },
-            { provide: 'categoryField', useValue: 'testCategoryField' },
-            { provide: 'compareField', useValue: 'testCategoryField' },
-            { provide: 'cropAndScale', useValue: 'both' },
-            { provide: 'dateField', useValue: 'testDateField' },
-            { provide: 'defaultLabel', useValue: 'testDefaultLabel' },
-            { provide: 'defaultPercent', useValue: 'testDefaultPercent' },
-            { provide: 'filterFields', useValue: ['testFilterField'] },
-            { provide: 'id', useValue: 'testId' },
-            { provide: 'idField', useValue: 'testIdField' },
-            { provide: 'ignoreSelf', useValue: true },
-            { provide: 'linkField', useValue: 'testLinkField' },
-            { provide: 'linkPrefix', useValue: 'prefix/' },
-            { provide: 'nameField', useValue: 'testNameField' },
-            { provide: 'objectIdField', useValue: 'testIdField' },
-            { provide: 'objectNameField', useValue: 'testNameField' },
-            { provide: 'openOnMouseClick', useValue: false },
-            { provide: 'percentField', useValue: 'testSizeField' },
-            { provide: 'predictedNameField', useValue: 'testNameField' },
-            { provide: 'sortDescending', useValue: false },
-            { provide: 'sortField', useValue: 'testSortField' },
-            { provide: 'tableKey', useValue: 'table_key_2' },
-            { provide: 'textMap', useValue: { actual: 'Truth', percentage: 'Score' } },
-            { provide: 'title', useValue: 'Test Title' },
-            { provide: 'typeField', useValue: 'testTypeField' },
-            { provide: 'typeMap', useValue: { jpg: 'img', mov: 'vid' } }
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
         ],
         imports: [
             ThumbnailGridModule
@@ -798,6 +764,38 @@ describe('Component: ThumbnailGrid with config', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(ThumbnailGridComponent);
         component = fixture.componentInstance;
+        component.configOptions = {
+            filter: { lhs: 'testConfigFilterField', operator: '=', rhs: 'testConfigFilterValue' },
+            limit: 10,
+            border: 'percentCompare',
+            borderCompareValue: 'Test Compare Value',
+            borderPercentThreshold: 0.25,
+            categoryField: 'testCategoryField',
+            compareField: 'testCategoryField',
+            cropAndScale: 'both',
+            dateField: 'testDateField',
+            defaultLabel: 'testDefaultLabel',
+            defaultPercent: 'testDefaultPercent',
+            filterFields: ['testFilterField'],
+            id: 'testId',
+            idField: 'testIdField',
+            ignoreSelf: true,
+            linkField: 'testLinkField',
+            linkPrefix: 'prefix/',
+            nameField: 'testNameField',
+            objectIdField: 'testIdField',
+            objectNameField: 'testNameField',
+            openOnMouseClick: false,
+            percentField: 'testSizeField',
+            predictedNameField: 'testNameField',
+            sortDescending: false,
+            sortField: 'testSortField',
+            tableKey: 'table_key_2',
+            textMap: { actual: 'Truth', percentage: 'Score' },
+            title: 'Test Title',
+            typeField: 'testTypeField',
+            typeMap: { jpg: 'img', mov: 'vid' }
+        };
         fixture.detectChanges();
     });
 

--- a/src/app/components/thumbnail-grid/thumbnail-grid.component.ts
+++ b/src/app/components/thumbnail-grid/thumbnail-grid.component.ts
@@ -17,7 +17,6 @@ import {
     ChangeDetectorRef,
     Component,
     ElementRef,
-    Injector,
     OnDestroy,
     OnInit,
     ViewChild,
@@ -83,7 +82,6 @@ export class ThumbnailGridComponent extends BaseNeonComponent implements OnInit,
         dashboardService: DashboardService,
         filterService: InjectableFilterService,
         searchService: AbstractSearchService,
-        injector: Injector,
         ref: ChangeDetectorRef,
         private sanitizer: DomSanitizer,
         dialog: MatDialog,
@@ -93,7 +91,6 @@ export class ThumbnailGridComponent extends BaseNeonComponent implements OnInit,
             dashboardService,
             filterService,
             searchService,
-            injector,
             ref,
             dialog
         );
@@ -521,7 +518,9 @@ export class ThumbnailGridComponent extends BaseNeonComponent implements OnInit,
         }
 
         // Backwards compatibility (showOnlyFiltered deprecated due to its redundancy with hideUnfiltered).
-        this.options.hideUnfiltered = this.injector.get('showOnlyFiltered', this.options.hideUnfiltered);
+        if (typeof this.options.showOnlyFiltered !== 'undefined') {
+            this.options.hideUnfiltered = this.options.showOnlyFiltered;
+        }
 
         // Backwards compatibility (filterField deprecated due to its redundancy with filterFields).
         if (this.options.filterField.columnName && !this.options.filterFields.length) {

--- a/src/app/components/timeline/timeline.component.spec.ts
+++ b/src/app/components/timeline/timeline.component.spec.ts
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Injector } from '@angular/core';
 
 import { } from 'jasmine-core';
 
@@ -41,8 +40,7 @@ describe('Component: Timeline', () => {
             InjectableColorThemeService,
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
         ],
         imports: [
             TimelineModule

--- a/src/app/components/timeline/timeline.component.ts
+++ b/src/app/components/timeline/timeline.component.ts
@@ -18,7 +18,6 @@ import {
     Component,
     ElementRef,
     HostListener,
-    Injector,
     OnDestroy,
     OnInit,
     ViewChild
@@ -95,7 +94,6 @@ export class TimelineComponent extends BaseNeonComponent implements OnInit, OnDe
         dashboardService: DashboardService,
         filterService: InjectableFilterService,
         searchService: AbstractSearchService,
-        injector: Injector,
         ref: ChangeDetectorRef,
         protected colorThemeService: InjectableColorThemeService,
         dialog: MatDialog,
@@ -105,7 +103,6 @@ export class TimelineComponent extends BaseNeonComponent implements OnInit, OnDe
             dashboardService,
             filterService,
             searchService,
-            injector,
             ref,
             dialog
         );
@@ -206,7 +203,9 @@ export class TimelineComponent extends BaseNeonComponent implements OnInit, OnDe
      */
     initializeProperties() {
         // Backwards compatibility (showOnlyFiltered deprecated due to its redundancy with hideUnfiltered).
-        this.options.hideUnfiltered = this.injector.get('showOnlyFiltered', this.options.hideUnfiltered);
+        if (typeof this.options.showOnlyFiltered !== 'undefined') {
+            this.options.hideUnfiltered = this.options.showOnlyFiltered;
+        }
     }
 
     /**

--- a/src/app/components/visualization-injector/visualization-injector.component.ts
+++ b/src/app/components/visualization-injector/visualization-injector.component.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Input, ReflectiveInjector, ViewChild, ViewContainerRef, ComponentRef } from '@angular/core';
+import { Component, ComponentFactoryResolver, Input, ReflectiveInjector, ViewChild, ViewContainerRef, ComponentRef } from '@angular/core';
 import { NeonGridItem } from '../../models/neon-grid-item';
 import { ReactiveComponentLoader } from '@wishtack/reactive-component-loader';
 import { BaseNeonComponent } from '../base-neon-component/base-neon.component';
@@ -43,27 +43,19 @@ export class VisualizationInjectorComponent {
             data.bindings = data.bindings || {};
             data.bindings._id = data.id;
 
-            // Inputs need to be in the following format to be resolved properly
-            let inputProviders = Object.keys(data.bindings).map((bindingKey) => ({
-                provide: bindingKey,
-                useValue: data.bindings[bindingKey]
-            }));
-            let resolvedInputs = ReflectiveInjector.resolve(inputProviders);
+            // Create an injector using an empty array since we'll just save the custom bindings on the widget's configOptions property.
+            let injector = ReflectiveInjector.fromResolvedProviders(ReflectiveInjector.resolve([]),
+                this.dynamicComponentContainer.parentInjector);
 
-            // We create an injector out of the data we want to pass down and this components injector
-            let injector = ReflectiveInjector.fromResolvedProviders(resolvedInputs, this.dynamicComponentContainer.parentInjector);
+            // Use the ngModuleFactory from the component recipe to create the new component.
+            this.currentComponent = this.dynamicComponentContainer.createComponent(input.ngModuleFactory.create(injector)
+                .componentFactoryResolver.resolveComponentFactory<BaseNeonComponent>(input.componentType));
 
-            // We create the component using the factory and the injector
-            this.currentComponent = input.ngModuleFactory.create(injector).componentFactoryResolver
-                .resolveComponentFactory<BaseNeonComponent>(input.componentType)
-                .create(injector);
-
-            // We insert the component into the dom container
-            this.dynamicComponentContainer.insert(this.currentComponent.hostView);
+            this.currentComponent.instance.configOptions = data.bindings;
         });
     }
 
-    constructor(private loader: ReactiveComponentLoader) { }
+    constructor(private loader: ReactiveComponentLoader, private resolver: ComponentFactoryResolver) { }
 
     findVisualizationComponent(type: string) {
         const id = type.replace(/([a-z])([A-Z])/g, (__all, left, right) => `${left}-${right.toLowerCase()}`);

--- a/src/app/components/wiki-viewer/wiki-viewer.component.spec.ts
+++ b/src/app/components/wiki-viewer/wiki-viewer.component.spec.ts
@@ -16,7 +16,6 @@ import { By } from '@angular/platform-browser';
 import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
 import { DatabaseConfig, FieldConfig, TableConfig } from '../../library/core/models/dataset';
 import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
-import { Injector } from '@angular/core';
 
 import { } from 'jasmine-core';
 
@@ -38,10 +37,9 @@ describe('Component: WikiViewer', () => {
 
     initializeTestBed('Wiki Viewer', {
         providers: [
-            DashboardService,
+            { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
 
         ],
         imports: [
@@ -157,10 +155,9 @@ describe('Component: WikiViewer with mock HTTP', () => {
 
     initializeTestBed('Wiki Viewer', {
         providers: [
-            DashboardService,
+            { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
 
         ],
         imports: [
@@ -325,13 +322,7 @@ describe('Component: WikiViewer with config', () => {
         providers: [
             { provide: DashboardService, useClass: DashboardServiceMock },
             InjectableFilterService,
-            { provide: AbstractSearchService, useClass: SearchServiceMock },
-            Injector,
-            { provide: 'tableKey', useValue: 'table_key_1' },
-            { provide: 'id', useValue: 'testId' },
-            { provide: 'idField', useValue: 'testIdField' },
-            { provide: 'linkField', useValue: 'testLinkField' },
-            { provide: 'title', useValue: 'Test Title' }
+            { provide: AbstractSearchService, useClass: SearchServiceMock }
         ],
         imports: [
             WikiViewerModule,
@@ -342,6 +333,13 @@ describe('Component: WikiViewer with config', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(WikiViewerComponent);
         component = fixture.componentInstance;
+        component.configOptions = {
+            tableKey: 'table_key_1',
+            id: 'testId',
+            idField: 'testIdField',
+            linkField: 'testLinkField',
+            title: 'Test Title'
+        };
         fixture.detectChanges();
     });
 

--- a/src/app/components/wiki-viewer/wiki-viewer.component.ts
+++ b/src/app/components/wiki-viewer/wiki-viewer.component.ts
@@ -17,7 +17,6 @@ import {
     ChangeDetectorRef,
     Component,
     ElementRef,
-    Injector,
     OnDestroy,
     OnInit,
     ViewChild,
@@ -73,7 +72,6 @@ export class WikiViewerComponent extends BaseNeonComponent implements OnInit, On
         dashboardService: DashboardService,
         filterService: InjectableFilterService,
         searchService: AbstractSearchService,
-        injector: Injector,
         ref: ChangeDetectorRef,
         protected http: HttpClient,
         protected sanitizer: DomSanitizer,
@@ -84,7 +82,6 @@ export class WikiViewerComponent extends BaseNeonComponent implements OnInit, On
             dashboardService,
             filterService,
             searchService,
-            injector,
             ref,
             dialog
         );

--- a/src/app/library/core/models/config-option.ts
+++ b/src/app/library/core/models/config-option.ts
@@ -98,6 +98,7 @@ export const OptionChoices = {
 export enum OptionType {
     COLOR = 'COLOR',
     DATABASE = 'DATABASE',
+    DATASTORE = 'DATASTORE',
     FIELD = 'FIELD',
     FIELD_ARRAY = 'FIELD_ARRAY',
     FREE_TEXT = 'FREE_TEXT',
@@ -119,7 +120,12 @@ export class ConfigOption {
         public valueDefault: any,
         public valueChoices: OptionChoice[],
         public hideFromMenu: boolean | OptionCallback = false
-    ) { }
+    ) {
+        // Change null to undefined or else the YAML library will consider it a string.
+        if (this.valueDefault === null) {
+            this.valueDefault = undefined;
+        }
+    }
 
     /**
      * Returns the current value to save in the bindings.
@@ -127,7 +133,8 @@ export class ConfigOption {
      * @return {any}
      */
     getValueToSaveInBindings() {
-        return this.valueCurrent;
+        // Change null to undefined or else the YAML library will consider it a string.
+        return this.valueCurrent === null ? undefined : this.valueCurrent;
     }
 }
 
@@ -156,7 +163,25 @@ export class ConfigOptionDatabase extends ConfigOption {
      * @override
      */
     getValueToSaveInBindings() {
-        return this.valueCurrent.name;
+        return this.valueCurrent ? this.valueCurrent.name : undefined;
+    }
+}
+
+export class ConfigOptionDatastore extends ConfigOption {
+    constructor() {
+        // Value default and choices are set elsewhere.
+        // TODO THOR-1047 Show datastore in widget option menu
+        super(OptionType.DATASTORE, true, 'datastore', 'Datastore', undefined, undefined, true);
+    }
+
+    /**
+     * Returns the current value to save in the bindings.
+     *
+     * @return {any}
+     * @override
+     */
+    getValueToSaveInBindings() {
+        return this.valueCurrent ? this.valueCurrent.name : undefined;
     }
 }
 
@@ -339,7 +364,7 @@ export class ConfigOptionTable extends ConfigOption {
      * @override
      */
     getValueToSaveInBindings() {
-        return this.valueCurrent.name;
+        return this.valueCurrent ? this.valueCurrent.name : undefined;
     }
 }
 

--- a/src/app/library/core/models/dataset.spec.ts
+++ b/src/app/library/core/models/dataset.spec.ts
@@ -653,42 +653,6 @@ describe('Dataset Util Misc Tests', () => {
         });
     });
 
-    it('deconstructTableOrFieldKeySafely with key map should work as expected', () => {
-        const keyMap = {
-            key1: 'a.b.c',
-            key2: 'a.b.c.d',
-            key3: 'a.b.c.d.e.f'
-        };
-
-        expect(DatasetUtil.deconstructTableOrFieldKeySafely('key1', keyMap)).toEqual({
-            datastore: 'a',
-            database: 'b',
-            table: 'c',
-            field: ''
-        });
-
-        expect(DatasetUtil.deconstructTableOrFieldKeySafely('key2', keyMap)).toEqual({
-            datastore: 'a',
-            database: 'b',
-            table: 'c',
-            field: 'd'
-        });
-
-        expect(DatasetUtil.deconstructTableOrFieldKeySafely('key3', keyMap)).toEqual({
-            datastore: 'a',
-            database: 'b',
-            table: 'c',
-            field: 'd.e.f'
-        });
-
-        expect(DatasetUtil.deconstructTableOrFieldKeySafely('w.x.y.z', keyMap)).toEqual({
-            datastore: 'w',
-            database: 'x',
-            table: 'y',
-            field: 'z'
-        });
-    });
-
     it('deconstructTableOrFieldKey should work as expected', () => {
         expect(DatasetUtil.deconstructTableOrFieldKey(null)).toEqual(null);
         expect(DatasetUtil.deconstructTableOrFieldKey('')).toEqual(null);

--- a/src/app/library/core/models/dataset.ts
+++ b/src/app/library/core/models/dataset.ts
@@ -323,10 +323,10 @@ export class DatasetUtil {
 
     /**
      * Returns an object containing the datastore/database/table/field in the given tablekey (datastore.database.table) or fieldkey
-     * (datastore.database.table.field) or the given tablekey/fieldkey in the given collection.
+     * (datastore.database.table.field).
      */
-    static deconstructTableOrFieldKeySafely(key: string, keys: Record<string, string> = {}): FieldKey {
-        const [datastore, database, table, ...field] = (keys[key] || key || '').split('.');
+    static deconstructTableOrFieldKeySafely(key: string): FieldKey {
+        const [datastore, database, table, ...field] = (key || '').split('.');
         return {
             datastore: datastore || '',
             database: database || '',
@@ -337,10 +337,10 @@ export class DatasetUtil {
 
     /**
      * Returns an object containing the datastore/database/table/field in the given tablekey (datastore.database.table) or fieldkey
-     * (datastore.database.table.field) or the given tablekey/fieldkey in the given collection, or null if the key is not viable.
+     * (datastore.database.table.field), or null if the key is not viable.
      */
-    static deconstructTableOrFieldKey(key: string, keys: Record<string, string> = {}): FieldKey {
-        const fieldKeyObject: FieldKey = DatasetUtil.deconstructTableOrFieldKeySafely(key, keys);
+    static deconstructTableOrFieldKey(key: string): FieldKey {
+        const fieldKeyObject: FieldKey = DatasetUtil.deconstructTableOrFieldKeySafely(key);
         return (fieldKeyObject.database && fieldKeyObject.table) ? fieldKeyObject : null;
     }
 
@@ -355,7 +355,7 @@ export class DatasetUtil {
      * Returns just the field name for the given field key.
      */
     static translateFieldKeyToFieldName(fieldKey: string, fieldKeys: Record<string, string>): string {
-        return DatasetUtil.deconstructTableOrFieldKeySafely(fieldKey, fieldKeys).field || fieldKey;
+        return DatasetUtil.deconstructTableOrFieldKeySafely(fieldKeys[fieldKey] || fieldKey).field || fieldKey;
     }
 
     /**

--- a/src/app/models/widget-option-collection.spec.ts
+++ b/src/app/models/widget-option-collection.spec.ts
@@ -13,9 +13,10 @@
  * limitations under the License.
  */
 
-import { DatabaseConfig, FieldConfig, TableConfig } from '../library/core/models/dataset';
+import { DatabaseConfig, DatastoreConfig, FieldConfig, TableConfig } from '../library/core/models/dataset';
 import {
     ConfigOptionDatabase,
+    ConfigOptionDatastore,
     ConfigOptionField,
     ConfigOptionFieldArray,
     ConfigOptionFreeText,
@@ -26,7 +27,7 @@ import {
 } from '../library/core/models/config-option';
 import { OptionCollection, OptionConfig, RootWidgetOptionCollection, WidgetOptionCollection } from './widget-option-collection';
 
-import { DATABASES, DATABASES_LIST, DATASET, FIELD_MAP, FIELDS, TABLES, TABLES_LIST } from '../library/core/models/mock.dataset';
+import { DATABASES, DATABASES_LIST, DATASET, DATASTORE, FIELD_MAP, FIELDS, TABLES, TABLES_LIST } from '../library/core/models/mock.dataset';
 
 import * as _ from 'lodash';
 import * as yaml from 'js-yaml';
@@ -35,7 +36,7 @@ describe('OptionCollection', () => {
     let options: OptionCollection;
 
     beforeEach(() => {
-        options = new OptionCollection(new OptionConfig({
+        options = new OptionCollection(DATASET, new OptionConfig({
             keyA: 'provideA',
             keyB: 'provideB',
             testDate: 'testDateField',
@@ -223,11 +224,15 @@ describe('OptionCollection', () => {
     });
 
     it('list does return an array of all widget options', () => {
+        let datastoreOption = new ConfigOptionDatastore();
+        datastoreOption.valueCurrent = DATASTORE;
         let databaseOption = new ConfigOptionDatabase();
         databaseOption.valueCurrent = DatabaseConfig.get();
         let tableOption = new ConfigOptionTable();
         tableOption.valueCurrent = TableConfig.get();
-        expect(options.list()).toEqual([databaseOption, tableOption]);
+        let tableKeyOption = new ConfigOptionFreeText('tableKey', 'Table Key', true, '', true);
+        tableKeyOption.valueCurrent = '';
+        expect(options.list()).toEqual([datastoreOption, databaseOption, tableOption, tableKeyOption]);
 
         let widgetOption1 = new ConfigOptionSelect('key1', 'label1', false, 'default1', []);
         let widgetOption2 = new ConfigOptionSelect('key2', 'label2', false, 'default2', []);
@@ -238,10 +243,12 @@ describe('OptionCollection', () => {
         expect(widgetOption1.valueCurrent).toEqual('current1');
         expect(widgetOption2.valueCurrent).toEqual('current2');
 
-        expect(options.list()).toEqual([databaseOption, tableOption, widgetOption1, widgetOption2]);
+        expect(options.list()).toEqual([datastoreOption, databaseOption, tableOption, tableKeyOption, widgetOption1, widgetOption2]);
     });
 
-    it('updateDatabases does update databases, tables, and fields', () => {
+    it('updateDatabases without config does update databases, tables, and fields', () => {
+        options.datastores = [DATASTORE];
+        options.datastore = DATASTORE;
         options.databases = [];
         options.database = DatabaseConfig.get();
         options.tables = [];
@@ -250,42 +257,155 @@ describe('OptionCollection', () => {
 
         options.updateDatabases(DATASET);
 
+        expect(options.datastores).toEqual([DATASTORE]);
+        expect(options.datastore).toEqual(DATASTORE);
         expect(options.databases).toEqual(DATABASES_LIST);
-        expect(options.database).toEqual(DATABASES.testDatabase1);
+        expect(options.database).toEqual(DATABASES_LIST[0]);
         expect(options.tables).toEqual(TABLES_LIST);
-        expect(options.table).toEqual(TABLES.testTable1);
+        expect(options.table).toEqual(TABLES_LIST[0]);
         expect(options.fields).toEqual(FIELDS);
     });
 
-    it('updateFields does update fields', () => {
+    it('updateDatastores without config does update datastores, databases, tables, and fields', () => {
+        options.datastores = [];
+        options.datastore = DatastoreConfig.get();
+        options.databases = [];
+        options.database = DatabaseConfig.get();
+        options.tables = [];
+        options.table = TableConfig.get();
+        options.fields = [];
+
+        options.updateDatastores(DATASET);
+
+        expect(options.datastores).toEqual([DATASTORE]);
+        expect(options.datastore).toEqual(DATASTORE);
+        expect(options.databases).toEqual(DATABASES_LIST);
+        expect(options.database).toEqual(DATABASES_LIST[0]);
+        expect(options.tables).toEqual(TABLES_LIST);
+        expect(options.table).toEqual(TABLES_LIST[0]);
+        expect(options.fields).toEqual(FIELDS);
+    });
+
+    it('updateFields without config does update fields', () => {
+        options.datastores = [DATASTORE];
+        options.datastore = DATASTORE;
         options.databases = DATABASES_LIST;
-        options.database = DATABASES.testDatabase1;
+        options.database = DATABASES_LIST[0];
         options.tables = TABLES_LIST;
-        options.table = TABLES.testTable1;
+        options.table = TABLES_LIST[0];
         options.fields = [];
 
         options.updateFields();
 
+        expect(options.datastores).toEqual([DATASTORE]);
+        expect(options.datastore).toEqual(DATASTORE);
         expect(options.databases).toEqual(DATABASES_LIST);
-        expect(options.database).toEqual(DATABASES.testDatabase1);
+        expect(options.database).toEqual(DATABASES_LIST[0]);
         expect(options.tables).toEqual(TABLES_LIST);
-        expect(options.table).toEqual(TABLES.testTable1);
+        expect(options.table).toEqual(TABLES_LIST[0]);
         expect(options.fields).toEqual(FIELDS);
     });
 
-    it('updateTables does update tables and fields', () => {
+    it('updateTables without config does update tables and fields', () => {
+        options.datastores = [DATASTORE];
+        options.datastore = DATASTORE;
         options.databases = DATABASES_LIST;
-        options.database = DATABASES.testDatabase1;
+        options.database = DATABASES_LIST[0];
         options.tables = [];
         options.table = TableConfig.get();
         options.fields = [];
 
         options.updateTables(DATASET);
 
+        expect(options.datastores).toEqual([DATASTORE]);
+        expect(options.datastore).toEqual(DATASTORE);
         expect(options.databases).toEqual(DATABASES_LIST);
-        expect(options.database).toEqual(DATABASES.testDatabase1);
+        expect(options.database).toEqual(DATABASES_LIST[0]);
         expect(options.tables).toEqual(TABLES_LIST);
-        expect(options.table).toEqual(TABLES.testTable1);
+        expect(options.table).toEqual(TABLES_LIST[0]);
+        expect(options.fields).toEqual(FIELDS);
+    });
+
+    it('updateDatabases with tableKey does update databases, tables, and fields', () => {
+        options.datastores = [DATASTORE];
+        options.datastore = DATASTORE;
+        options.databases = [];
+        options.database = DatabaseConfig.get();
+        options.tables = [];
+        options.table = TableConfig.get();
+        options.fields = [];
+
+        options.tableKey = 'datastore1.testDatabase2.testTable2';
+        options.updateDatabases(DATASET);
+
+        expect(options.datastores).toEqual([DATASTORE]);
+        expect(options.datastore).toEqual(DATASTORE);
+        expect(options.databases).toEqual(DATABASES_LIST);
+        expect(options.database).toEqual(DATABASES.testDatabase2);
+        expect(options.tables).toEqual(TABLES_LIST);
+        expect(options.table).toEqual(TABLES.testTable2);
+        expect(options.fields).toEqual(FIELDS);
+    });
+
+    it('updateDatastores with tableKey does update databases, tables, and fields', () => {
+        options.datastores = [];
+        options.datastore = DatastoreConfig.get();
+        options.databases = [];
+        options.database = DatabaseConfig.get();
+        options.tables = [];
+        options.table = TableConfig.get();
+        options.fields = [];
+
+        options.tableKey = 'datastore1.testDatabase2.testTable2';
+        options.updateDatastores(DATASET);
+
+        expect(options.datastores).toEqual([DATASTORE]);
+        expect(options.datastore).toEqual(DATASTORE);
+        expect(options.databases).toEqual(DATABASES_LIST);
+        expect(options.database).toEqual(DATABASES.testDatabase2);
+        expect(options.tables).toEqual(TABLES_LIST);
+        expect(options.table).toEqual(TABLES.testTable2);
+        expect(options.fields).toEqual(FIELDS);
+    });
+
+    it('updateFields with tableKey does update fields', () => {
+        options.datastores = [DATASTORE];
+        options.datastore = DATASTORE;
+        options.databases = DATABASES_LIST;
+        options.database = DATABASES.testDatabase2;
+        options.tables = TABLES_LIST;
+        options.table = TABLES.testTable2;
+        options.fields = [];
+
+        options.tableKey = 'datastore1.testDatabase2.testTable2';
+        options.updateFields();
+
+        expect(options.datastores).toEqual([DATASTORE]);
+        expect(options.datastore).toEqual(DATASTORE);
+        expect(options.databases).toEqual(DATABASES_LIST);
+        expect(options.database).toEqual(DATABASES.testDatabase2);
+        expect(options.tables).toEqual(TABLES_LIST);
+        expect(options.table).toEqual(TABLES.testTable2);
+        expect(options.fields).toEqual(FIELDS);
+    });
+
+    it('updateTables with tableKey does update tables and fields', () => {
+        options.datastores = [DATASTORE];
+        options.datastore = DATASTORE;
+        options.databases = DATABASES_LIST;
+        options.database = DATABASES.testDatabase2;
+        options.tables = [];
+        options.table = TableConfig.get();
+        options.fields = [];
+
+        options.tableKey = 'datastore1.testDatabase2.testTable2';
+        options.updateTables(DATASET);
+
+        expect(options.datastore).toEqual(DATASTORE);
+        expect(options.databases).toEqual(DATABASES_LIST);
+        expect(options.database).toEqual(DATABASES.testDatabase2);
+        expect(options.tables).toEqual(TABLES_LIST);
+        expect(options.table).toEqual(TABLES.testTable2);
         expect(options.fields).toEqual(FIELDS);
     });
 });
@@ -295,6 +415,7 @@ describe('WidgetOptionCollection', () => {
 
     beforeEach(() => {
         options = new WidgetOptionCollection(DATASET, () => [
+            new ConfigOptionFreeText('tableKey', 'Table Key', true, 'datastore1.testDatabase1.testTable1'),
             new ConfigOptionField('testCustomField', 'Test Custom Field', false),
             new ConfigOptionFieldArray('testCustomFieldArray', 'Test Custom Field Array', false),
             new ConfigOptionFreeText('testCustomKey', 'Test Custom Key', false, 'default value')
@@ -309,6 +430,7 @@ describe('WidgetOptionCollection', () => {
     });
 
     it('does have databases, fields, tables, and custom properties', () => {
+        expect(options.datastore).toEqual(DATASTORE);
         expect(options.databases).toEqual(DATABASES_LIST);
         expect(options.database).toEqual(DATABASES.testDatabase2);
         expect(options.tables).toEqual(TABLES_LIST);
@@ -329,58 +451,82 @@ describe('WidgetOptionCollection', () => {
         options.tables = [];
         options.table = TableConfig.get();
         options.fields = [];
-        options.testCustomField = null;
-        options.testCustomFieldArray = null;
+        options.testCustomField = FieldConfig.get();
+        options.testCustomFieldArray = [];
 
         options.updateDatabases(DATASET);
 
+        expect(options.datastores).toEqual([DATASTORE]);
+        expect(options.datastore).toEqual(DATASTORE);
         expect(options.databases).toEqual(DATABASES_LIST);
         expect(options.database).toEqual(DATABASES.testDatabase2);
         expect(options.tables).toEqual(TABLES_LIST);
         expect(options.table).toEqual(TABLES.testTable2);
         expect(options.fields).toEqual(FIELDS);
-        expect(options.testCustomField).toEqual(FIELD_MAP.TEXT);
-        expect(options.testCustomFieldArray).toEqual([FIELD_MAP.NAME, FIELD_MAP.TYPE]);
+        expect(options.testCustomField).toEqual(FieldConfig.get());
+        expect(options.testCustomFieldArray).toEqual([]);
     });
 
-    it('updateFields does update fields with custom properties', () => {
-        options.databases = DATABASES_LIST;
-        options.database = DATABASES.testDatabase2;
-        options.tables = TABLES_LIST;
-        options.table = TABLES.testTable2;
-        options.fields = [];
-        options.testCustomField = null;
-        options.testCustomFieldArray = null;
-
-        options.updateFields();
-
-        expect(options.databases).toEqual(DATABASES_LIST);
-        expect(options.database).toEqual(DATABASES.testDatabase2);
-        expect(options.tables).toEqual(TABLES_LIST);
-        expect(options.table).toEqual(TABLES.testTable2);
-        expect(options.fields).toEqual(FIELDS);
-        expect(options.testCustomField).toEqual(FIELD_MAP.TEXT);
-        expect(options.testCustomFieldArray).toEqual([FIELD_MAP.NAME, FIELD_MAP.TYPE]);
-    });
-
-    it('updateTables does update tables and fields with custom properties', () => {
-        options.databases = DATABASES_LIST;
-        options.database = DATABASES.testDatabase2;
+    it('updateDatastores does update databases, tables, and fields with custom properties', () => {
+        options.datastores = [];
+        options.datastore = DatastoreConfig.get();
+        options.databases = [];
+        options.database = DatabaseConfig.get();
         options.tables = [];
         options.table = TableConfig.get();
         options.fields = [];
-        options.testCustomField = null;
-        options.testCustomFieldArray = null;
+        options.testCustomField = FieldConfig.get();
+        options.testCustomFieldArray = [];
 
-        options.updateTables(DATASET);
+        options.updateDatastores(DATASET);
 
+        expect(options.datastores).toEqual([DATASTORE]);
+        expect(options.datastore).toEqual(DATASTORE);
         expect(options.databases).toEqual(DATABASES_LIST);
         expect(options.database).toEqual(DATABASES.testDatabase2);
         expect(options.tables).toEqual(TABLES_LIST);
-        expect(options.table.prettyName).toEqual(TABLES.testTable2.prettyName);
+        expect(options.table).toEqual(TABLES.testTable2);
         expect(options.fields).toEqual(FIELDS);
-        expect(options.testCustomField).toEqual(FIELD_MAP.TEXT);
-        expect(options.testCustomFieldArray).toEqual([FIELD_MAP.NAME, FIELD_MAP.TYPE]);
+        expect(options.testCustomField).toEqual(FieldConfig.get());
+        expect(options.testCustomFieldArray).toEqual([]);
+    });
+
+    it('updateFields does update fields with custom properties', () => {
+        options.fields = [];
+        options.testCustomField = FieldConfig.get();
+        options.testCustomFieldArray = [];
+
+        options.updateFields();
+
+        expect(options.datastores).toEqual([DATASTORE]);
+        expect(options.datastore).toEqual(DATASTORE);
+        expect(options.databases).toEqual(DATABASES_LIST);
+        expect(options.database).toEqual(DATABASES.testDatabase2);
+        expect(options.tables).toEqual(TABLES_LIST);
+        expect(options.table).toEqual(TABLES.testTable2);
+        expect(options.fields).toEqual(FIELDS);
+        expect(options.testCustomField).toEqual(FieldConfig.get());
+        expect(options.testCustomFieldArray).toEqual([]);
+    });
+
+    it('updateTables does update tables and fields with custom properties', () => {
+        options.tables = [];
+        options.table = TableConfig.get();
+        options.fields = [];
+        options.testCustomField = FieldConfig.get();
+        options.testCustomFieldArray = [];
+
+        options.updateTables(DATASET);
+
+        expect(options.datastores).toEqual([DATASTORE]);
+        expect(options.datastore).toEqual(DATASTORE);
+        expect(options.databases).toEqual(DATABASES_LIST);
+        expect(options.database).toEqual(DATABASES.testDatabase2);
+        expect(options.tables).toEqual(TABLES_LIST);
+        expect(options.table).toEqual(TABLES.testTable2);
+        expect(options.fields).toEqual(FIELDS);
+        expect(options.testCustomField).toEqual(FieldConfig.get());
+        expect(options.testCustomFieldArray).toEqual([]);
     });
 });
 
@@ -389,6 +535,7 @@ describe('WidgetOptionCollection with no bindings', () => {
 
     beforeEach(() => {
         options = new WidgetOptionCollection(DATASET, () => [
+            new ConfigOptionFreeText('tableKey', 'Table Key', true, 'datastore1.testDatabase1.testTable1'),
             new ConfigOptionField('testCustomField', 'Test Custom Field', false),
             new ConfigOptionFieldArray('testCustomFieldArray', 'Test Custom Field Array', false),
             new ConfigOptionFreeText('testCustomKey', 'Test Custom Key', false, 'default value')
@@ -396,6 +543,7 @@ describe('WidgetOptionCollection with no bindings', () => {
     });
 
     it('does have databases, fields, tables, and custom properties with default values', () => {
+        expect(options.datastore).toEqual(DATASTORE);
         expect(options.databases).toEqual(DATABASES_LIST);
         expect(options.database).toEqual(DATABASES.testDatabase1);
         expect(options.tables).toEqual(TABLES_LIST);
@@ -416,10 +564,12 @@ describe('RootWidgetOptionCollection', () => {
 
     beforeEach(() => {
         options = new RootWidgetOptionCollection(DATASET, () => [
+            new ConfigOptionFreeText('tableKey', 'Table Key', true, 'datastore1.testDatabase1.testTable1'),
             new ConfigOptionField('testCustomField', 'Test Custom Field', false),
             new ConfigOptionFieldArray('testCustomFieldArray', 'Test Custom Field Array', false),
             new ConfigOptionFreeText('testCustomKey', 'Test Custom Key', false, 'default value')
         ], () => [
+            new ConfigOptionFreeText('tableKey', 'Table Key', true, 'datastore1.testDatabase1.testTable1'),
             new ConfigOptionField('testCustomLayerField', 'Test Custom Layer Field', false),
             new ConfigOptionFieldArray('testCustomLayerFieldArray', 'Test Custom Layer Field Array', false),
             new ConfigOptionFreeText('testCustomLayerKey', 'Test Custom Layer Key', false, 'default layer value')
@@ -461,6 +611,7 @@ describe('RootWidgetOptionCollection', () => {
         expect(options.testCustomKey).toEqual('testCustomValue');
 
         expect(options.layers.length).toEqual(1);
+        expect(options.layers[0].datastore).toEqual(DATASTORE);
         expect(options.layers[0].databases).toEqual(DATABASES_LIST);
         expect(options.layers[0].database).toEqual(DATABASES.testDatabase2);
         expect(options.layers[0].tables).toEqual(TABLES_LIST);
@@ -538,10 +689,12 @@ describe('RootWidgetOptionCollection with no bindings', () => {
 
     beforeEach(() => {
         options = new RootWidgetOptionCollection(DATASET, () => [
+            new ConfigOptionFreeText('tableKey', 'Table Key', true, 'datastore1.testDatabase1.testTable1'),
             new ConfigOptionField('testCustomField', 'Test Custom Field', false),
             new ConfigOptionFieldArray('testCustomFieldArray', 'Test Custom Field Array', false),
             new ConfigOptionFreeText('testCustomKey', 'Test Custom Key', false, 'default value')
         ], () => [
+            new ConfigOptionFreeText('tableKey', 'Table Key', true, 'datastore1.testDatabase1.testTable1'),
             new ConfigOptionField('testCustomLayerField', 'Test Custom Layer Field', false),
             new ConfigOptionFieldArray('testCustomLayerFieldArray', 'Test Custom Layer Field Array', false),
             new ConfigOptionFreeText('testCustomLayerKey', 'Test Custom Layer Key', false, 'default layer value')
@@ -555,8 +708,8 @@ describe('RootWidgetOptionCollection with no bindings', () => {
         expect(options.table).toEqual(null);
         expect(options.fields).toEqual(FIELDS);
 
-        expect(options.contributionKeys).toEqual(null);
-        expect(options.filter).toEqual(null);
+        expect(options.contributionKeys).toEqual(undefined);
+        expect(options.filter).toEqual(undefined);
         expect(options.hideUnfiltered).toEqual(false);
         expect(options.limit).toEqual(100);
         expect(options.title).toEqual('Test Title');
@@ -566,6 +719,7 @@ describe('RootWidgetOptionCollection with no bindings', () => {
         expect(options.testCustomKey).toEqual('default value');
 
         expect(options.layers.length).toEqual(1);
+        expect(options.layers[0].datastore).toEqual(DATASTORE);
         expect(options.layers[0].databases).toEqual(DATABASES_LIST);
         expect(options.layers[0].database).toEqual(DATABASES.testDatabase1);
         expect(options.layers[0].tables).toEqual(TABLES_LIST);

--- a/src/app/models/widget-option-collection.ts
+++ b/src/app/models/widget-option-collection.ts
@@ -18,6 +18,7 @@ import * as uuidv4 from 'uuid/v4';
 import {
     ConfigOption,
     ConfigOptionDatabase,
+    ConfigOptionDatastore,
     ConfigOptionFreeText,
     ConfigOptionNonPrimitive,
     ConfigOptionSelect,
@@ -28,11 +29,15 @@ import {
 } from '../library/core/models/config-option';
 
 export class OptionConfig {
-    constructor(protected config: any) { }
+    constructor(protected config: any = {}) { }
 
     public get(bindingKey: string, defaultValue: any): any {
         // Assume config is just a Record<string, any>
         return typeof this.config[bindingKey] === 'undefined' ? defaultValue : this.config[bindingKey];
+    }
+
+    public set(bindingKey: string, newValue: any): void {
+        this.config[bindingKey] = newValue;
     }
 }
 
@@ -44,23 +49,23 @@ export class OptionCollection {
     private _collection: { [bindingKey: string]: ConfigOption } = {};
 
     public _id: string;
-    public database: DatabaseConfig = null;
     public databases: DatabaseConfig[] = [];
-    public datastore: DatastoreConfig = null;
     public datastores: DatastoreConfig[] = [];
     public fields: FieldConfig[] = [];
-    public table: TableConfig = null;
     public tables: TableConfig[] = [];
 
-    /**
-     * @constructor
-     * @arg {OptionConfig} [config] An object with configured bindings.
-     */
-    constructor(protected config: OptionConfig = new OptionConfig({})) {
+    constructor(protected dataset: Dataset = new Dataset({}), protected config: OptionConfig = new OptionConfig({})) {
         // TODO Do not use a default _id.  Throw an error if undefined!
         this._id = this.config.get('_id', uuidv4());
-        this.append(new ConfigOptionDatabase(), DatabaseConfig.get());
-        this.append(new ConfigOptionTable(), TableConfig.get());
+        const datastoreName = this.config.get('datastore', '');
+        const databaseName = this.config.get('database', '');
+        const tableName = this.config.get('table', '');
+        const tableKey = this.config.get('tableKey', (datastoreName && databaseName && tableName) ?
+            (datastoreName + '.' + databaseName + '.' + tableName) : '');
+        this.append(new ConfigOptionDatastore(), dataset.retrieveDatastore(datastoreName) || DatastoreConfig.get());
+        this.append(new ConfigOptionDatabase(), dataset.retrieveDatabase(datastoreName, databaseName) || DatabaseConfig.get());
+        this.append(new ConfigOptionTable(), dataset.retrieveTable(datastoreName, databaseName, tableName) || TableConfig.get());
+        this.append(new ConfigOptionFreeText('tableKey', 'Table Key', true, '', true), tableKey);
     }
 
     [key: string]: any; // Ordering demands it be placed here
@@ -88,18 +93,27 @@ export class OptionCollection {
             get: () => this._collection[option.bindingKey].valueCurrent,
             set: (value: any) => {
                 this._collection[option.bindingKey].valueCurrent = value;
+                // Also update the original config object to keep the new value in case the dashboard is saved later.
+                if (option.bindingKey === 'datastore' || option.bindingKey === 'database' || option.bindingKey === 'table') {
+                    const datastoreName = this._collection.datastore.getValueToSaveInBindings();
+                    const databaseName = this._collection.database.getValueToSaveInBindings();
+                    const tableName = this._collection.table.getValueToSaveInBindings();
+                    if (datastoreName && databaseName && tableName) {
+                        this.tableKey = datastoreName + '.' + databaseName + '.' + tableName;
+                    }
+                } else if (option.bindingKey !== '_id') {
+                    const newValue = option.getValueToSaveInBindings();
+                    this.config.set(option.bindingKey, newValue === null ? undefined : newValue);
+                }
             }
         });
     }
 
     protected copyCommonProperties(copy: this): this {
         copy._id = this._id;
-        copy.database = this.database;
         copy.databases = this.databases;
-        copy.datastore = this.datastore;
         copy.datastores = this.datastores;
         copy.fields = this.fields;
-        copy.table = this.table;
         copy.tables = this.tables;
         this.list().forEach((option: ConfigOption) => {
             copy.append(_.cloneDeep(option), option.valueCurrent);
@@ -113,7 +127,7 @@ export class OptionCollection {
      * @return {OptionCollection}
      */
     public copy(): this {
-        let copy = new (this.getConstructor())(this.config);
+        let copy = new (this.getConstructor())(this.dataset, this.config);
         return this.copyCommonProperties(copy);
     }
 
@@ -193,24 +207,22 @@ export class OptionCollection {
         this.databases = Object.values(dataset.datastores).reduce((list, datastore) =>
             list.concat(Object.values(datastore.databases).sort((one, two) => one.name.localeCompare(two.name))), []);
 
-        this.database = this.databases[0] || this.database;
+        // If the previously set database is not in the newly set list, unset it.
+        if (this.database.name && this.databases.length && this.databases.map((item) => item.name).indexOf(this.database.name) < 0) {
+            this.database = DatabaseConfig.get();
+        }
 
         if (this.databases.length) {
-            // By default, set the initial database to the first one in the dataset's configured table keys.
-            let configuredTableKeys = Object.keys(dataset.tableKeyCollection || {});
-            let configuredDatabase = !configuredTableKeys.length ? null : DatasetUtil.deconstructTableOrFieldKeySafely(
-                configuredTableKeys[0], dataset.tableKeyCollection
-            ).database;
+            let configuredDatabase;
 
-            // Look for the table key configured for the specific visualization.
-            let configuredTableKey = this.config.get('tableKey', null);
-            if (configuredTableKey && dataset.tableKeyCollection[configuredTableKey]) {
-                configuredDatabase = DatasetUtil.deconstructTableOrFieldKeySafely(configuredTableKey,
-                    dataset.tableKeyCollection).database;
+            if (this.tableKey) {
+                // The table key is either a tablekey string (datastore.database.table) or a unique ID in the dataset's tableKeyCollection.
+                const datasetTableKey = dataset.tableKeyCollection[this.tableKey];
+                configuredDatabase = DatasetUtil.deconstructTableOrFieldKeySafely(datasetTableKey || this.tableKey).database;
             }
 
             if (configuredDatabase) {
-                for (let database of this.databases) {
+                for (const database of this.databases) {
                     if (configuredDatabase === database.name) {
                         this.database = database;
                         break;
@@ -218,6 +230,9 @@ export class OptionCollection {
                 }
             }
         }
+
+        // Ensure that the database object is not empty, but only once the table key (if any) is reviewed.
+        this.database = this.database.name ? this.database : this.databases[0];
 
         return this.updateTables(dataset);
     }
@@ -227,7 +242,33 @@ export class OptionCollection {
      */
     public updateDatastores(dataset: Dataset): void {
         this.datastores = Object.values(dataset.datastores);
-        this.datastore = this.datastores[0] || this.datastore;
+
+        // If the previously set datastore is not in the newly set list, unset it.
+        if (this.datastore.name && this.datastores.length && this.datastores.map((item) => item.name).indexOf(this.datastore.name) < 0) {
+            this.datastore = DatastoreConfig.get();
+        }
+
+        if (this.datastores.length) {
+            let configuredDatastore;
+
+            if (this.tableKey) {
+                // The table key is either a tablekey string (datastore.database.table) or a unique ID in the dataset's tableKeyCollection.
+                const datasetTableKey = dataset.tableKeyCollection[this.tableKey];
+                configuredDatastore = DatasetUtil.deconstructTableOrFieldKeySafely(datasetTableKey || this.tableKey).datastore;
+            }
+
+            if (configuredDatastore) {
+                for (const datastore of this.datastores) {
+                    if (configuredDatastore === datastore.name) {
+                        this.datastore = datastore;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Ensure that the datastore object is not empty, but only once the table key (if any) is reviewed.
+        this.datastore = this.datastore.name ? this.datastore : this.datastores[0];
 
         return this.updateDatabases(dataset);
     }
@@ -255,27 +296,25 @@ export class OptionCollection {
      * Updates all the tables and fields in the options.
      */
     public updateTables(dataset: Dataset): void {
-        this.tables = !this.database ? [] : Object.values(this.database.tables).sort((tableA, tableB) =>
+        this.tables = !this.database ? [] : Object.values(this.database.tables as TableConfig[]).sort((tableA, tableB) =>
             tableA.name.localeCompare(tableB.name));
 
-        this.table = this.tables[0] || this.table;
+        // If the previously set table is not in the newly set list, unset it.
+        if (this.table.name && this.tables.length && this.tables.map((table) => table.name).indexOf(this.table.name) < 0) {
+            this.table = TableConfig.get();
+        }
 
-        if (this.tables.length > 0) {
-            // By default, set the initial table to the first one in the dataset's configured table keys.
-            let configuredTableKeys = Object.keys(dataset.tableKeyCollection || {});
-            let configuredTable = !configuredTableKeys.length ? null : DatasetUtil.deconstructTableOrFieldKeySafely(
-                configuredTableKeys[0], dataset.tableKeyCollection
-            ).table;
+        if (this.tables.length) {
+            let configuredTable;
 
-            // Look for the table key configured for the specific visualization.
-            let configuredTableKey = this.config.get('tableKey', null);
-            if (configuredTableKey && dataset.tableKeyCollection[configuredTableKey]) {
-                configuredTable = DatasetUtil.deconstructTableOrFieldKeySafely(configuredTableKey,
-                    dataset.tableKeyCollection).table;
+            if (this.tableKey) {
+                // The table key is either a tablekey string (datastore.database.table) or a unique ID in the dataset's tableKeyCollection.
+                const datasetTableKey = dataset.tableKeyCollection[this.tableKey];
+                configuredTable = DatasetUtil.deconstructTableOrFieldKeySafely(datasetTableKey || this.tableKey).table;
             }
 
             if (configuredTable) {
-                for (let table of this.tables) {
+                for (const table of this.tables) {
                     if (configuredTable === table.name) {
                         this.table = table;
                         break;
@@ -283,6 +322,9 @@ export class OptionCollection {
                 }
             }
         }
+
+        // Ensure that the table object is not empty, but only once the table key (if any) is reviewed.
+        this.table = this.table.name ? this.table : this.tables[0];
 
         return this.updateFields();
     }
@@ -292,22 +334,14 @@ export class OptionCollection {
  * Manages configurable options with common widget options and a custom options callback function to initialize them.
  */
 export class WidgetOptionCollection extends OptionCollection {
-    /**
-     * @constructor
-     * @arg {Dataset} [dataset] The current dataset.
-     * @arg {function} [createOptionsCallback] A callback function to create the options.
-     * @arg {string} [defaultTitle] The default value for the injected 'title' option.
-     * @arg {number} [defaultLimit] The default value for the injected 'limit' option.
-     * @arg {OptionConfig} [config] An object with configured bindings.
-     */
     constructor(
-        protected dataset: Dataset = new Dataset({}),
+        dataset: Dataset = new Dataset({}),
         protected createOptionsCallback: () => ConfigOption[] = () => [],
         defaultTitle: string = '',
         defaultLimit: number = 0,
         config: OptionConfig = new OptionConfig({})
     ) {
-        super(config);
+        super(dataset, config);
 
         let nonFieldOptions = this.createOptions().filter((option) => !isFieldOption(option));
 
@@ -364,16 +398,6 @@ export class RootWidgetOptionCollection extends WidgetOptionCollection {
 
     private _nextLayerIndex = 1;
 
-    /**
-     * @constructor
-     * @arg {Dataset} [dataset] The current dataset.
-     * @arg {function} [createOptionsCallback] A callback function to create the options.
-     * @arg {function} [createOptionsForLayerCallback] A callback function to create the options for the layers (if any).
-     * @arg {string} [defaultTitle] The default value for the injected 'title' option.
-     * @arg {number} [defaultLimit] The default value for the injected 'limit' option.
-     * @arg {boolean} [defaultLayer] Whether to add a default layer.
-     * @arg {OptionConfig} [config] An object with configured bindings.
-     */
     constructor(
         dataset: Dataset = new Dataset({}),
         createOptionsCallback: () => ConfigOption[] = () => [],
@@ -386,7 +410,7 @@ export class RootWidgetOptionCollection extends WidgetOptionCollection {
         super(dataset, createOptionsCallback, defaultTitle, defaultLimit, config);
 
         // Backwards compatibility (configFilter deprecated and renamed to filter).
-        this.filter = this.filter || this.config.get('configFilter', null);
+        this.filter = this.filter || this.config.get('configFilter', undefined);
 
         this.config.get('layers', []).forEach((layerBindings) => {
             this.addLayer(layerBindings);
@@ -399,6 +423,7 @@ export class RootWidgetOptionCollection extends WidgetOptionCollection {
 
         // Remove the database and the table from this options if it has a layer to manage them both.
         if (defaultLayer) {
+            this.datastore = null;
             this.database = null;
             this.table = null;
         }
@@ -436,9 +461,9 @@ export class RootWidgetOptionCollection extends WidgetOptionCollection {
         return [
             new ConfigOptionNonPrimitive('customEventsToPublish', 'Custom Events To Publish', false, [], true),
             new ConfigOptionNonPrimitive('customEventsToReceive', 'Custom Events To Receive', false, [], true),
-            new ConfigOptionNonPrimitive('filter', 'Custom Widget Filter', false, null),
+            new ConfigOptionNonPrimitive('filter', 'Custom Widget Filter', false, undefined),
             new ConfigOptionSelect('hideUnfiltered', 'Hide Widget if Unfiltered', false, false, OptionChoices.NoFalseYesTrue),
-            new ConfigOptionNonPrimitive('contributionKeys', 'Contribution Keys', false, null, true),
+            new ConfigOptionNonPrimitive('contributionKeys', 'Contribution Keys', false, undefined, true),
             ...super.createOptions()
         ];
     }


### PR DESCRIPTION
Issues:
- Any changes to a widget's options (in the widget options "gear" menu) are not preserved in a saved dashboard state.  This is because the widget's options (a.k.a. "bindings" from the config file) are saved as a JSON object in the `DashboardComponent` but are transformed into an Angular `Injector` that is used by the `BaseNeonComponent` and `GearComponent`.
- The Angular `Injector` object is less intuitive than standard data binding practices.

Changes:
- Replaced the Angular `Injector` that was autowired into the `BaseNeonComponent` with an `@Input` variable called `configOptions`.  The `DashboardComponent` now passes a reference to its own JSON object containing the config bindings to the `BaseNeonComponent`.  Now any of the user's changes to the widget's options will be preserved in saved dashboard states.
- Added a `ConfigOptionDatastore` object.
- Fixed the `OptionCollection` to properly retrieve datastores, databases, and tables from the current dataset using either the `tableKey` binding or separate `datastore`, `database`, and `table` bindings.  Documented that the `tableKey` binding serves multiple roles.  Now any changes to the `datastore`, `database`, or `table` (in the widget options "gear" menu) are properly reflected in the `tableKey` binding as well.
- Updated all the subclasses of `BaseNeonComponent` as needed.

Please let me know if you have any questions.  Thanks!