### PR TITLE
Fixed the config editor and moved it into the dashboard states panel.

### DIFF
--- a/src/app/components/config-editor/config-editor.component.html
+++ b/src/app/components/config-editor/config-editor.component.html
@@ -1,6 +1,6 @@
-<div class="messages">
-    <div class="messages-header">Configuration Editor</div>
-    <div class="message-body">
+<div class="editor">
+    <div class="editor-header">Edit Current Dashboard Configuration</div>
+    <div class="editor-body">
         <ngx-monaco-editor #editor [options]="{
       theme: 'vs',
       language: 'yaml',
@@ -11,13 +11,16 @@
   }" [(ngModel)]="configText">
         </ngx-monaco-editor>
     </div>
-    <div class="messages-footer">
-        <button mat-raised-button class="neon-button-large" (click)="save()" aria-label="Save"
-            matTooltip="Saves configuration to Property Service.  Refresh is required to see changes."
-            matTooltipPosition="below">Save</button>
-        <button mat-raised-button class="neon-button-large" (click)="reset()" aria-label="Reset"
-            matTooltip="Reset changes to actively loaded configuation." matTooltipPosition="below">Reset</button>
-        <button mat-raised-button class="neon-button-large" matDialogClose="close" aria-label="Close"
-            matTooltip="Close configuration editor and discard changes." matTooltipPosition="below">Close</button>
+    <div class="editor-footer">
+        <mat-form-field>
+            <input matInput placeholder="Dashboard Name" maxlength="100" [(ngModel)]="dashboardName">
+        </mat-form-field>
+        <button mat-raised-button class="neon-button-large" matDialogClose="close" (click)="save()" aria-label="Save as New Dashboard"
+            [disabled]="!dashboardName">
+            Save as New Dashboard
+        </button>
+        <button mat-raised-button class="neon-button-large" matDialogClose="close" (click)="cancel()" aria-label="Cancel">
+            Cancel
+        </button>
     </div>
 </div>

--- a/src/app/components/config-editor/config-editor.component.scss
+++ b/src/app/components/config-editor/config-editor.component.scss
@@ -21,7 +21,7 @@
     height: 100%;
 }
 
