### PR TITLE
THOR-1470 Added a Create New Dashboard button in the Dashboard State navbar menu

### DIFF
--- a/src/app/components/dashboard-selector/dashboard-selector.component.spec.ts
+++ b/src/app/components/dashboard-selector/dashboard-selector.component.spec.ts
@@ -28,7 +28,7 @@ let dashboards = NeonDashboardChoiceConfig.get({
     category: 'Choose an option',
     choices: {
         dash1: {
-            fullTitle: 'Test Discovery Config',
+            fullTitle: ['Test Discovery Config'],
             layout: 'DISCOVERY',
             tables: {
                 tableKey: 'datastore1.database1.table1'
@@ -38,11 +38,11 @@ let dashboards = NeonDashboardChoiceConfig.get({
             }
         },
         dash2: {
-            fullTitle: 'Other Config',
+            fullTitle: ['Other Config'],
             category: 'Select an option...',
             choices: {
                 nextChoice: {
-                    fullTitle: 'Last Config',
+                    fullTitle: ['Other Config', 'Last Config'],
                     layout: 'layout3',
                     tables: {
                         tableKey: 'datastore2.database2.table1'
@@ -87,8 +87,8 @@ describe('Component: Dashboard Selector', () => {
 
     it('getDashboardName() should return correct dashboard name', (() => {
         const choices = component.getNextChoices(component.dashboards);
-        expect(choices.find((ch) => ch.name === 'dash1').fullTitle).toEqual('Test Discovery Config');
-        expect(choices.find((ch) => ch.name === 'dash2').fullTitle).toEqual('Other Config');
+        expect(choices.find((ch) => ch.name === 'dash1').fullTitle).toEqual(['Test Discovery Config']);
+        expect(choices.find((ch) => ch.name === 'dash2').fullTitle).toEqual(['Other Config']);
     }));
 
     it('updateDashboardState() should navigate to dashboard name', (() => {

--- a/src/app/components/dashboard-selector/dashboard-selector.component.ts
+++ b/src/app/components/dashboard-selector/dashboard-selector.component.ts
@@ -91,7 +91,7 @@ export class DashboardSelectorComponent implements OnInit, OnDestroy {
                     return [root, ...res];
                 }
             }
-        } else if (this.dashboardChoice && root.fullTitle === this.dashboardChoice.fullTitle) {
+        } else if (this.dashboardChoice && _.isEqual(root.fullTitle, this.dashboardChoice.fullTitle)) {
             return [root];
         }
         return [];
@@ -105,7 +105,7 @@ export class DashboardSelectorComponent implements OnInit, OnDestroy {
                     return [key, ...res];
                 }
             }
-        } else if (this.dashboardChoice && root.fullTitle === this.dashboardChoice.fullTitle) {
+        } else if (this.dashboardChoice && _.isEqual(root.fullTitle, this.dashboardChoice.fullTitle)) {
             return [];
         }
         return undefined;

--- a/src/app/components/save-state/save-state.component.html
+++ b/src/app/components/save-state/save-state.component.html
@@ -1,10 +1,14 @@
-<form #optionsForm="ngForm" (submit)="saveState(stateName.value, false)">
+<form #optionsForm="ngForm">
     <mat-form-field>
-        <input #stateName matInput placeholder="New State Name" maxlength="100" name="stateToSave" dividerColor="accent">
+        <input #stateName matInput placeholder="Dashboard Name" maxlength="100" name="stateToSave" dividerColor="accent">
     </mat-form-field>
 
-    <button mat-raised-button class="neon-button-small" type="submit">
-        <span>Save State</span>
+    <button mat-raised-button class="neon-button-small" (click)="saveState(stateName.value, false)" [disabled]="!stateName.value">
+        <span>Save Current Dashboard</span>
+    </button>
+
+    <button mat-raised-button class="neon-button-small" (click)="createState(stateName.value)" [disabled]="!stateName.value">
+        <span>Create New Dashboard</span>
     </button>
 </form>
 

--- a/src/app/components/save-state/save-state.component.scss
+++ b/src/app/components/save-state/save-state.component.scss
@@ -23,10 +23,13 @@
 
 form {
     display: grid;
-    grid-template-columns: 1fr auto;
     align-items: baseline;
     grid-gap: 1em;
     margin-bottom: 0.5em;
+
+    mat-form-field {
+        grid-column: 1 / 3;
+    }
 }
 
 .option-row {

--- a/src/app/components/save-state/save-state.component.spec.ts
+++ b/src/app/components/save-state/save-state.component.spec.ts
@@ -145,6 +145,22 @@ describe('Component: SaveStateComponent', () => {
         expect(confirmCalls).toEqual(3);
     });
 
+    it('createState does call configService.save with expected data', () => {
+        let calls = 0;
+
+        spyOn(component['dashboardService'], 'createEmptyDashboardConfig').and.callFake(() => ({}));
+
+        spyOn(component['configService'], 'save').and.callFake((data) => {
+            calls++;
+            expect(data).toEqual({});
+            return of(1);
+        });
+
+        component.createState('testState');
+
+        expect(calls).toEqual(1);
+    });
+
     it('saveState does call configService.save with expected data', () => {
         let calls = 0;
 

--- a/src/app/components/save-state/save-state.component.ts
+++ b/src/app/components/save-state/save-state.component.ts
@@ -88,6 +88,18 @@ export class SaveStateComponent implements OnInit {
         }
     }
 
+    /**
+     * Creates an empty dashboard state using the given name, automatically loads it, and closes the saved state menu.
+     */
+    public createState(name: string): void {
+        const config = this.dashboardService.createEmptyDashboardConfig(name);
+        this.configService.save(config)
+            .subscribe(() => {
+                this.openNotification(name, 'created');
+                this.loadState(name);
+            }, this.handleStateFailure.bind(this, name));
+    }
+
     get currentFilename() {
         return this.dashboardService.config.fileName;
     }

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -30,8 +30,7 @@
             <div *ngIf="currentDashboard">
                 <div class="dashboard-name" matBadge="x" matBadgePosition="above after" [matBadgeHidden]="!dashboardService.state.modified"
                     matBadgeColor="accent" matBadgeOverlap="false" matBadgeSize="small">
-                    {{ currentDashboard.name }}
-                    <small *ngIf="currentDashboard.fullTitle">- {{ currentDashboard.fullTitle }}</small>
+                    {{ retrieveFullDashboardTitle(currentDashboard.fullTitle) }}
                 </div>
             </div>
             <div *ngIf="!currentDashboard">Choose Dashboard...</div>
@@ -66,8 +65,8 @@
                 <button mat-menu-item (click)="setPanel('addVis', 'Add Visualizations');">
                     <mat-icon>add_circle</mat-icon>Add Visualizations
                 </button>
-                <button mat-menu-item (click)="setPanel('savedState', 'Save States');">
-                    <mat-icon>save</mat-icon>Saved States
+                <button mat-menu-item (click)="setPanel('savedState', 'Create or Save Dashboard');">
+                    <mat-icon>save</mat-icon>Dashboard States
                 </button>
                 <button mat-menu-item (click)="setPanel('settings', 'Dashboard Settings');">
                     <mat-icon>settings</mat-icon>Dashboard Settings

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -845,6 +845,15 @@ describe('Dashboard', () => {
         component['resizeGrid']();
         expect(spy.calls.count()).toEqual(1);
     });
+
+    it('retrieveFullDashboardTitle does return expected string', () => {
+        expect(component.retrieveFullDashboardTitle([])).toEqual('');
+        expect(component.retrieveFullDashboardTitle(['a'])).toEqual('');
+        expect(component.retrieveFullDashboardTitle(['a', 'b'])).toEqual('b');
+        expect(component.retrieveFullDashboardTitle(['a', 'b', 'c'])).toEqual('b / c');
+        expect(component.retrieveFullDashboardTitle(['a', 'b', 'c', 'd'])).toEqual('b / c / d');
+        expect(component.retrieveFullDashboardTitle(['a', 'b', 'c', 'd', 'e'])).toEqual('b / c / d / e');
+    });
 });
 
 describe('Dashboard Custom', () => {
@@ -909,7 +918,7 @@ describe('Dashboard Custom', () => {
 
         let testDashboard = NeonDashboardLeafConfig.get({
             layout: 'DISCOVERY',
-            fullTitle: 'Test Title',
+            fullTitle: ['Test Title'],
             category: 'Select an option...',
             options: {
                 connectOnLoad: true
@@ -991,7 +1000,7 @@ describe('Dashboard Custom', () => {
 
         let testDashboard = NeonDashboardLeafConfig.get({
             category: 'Select an option...',
-            fullTitle: 'Test Title',
+            fullTitle: ['Test Title'],
             layout: 'DISCOVERY',
             options: { connectOnLoad: true }
         });

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -49,6 +49,8 @@ import { Subject, fromEvent } from 'rxjs';
 import { Location } from '@angular/common';
 import { distinctUntilKeyChanged, takeUntil } from 'rxjs/operators';
 
+import * as _ from 'lodash';
+
 export function DashboardModified() {
     return (__inst: any, __prop: string | symbol, descriptor) => {
         const fn = descriptor.value;
@@ -127,7 +129,7 @@ export class DashboardComponent implements AfterViewInit, OnInit, OnDestroy {
     messageReceiver: eventing.Messenger;
     messageSender: eventing.Messenger;
 
-    private currentDashboardId: string;
+    private currentDashboardId: string[];
 
     private _filterChangeData: {
         callerId: string;
@@ -215,7 +217,7 @@ export class DashboardComponent implements AfterViewInit, OnInit, OnDestroy {
         }
 
         // Clean on different dashboard
-        if (this.currentDashboardId !== state.id) {
+        if (!_.isEqual(this.currentDashboardId, state.id)) {
             this.dashboardService.state.modified = false;
 
             this.pendingInitialRegistrations = this.widgets.size;
@@ -527,6 +529,13 @@ export class DashboardComponent implements AfterViewInit, OnInit, OnDestroy {
      */
     private resizeGrid() {
         this.grid.triggerResize();
+    }
+
+    /**
+     * Returns the full dashboard title to show in the navbar.
+     */
+    public retrieveFullDashboardTitle(fullTitle: string[]): string {
+        return (fullTitle || []).slice(1, fullTitle.length).join(' / ');
     }
 
     /**

--- a/src/app/models/dashboard-state.ts
+++ b/src/app/models/dashboard-state.ts
@@ -30,7 +30,7 @@ export class DashboardState {
     /**
      * Returns the current dashboard config title.
      */
-    public getTitle(): string {
+    public getTitle(): string[] {
         return this.dashboard ? this.dashboard.fullTitle : null;
     }
 

--- a/src/app/models/types.ts
+++ b/src/app/models/types.ts
@@ -132,7 +132,7 @@ export interface NeonContributor {
 }
 
 export interface NeonDashboardBaseConfig {
-    fullTitle?: string; // Added to dashboard in validateDashboards()
+    fullTitle?: string[]; // The fullTitle is added to the dashboard object during runtime.
     name?: string;
 }
 
@@ -157,7 +157,7 @@ export class NeonDashboardLeafConfig {
             options: {},
             visualizationTitles: {},
             contributors: {},
-            fullTitle: '',
+            fullTitle: [],
             ...dash
         } as NeonDashboardLeafConfig;
     }
@@ -171,7 +171,7 @@ export interface NeonDashboardChoiceConfig extends NeonDashboardBaseConfig {
 export class NeonDashboardChoiceConfig {
     static get(dash: DeepPartial<NeonDashboardChoiceConfig> = {}): NeonDashboardChoiceConfig {
         return {
-            fullTitle: '',
+            fullTitle: [],
             ...dash,
             choices: translateValues(dash.choices || {}, NeonDashboardUtil.get.bind(null), true)
         } as NeonDashboardChoiceConfig;

--- a/src/app/services/dashboard.service.spec.ts
+++ b/src/app/services/dashboard.service.spec.ts
@@ -15,7 +15,7 @@
 import { inject } from '@angular/core/testing';
 
 import { CompoundFilterType } from '../library/core/models/config-option';
-import { FilterConfig, NeonConfig, NeonDashboardLeafConfig } from '../models/types';
+import { FilterConfig, NeonConfig, NeonDashboardChoiceConfig, NeonDashboardLeafConfig } from '../models/types';
 import { DatastoreConfig } from '../library/core/models/dataset';
 import { DashboardService } from './dashboard.service';
 
@@ -247,7 +247,7 @@ describe('Service: DashboardService with Mock Data', () => {
             },
             layouts,
             dashboards: {
-                fullTitle: 'Full Title',
+                fullTitle: ['Full Title'],
                 layout: 'testState',
                 name: 'dashName',
                 filters,
@@ -275,7 +275,7 @@ describe('Service: DashboardService with Mock Data', () => {
         return { config, filters, layouts };
     }
 
-    it('exportConfig should produce valid results', (done) => {
+    it('exportToConfig should produce valid results', (done) => {
         const { config, filters, layouts } = getConfig([
             {
                 id: 'id1',
@@ -328,7 +328,7 @@ describe('Service: DashboardService with Mock Data', () => {
 
             const data = localDashboardService
                 .exportToConfig('testState') as NeonConfig & { dashboards: NeonDashboardLeafConfig };
-            expect(data.dashboards.fullTitle).toEqual('Full Title');
+            expect(data.dashboards.fullTitle).toEqual(['Full Title']);
             expect(data.dashboards.layout).toEqual('testState');
             expect(data.dashboards.name).toEqual('testState');
             expect(data.dashboards.tables).toEqual({
@@ -373,7 +373,7 @@ describe('Service: DashboardService with Mock Data', () => {
         localConfigService.setActive(config);
     });
 
-    it('exportConfig should produce valid results with string filter', (done) => {
+    it('exportToConfig should produce valid results with string filter', (done) => {
         const { config, layouts } = getConfig(`[
             ["id1", ["relation1"], "datastore1.testDatabase1.testTable1.testNameField", "=", "testValue"],
             ["and", "id2", ["relation2"],
@@ -398,7 +398,7 @@ describe('Service: DashboardService with Mock Data', () => {
 
             const data = localDashboardService
                 .exportToConfig('testState') as NeonConfig & { dashboards: NeonDashboardLeafConfig };
-            expect(data.dashboards.fullTitle).toEqual('Full Title');
+            expect(data.dashboards.fullTitle).toEqual(['Full Title']);
             expect(data.dashboards.layout).toEqual('testState');
             expect(data.dashboards.name).toEqual('testState');
             expect(data.dashboards.tables).toEqual({
@@ -439,6 +439,28 @@ describe('Service: DashboardService with Mock Data', () => {
         });
 
         localConfigService.setActive(config);
+    });
+
+    it('createEmptyDashboardConfig does return expected object', () => {
+        expect(dashboardService.createEmptyDashboardConfig('testDashboardName')).toEqual(NeonConfig.get({
+            dashboards: NeonDashboardChoiceConfig.get({
+                choices: {
+                    testDashboardName: {
+                        layout: 'empty',
+                        options: {
+                            connectOnLoad: true
+                        }
+                    }
+                }
+            }),
+            datastores: {
+                datastore1: DATASTORE
+            },
+            layouts: {
+                empty: []
+            },
+            projectTitle: 'testDashboardName'
+        }));
     });
 });
 

--- a/src/app/services/dashboard.service.ts
+++ b/src/app/services/dashboard.service.ts
@@ -425,6 +425,30 @@ export class DashboardService {
     }
 
     /**
+     * Creates and returns a new config object with the existing datastores and an empty dashboard object.
+     */
+    public createEmptyDashboardConfig(name: string): NeonConfig {
+        let choices = {};
+        choices[name] = {
+            layout: 'empty',
+            options: {
+                connectOnLoad: true
+            }
+        };
+
+        return NeonConfig.get({
+            dashboards: NeonDashboardChoiceConfig.get({
+                choices
+            }),
+            datastores: this.config.datastores,
+            layouts: {
+                empty: []
+            },
+            projectTitle: name
+        });
+    }
+
+    /**
      * Returns the filters as string for use in URL
      */
     public getFiltersToSaveInURL(): string {

--- a/src/app/util/config.util.spec.ts
+++ b/src/app/util/config.util.spec.ts
@@ -94,15 +94,15 @@ describe('Config Util Tests', () => {
         });
         ConfigUtil.nameDashboards(config, 'prefix');
 
-        expect(config.fullTitle).toBeFalsy();
+        expect(config.fullTitle).toEqual([]);
         expect(config.name).toEqual('g');
 
-        expect(config.choices.a.fullTitle).toBeFalsy();
+        expect(config.choices.a.fullTitle).toEqual([]);
         expect(config.choices.a.name).toEqual('a');
-        expect((config.choices.a as NeonDashboardChoiceConfig).choices.c.fullTitle).toEqual('prefix / g / a / c');
+        expect((config.choices.a as NeonDashboardChoiceConfig).choices.c.fullTitle).toEqual(['prefix', 'g', 'a', 'c']);
         expect((config.choices.a as NeonDashboardChoiceConfig).choices.c.name).toEqual('c');
 
-        expect(config.choices.b.fullTitle).toEqual('prefix / g / b');
+        expect(config.choices.b.fullTitle).toEqual(['prefix', 'g', 'b']);
         expect(config.choices.b.name).toEqual('b');
     });
 

--- a/src/app/util/config.util.ts
+++ b/src/app/util/config.util.ts
@@ -84,14 +84,7 @@ export class ConfigUtil {
     static nameDashboards(dashboard: NeonDashboardConfig, prefix: string) {
         this.visitDashboards(dashboard, {
             leaf: (dash, choices) => {
-                const name = [
-                    { name: prefix }, ...choices
-                ]
-                    .filter((ds) => !!ds.name && ds.name !== this.DEFAULT_CONFIG_NAME)
-                    .map((ds) => ds.name)
-                    .join(' / ');
-
-                dash.fullTitle = name;
+                dash.fullTitle = [{ name: prefix }, ...choices].filter((ds) => !!ds.name).map((ds) => ds.name);
             }
         });
     }


### PR DESCRIPTION
Kristy at ISSO wants to be able to more easily create new, empty dashboards.

I've added a button in the "Dashboard States" panel (previously called "Saved States", in the navbar menu) to do this.  It really just saves a new dashboard with an empty layout and then loads that dashboard.

I also changed the dashboard title ("fullTitle") to an array because keeping it as a string could lead to unintended collisions.