-.messages {
+.editor {
     height: 100%;
     padding: 7px;
     box-sizing: border-box;
@@ -29,7 +29,7 @@
     grid-template-rows: auto 1fr auto;
 }
 
-.message-body {
+.editor-body {
     &,
     > div {
         height: 100%;
@@ -37,17 +37,18 @@
     }
 }
 
-.messages-header {
+.editor-header {
     text-align: center;
     font-size: 1.5em;
     font-weight: bold;
     height: 1.5em;
 }
 
-.messages-footer {
+.editor-footer {
     text-align: right;
 
-    button {
+    > button,
+    > mat-form-field {
         margin: 5px 10px;
     }
 }

--- a/src/app/components/config-editor/config-editor.module.ts
+++ b/src/app/components/config-editor/config-editor.module.ts
@@ -16,8 +16,13 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ConfigEditorComponent } from './config-editor.component';
 import {
-    MatToolbarModule, MatTooltipModule, MatSelectModule,
-    MatDialogModule, MatButtonModule
+    MatButtonModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatToolbarModule,
+    MatTooltipModule
 } from '@angular/material';
 import { FormsModule } from '@angular/forms';
 import { MonacoEditorModule } from 'ngx-monaco-editor';
@@ -33,11 +38,13 @@ import { MonacoEditorModule } from 'ngx-monaco-editor';
     imports: [
         FormsModule,
         MonacoEditorModule.forRoot({ baseUrl: 'assets/' }),
-        MatDialogModule,
         MatButtonModule,
+        MatDialogModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatSelectModule,
         MatToolbarModule,
         MatTooltipModule,
-        MatSelectModule,
         CommonModule
     ]
 })

--- a/src/app/components/save-state/save-state.component.html
+++ b/src/app/components/save-state/save-state.component.html
@@ -1,5 +1,5 @@
 <form #optionsForm="ngForm">
-    <mat-form-field>
+    <mat-form-field class="expanded">
         <input #stateName matInput placeholder="Dashboard Name" maxlength="100" name="stateToSave" dividerColor="accent">
     </mat-form-field>
 
@@ -9,6 +9,10 @@
 
     <button mat-raised-button class="neon-button-small" (click)="createState(stateName.value)" [disabled]="!stateName.value">
         <span>Create New Dashboard</span>
+    </button>
+
+    <button mat-raised-button class="neon-button-small expanded" (click)="openConfigEditor()">
+        <span>Edit Current Dashboard Configuration</span>
     </button>
 </form>
 
@@ -21,11 +25,11 @@
 
     <div class="date">Last Modified - {{ state.lastModified ? (state.lastModified | date: 'yyyy-M-d h:mm') : "N/A" }}</div>
     <div class="actions">
-        <button mat-icon-button class="update-button" (click)="saveState(state.dashboards.name, true);"
+        <button mat-icon-button class="update-button" matTooltip="Save Dashboard Changes" (click)="saveState(state.dashboards.name, true);"
             *ngIf="(currentFilename === state.fileName && dashboardState.modified)">
             <mat-icon>save</mat-icon>
         </button>
-        <button mat-icon-button class="delete-button" (click)="deleteState(state.fileName, true);">
+        <button mat-icon-button class="delete-button" matTooltip="Delete Saved Dashboard" (click)="deleteState(state.fileName, true);">
             <mat-icon>delete</mat-icon>
         </button>
     </div>

--- a/src/app/components/save-state/save-state.component.scss
+++ b/src/app/components/save-state/save-state.component.scss
@@ -27,7 +27,7 @@ form {
     grid-gap: 1em;
     margin-bottom: 0.5em;
 
-    mat-form-field {
+    .expanded {
         grid-column: 1 / 3;
     }
 }

--- a/src/app/components/save-state/save-state.component.ts
+++ b/src/app/components/save-state/save-state.component.ts
@@ -13,20 +13,19 @@
  * limitations under the License.
  */
 import { Component, OnInit, Input } from '@angular/core';
-
 import { MatDialog, MatSidenav } from '@angular/material';
+import { Router } from '@angular/router';
 
+import { filter } from 'rxjs/operators';
+
+import { ConfigService } from '../../services/config.service';
 import { DashboardService } from '../../services/dashboard.service';
-
+import { DashboardState } from '../../models/dashboard-state';
+import { DynamicDialogComponent } from '../dynamic-dialog/dynamic-dialog.component';
+import { NeonConfig } from '../../models/types';
 import { neonEvents } from '../../models/neon-namespaces';
 
-import { DynamicDialogComponent } from '../dynamic-dialog/dynamic-dialog.component';
 import { eventing } from 'neon-framework';
-import { filter } from 'rxjs/operators';
-import { NeonConfig } from '../../models/types';
-import { DashboardState } from '../../models/dashboard-state';
-import { ConfigService } from '../../services/config.service';
-import { Router } from '@angular/router';
 
 export function Confirm(config: {
     title: string | ((arg: any) => string);
@@ -93,7 +92,7 @@ export class SaveStateComponent implements OnInit {
      */
     public createState(name: string): void {
         const config = this.dashboardService.createEmptyDashboardConfig(name);
-        this.configService.save(config)
+        this.configService.save(config, name)
             .subscribe(() => {
                 this.openNotification(name, 'created');
                 this.loadState(name);
@@ -115,7 +114,7 @@ export class SaveStateComponent implements OnInit {
     })
     public saveState(name: string, __confirm = true): void {
         const config = this.dashboardService.exportToConfig(name);
-        this.configService.save(config)
+        this.configService.save(config, name)
             .subscribe(() => {
                 this.dashboardState.modified = false;
                 this.openNotification(name, 'saved');
@@ -182,6 +181,18 @@ export class SaveStateComponent implements OnInit {
                 this.isLoading = false;
                 this.states = items;
             }, this.handleStateFailure.bind(this, 'load states'));
+    }
+
+    public openConfigEditor() {
+        this.dialog.open(DynamicDialogComponent, {
+            data: {
+                component: 'config-editor'
+            },
+            height: '95%',
+            width: '95%',
+            hasBackdrop: true,
+            disableClose: true
+        });
     }
 
     public openConfirmationDialog(config: { title: string, message: string, confirmText: string, cancelText?: string }) {

--- a/src/app/components/settings/settings.component.html
+++ b/src/app/components/settings/settings.component.html
@@ -10,13 +10,7 @@
             </mat-radio-button>
         </mat-radio-group>
     </div>
-    <mat-divider class="divider"></mat-divider>
-    <h3 class="header">Property Service Configuration</h3>
 
-    <button mat-raised-button class="neon-button-small btn-open-config-edit" matTooltip="Open configuration editor."
-        tooltip-position="below" (click)="openEditConfigDialog()">
-        Edit Configuration
-    </button>
     <mat-divider class="divider"></mat-divider>
     <h3 class="header">Display Tools</h3>
     <div class="display-tools-container">

--- a/src/app/components/settings/settings.component.scss
+++ b/src/app/components/settings/settings.component.scss
@@ -33,10 +33,6 @@
     width: 200px;
 }
 
-.btn-open-config-edit {
-    margin: 10px;
-}
-
 .radio-container {
     margin: 5 5px;
 

--- a/src/app/components/settings/settings.component.ts
+++ b/src/app/components/settings/settings.component.ts
@@ -25,7 +25,6 @@ import { InjectableColorThemeService } from '../../services/injectable.color-the
 import { DashboardService } from '../../services/dashboard.service';
 
 import { eventing } from 'neon-framework';
-import { DynamicDialogComponent } from '../dynamic-dialog/dynamic-dialog.component';
 import { DashboardState } from '../../models/dashboard-state';
 
 @Component({
@@ -97,18 +96,6 @@ export class SettingsComponent implements OnInit, OnDestroy {
         });
 
         this.changeDetection.detectChanges();
-    }
-
-    openEditConfigDialog() {
-        this.dialog.open(DynamicDialogComponent, {
-            data: {
-                component: 'config-editor'
-            },
-            height: '80%',
-            width: '80%',
-            hasBackdrop: true,
-            disableClose: true
-        });
     }
 
     publishShowFilterTray() {

--- a/src/app/services/config.service.spec.ts
+++ b/src/app/services/config.service.spec.ts
@@ -30,7 +30,7 @@ describe('Service: ConfigService', () => {
         configService = getConfigService();
     });
 
-    it('deleteState does validate the state name', () => {
+    it('delete does validate the state name and call openConnection().deleteState', () => {
         let calls = 0;
         spyOn(configService, 'openConnection').and.callFake(() => ({
             deleteState: (data, __successCallback) => {
@@ -43,7 +43,30 @@ describe('Service: ConfigService', () => {
         expect(calls).toEqual(1);
     });
 
-    it('load does validate the state name', () => {
+    it('list does call openConnection().listStates', () => {
+        let calls = 0;
+        spyOn(configService, 'openConnection').and.callFake(() => ({
+            listStates: (limit, offset, __successCallback) => {
+                calls++;
+                if (calls === 1) {
+                    expect(limit).toEqual(100);
+                    expect(offset).toEqual(0);
+                }
+                if (calls === 2) {
+                    expect(limit).toEqual(12);
+                    expect(offset).toEqual(34);
+                }
+            }
+        }));
+
+        configService.list();
+        expect(calls).toEqual(1);
+
+        configService.list(12, 34);
+        expect(calls).toEqual(2);
+    });
+
+    it('load does validate the state name and call openConnection().loadState', () => {
         let calls = 0;
         spyOn(configService, 'openConnection').and.callFake(() => ({
             loadState: (data, __successCallback) => {
@@ -56,16 +79,33 @@ describe('Service: ConfigService', () => {
         expect(calls).toEqual(1);
     });
 
-    it('saveState does validate the state name', () => {
+    it('save does validate the state name and call openConnection().saveState', () => {
         let calls = 0;
         spyOn(configService, 'openConnection').and.callFake(() => ({
             saveState: (data, __successCallback) => {
                 calls++;
                 expect(data.projectTitle).toEqual('folder.my-test.state_name1234');
+                expect(data.stateName).toEqual('folder.my-test.state_name1234');
             }
         }));
 
-        configService.save(NeonConfig.get({ projectTitle: '../folder/my-test.!@#$%^&*state_name`~?\\1234' }));
+        const projectTitle = '../folder/my-test.!@#$%^&*state_name`~?\\1234';
+        configService.save(NeonConfig.get({ projectTitle }), '');
+        expect(calls).toEqual(1);
+    });
+
+    it('save does set the projectTitle and stateName to the given state name', () => {
+        let calls = 0;
+        spyOn(configService, 'openConnection').and.callFake(() => ({
+            saveState: (data, __successCallback) => {
+                calls++;
+                expect(data.projectTitle).toEqual('folder.my-test.state_name1234');
+                expect(data.stateName).toEqual('folder.my-test.state_name1234');
+            }
+        }));
+
+        const projectTitle = '../folder/my-test.!@#$%^&*state_name`~?\\1234';
+        configService.save(NeonConfig.get({ projectTitle: 'whatever' }), projectTitle);
         expect(calls).toEqual(1);
     });
 

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -186,9 +186,9 @@ export class ConfigService {
     /**
      * Saves config under name
      */
-    save(config: NeonConfig): Observable<void> {
+    save(config: NeonConfig, name: string): Observable<void> {
         return from(new Promise<void>((resolve, reject) => {
-            config.projectTitle = ConfigUtil.validateName(config.projectTitle);
+            config.projectTitle = ConfigUtil.validateName(name || config.projectTitle);
             config['stateName'] = config.projectTitle;
             this.openConnection().saveState(config, resolve, reject);
         })).pipe(take(1));


### PR DESCRIPTION
The config editor lets you change the config file within the dashboard.  Access it in by clicking on Dashboard States (in the navbar Dashboard Menu), then the Edit Current Dashboard Configuration button.  Make changes, enter a new dashboard name, and click the Save button; it will be saved as a separate dashboard state and loaded automatically.  This makes it easier to edit the config file in production deployments (without rebuilding docker containers).